### PR TITLE
Dockerize the eval run flow and make the code cloud agnostic.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    make \
+    curl \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Go (required to build kubetest2)
+COPY --from=golang:1.22 /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Install Google Cloud SDK and kubectl
+RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && apt-get update && apt-get install -y \
+    google-cloud-cli \
+    google-cloud-cli-gke-gcloud-auth-plugin \
+    kubectl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy the codebase
+COPY . .
+
+# Build kubetest2
+RUN bash ./scripts/setup_kubetest2.sh
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Create a results directory
+RUN mkdir -p /app/results
+
+# Set up entrypoint
+RUN chmod +x /app/scripts/entrypoint.sh
+ENTRYPOINT ["/app/scripts/entrypoint.sh"]

--- a/pkg/evaluator/evaluate.py
+++ b/pkg/evaluator/evaluate.py
@@ -23,7 +23,7 @@ from pkg.agents.runner.api.llm_adapters import AnthropicClientAdapter, GeminiCli
 
 from pkg.agents.runner.api.api import run_api_agent
 from pkg.agents.runner.gcli import run_cli_agent
-from pkg.evaluator.loader import load_from_tasks_dir
+from pkg.evaluator.loader import load_from_tasks_dir, safe_parse_yaml
 
 
 class GeminiDeepEvalModel(DeepEvalBaseLLM):
@@ -120,6 +120,17 @@ def main():
     if os.path.isdir(input_path):
         print(f"Loading tasks specifications dynamically from {input_path} folder...")
         eval_data = load_from_tasks_dir(input_path)
+    elif input_path.endswith((".yaml", ".yml")):
+        print(f"Loading task specification from {input_path}...")
+        with open(input_path, "r") as f:
+            content = safe_parse_yaml(f.read())
+            eval_data = [{
+                "task_id": content.get("task_id", 1),
+                "name": content.get("name", "Legacy Case"),
+                "input": content.get("prompt", "").strip(),
+                "expected_output": content.get("expected_output", "").strip(),
+                "retrieval_context": content.get("retrieval_context", [])
+            }]
     else:
         with open(input_path, "r") as f:
             eval_data = json.load(f)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+# Verify required environment variables are set
+if [ -z "$CLOUD_PROVIDER" ] || [ -z "$TASK_FILE" ]; then
+    echo "Error: CLOUD_PROVIDER and TASK_FILE environment variables must be set."
+    echo "Usage: docker run -e CLOUD_PROVIDER=<gcp> -e TASK_FILE=<file> ..."
+    exit 1
+fi
+
+# Step 1: Set up environment (auth) by calling provider-specific script
+AUTH_SCRIPT="./scripts/setup_auth_${CLOUD_PROVIDER}.sh"
+if [ -f "$AUTH_SCRIPT" ]; then
+    echo "Running auth setup for $CLOUD_PROVIDER..."
+    source "$AUTH_SCRIPT"
+else
+    echo "Warning: No auth setup script found at $AUTH_SCRIPT"
+fi
+
+export KUBECONFIG=/tmp/kubeconfig
+
+# Step 2: Call the deployer script to bring up the cluster
+# We assume infra.py reads necessary env vars (like PROJECT_ID, CLUSTER_NAME) directly.
+echo "Step 2: Bringing up cluster for $CLOUD_PROVIDER..."
+python3 scripts/infra.py "$CLOUD_PROVIDER" up
+
+# Step 3: Call the eval script with the task to eval
+echo "Step 3: Running evaluation..."
+# TODO: This needs to be replaced by the actual eval run
+echo "Displaying task file content:"
+cat "$TASK_FILE"
+
+# Simulate writing results to host
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+echo "{\"task\": \"$TASK_FILE\", \"status\": \"mock_success\"}" > "/app/results/results_$TIMESTAMP.json"
+
+# Step 4: Call the deployer script to shut the environment down
+echo "Step 4: Tearing down cluster..."
+python3 scripts/infra.py "$CLOUD_PROVIDER" down

