### PR TITLE
Added the kubetest2 prep script. Bootstrapped a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*$py.class
+third_party/

--- a/scripts/setup_kubetest2.sh
+++ b/scripts/setup_kubetest2.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/third_party/kubetest2"
+
+if [ ! -d "$REPO_DIR" ]; then
+  echo "Cloning kubetest2..."
+  git clone https://github.com/kubernetes-sigs/kubetest2 "$REPO_DIR"
+else
+  echo "kubetest2 already cloned."
+fi
+
+cd "$REPO_DIR"
+
+echo "Building kubetest2..."
+make install
+
+echo "Building kubetest2-gke..."
+make install-deployer-gke
+
+echo "Setup complete. Binaries are in $REPO_DIR/bin"


### PR DESCRIPTION
This script clones / builds / installs the `kubetest2` binary and the `kubetest2 GKE deployer`.

The added gitignore ignores a bunch of python runtime cache + the `third_party` folder which is generated when you run the script.