--- a/scripts/infra.py
+++ b/scripts/infra.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import argparse
+
+# Ensure project root is in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from deployers.gcp.gcp_deployer import GCPDeployer
+
+def main():
+    parser = argparse.ArgumentParser(description="DevOps Bench Infra Manager")
+    subparsers = parser.add_subparsers(dest="provider", required=True, help="Cloud provider")
+    
+    # GCP Subparser
+    gcp_parser = subparsers.add_parser("gcp", help="GCP operations")
+    gcp_subparsers = gcp_parser.add_subparsers(dest="action", required=True, help="Action")
+    
+    # Add actions for GCP
+    for action in ["up", "down", "info"]:
+        p = gcp_subparsers.add_parser(action, help=f"Perform {action}")
+        p.add_argument("--project", help="GCP Project ID")
+        p.add_argument("--cluster-name", help="Name of the cluster")
+        p.add_argument("--zone", default="us-central1-a", help="GCP Zone")
+            
+    args = parser.parse_args()
+    
+    if args.provider == "gcp":
+        project = args.project or os.environ.get("PROJECT_ID")
+        cluster_name = args.cluster_name or os.environ.get("CLUSTER_NAME")
+        zone = args.zone or os.environ.get("ZONE", "us-central1-a")
+        
+        if not project or not cluster_name:
+            print("Error: Project and Cluster Name must be specified via flags or environment variables (PROJECT_ID, CLUSTER_NAME).", file=sys.stderr)
+            sys.exit(1)
+            
+        deployer = GCPDeployer(project=project, zone=zone, cluster_name=cluster_name)
+        
+        if args.action == "up":
+            print(f"Bringing up cluster {cluster_name}...")
+            deployer.up()
+        elif args.action == "down":
+            print(f"Tearing down cluster {cluster_name}...")
+            deployer.down()
+        elif args.action == "info":
+            import json
+            print(json.dumps(deployer.get_cluster_info(), indent=2))
+        else:
+            print(f"Critical Error: Unsupported action '{args.action}' for provider 'gcp'", file=sys.stderr)
+            sys.exit(1)
+    else:
+        print(f"Critical Error: Unsupported provider '{args.provider}'", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_auth_gcp.sh
+++ b/scripts/setup_auth_gcp.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ -n "$GCP_SERVICE_ACCOUNT_KEY" ]; then
+    echo "Authenticating with Service Account..."
+    echo "$GCP_SERVICE_ACCOUNT_KEY" > /tmp/gcp_key.json
+    gcloud auth activate-service-account --key-file=/tmp/gcp_key.json
+    export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp_key.json
+fi

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+# Ensure project root is in path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from scripts.infra import main
+
+class TestInfraCLI(unittest.TestCase):
+
+    @patch('deployers.gcp.gcp_deployer.GCPDeployer.up')
+    def test_gcp_up(self, mock_up):
+        test_args = ["infra.py", "gcp", "up", "--project", "my-project", "--cluster-name", "my-cluster"]
+        with patch.object(sys, 'argv', test_args):
+            main()
+        mock_up.assert_called_once()
+
+    @patch('deployers.gcp.gcp_deployer.GCPDeployer.down')
+    def test_gcp_down(self, mock_down):
+        test_args = ["infra.py", "gcp", "down", "--project", "my-project", "--cluster-name", "my-cluster"]
+        with patch.object(sys, 'argv', test_args):
+            main()
+        mock_down.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Note that the actual eval is NOT in the flow yet. However, the skeleton is there and it will read the task and simply `cat` the content. Just need to replace the placeholder with the actual eval run logic.

### Sample commands:

**Build the container:** 
```bash
docker build -t devops-bench:latest .
```

**Run the container for GCP workload with your local gcloud credentials:**
```bash
docker run -it \
  -v ~/.config/gcloud:/root/.config/gcloud \
  -v $(pwd)/results:/app/results \
  -e CLOUD_PROVIDER="gcp" \
  -e PROJECT_ID="project-id-goes-here" \
  -e CLUSTER_NAME="cluster-name-goes-here" \
  -e TASK_FILE="tasks/create-deployment/task.yaml" \
  devops-bench:latest
```

**Run the container for GCP workload with a GCP SA:**
```bash
docker run -it \
  -v $(pwd)/results:/app/results \
  -e CLOUD_PROVIDER="gcp" \
  -e GCP_SERVICE_ACCOUNT_KEY="$(cat path/to/your/sa-key.json)" \
  -e PROJECT_ID="project-id-goes-here" \
  -e CLUSTER_NAME="cluster-name-goes-here" \
  -e TASK_FILE="tasks/create-deployment/task.yaml" \
  devops-bench:latest```

