### PR TITLE
feat: Support using existing GKE clusters and skip teardown if pre-ex…

### DIFF
--- a/deployers/gcp/gcp_deployer.py
+++ b/deployers/gcp/gcp_deployer.py
@@ -25,22 +25,51 @@ class GCPDeployer(Deployer):
         return env
 
     def up(self) -> None:
-        cmd = [
-            "kubetest2", "gke",
-            "--project", self.project,
-            "--zone", self.zone,
-            "--cluster-name", self.cluster_name,
-        ]
-        for key, value in self.config.items():
-            if value is not None:
-                flag_name = f"--{key.replace('_', '-')}"
-                cmd.extend([flag_name, str(value)])
-            
-        cmd.append("--up")
-        print(f"Running: {' '.join(cmd)}")
-        subprocess.run(cmd, env=self._get_env(), check=True)
+        # Check if cluster exists
+        check_cmd = ["gcloud", "container", "clusters", "describe", self.cluster_name, "--project", self.project, "--zone", self.zone]
+        print(f"Checking if cluster exists: {' '.join(check_cmd)}")
+        result = subprocess.run(check_cmd, capture_output=True, text=True)
+        
+        state_file = "/tmp/cluster_created"
+        
+        if result.returncode == 0:
+            print(f"Cluster {self.cluster_name} already exists. Getting credentials.")
+            get_cred_cmd = ["gcloud", "container", "clusters", "get-credentials", self.cluster_name, "--project", self.project, "--zone", self.zone]
+            subprocess.run(get_cred_cmd, check=True)
+            # Record that we didn't create it
+            with open(state_file, "w") as f:
+                f.write("false")
+        else:
+            print(f"Cluster {self.cluster_name} does not exist or error checking. Creating it.")
+            cmd = [
+                "kubetest2", "gke",
+                "--project", self.project,
+                "--zone", self.zone,
+                "--cluster-name", self.cluster_name,
+            ]
+            for key, value in self.config.items():
+                if value is not None:
+                    flag_name = f"--{key.replace('_', '-')}"
+                    cmd.extend([flag_name, str(value)])
+                
+            cmd.append("--up")
+            print(f"Running: {' '.join(cmd)}")
+            subprocess.run(cmd, env=self._get_env(), check=True)
+            # Record that we created it
+            with open(state_file, "w") as f:
+                f.write("true")
 
     def down(self) -> None:
+        state_file = "/tmp/cluster_created"
+        created_by_us = True
+        if os.path.exists(state_file):
+            with open(state_file, "r") as f:
+                created_by_us = f.read().strip() == "true"
+                
+        if not created_by_us:
+            print(f"Skipping teardown for pre-existing cluster {self.cluster_name}")
+            return
+            
         cmd = [
             "kubetest2", "gke",
             "--project", self.project,

--- a/deployers/gcp/gcp_deployer.py
+++ b/deployers/gcp/gcp_deployer.py
@@ -30,7 +30,7 @@ class GCPDeployer(Deployer):
         print(f"Checking if cluster exists: {' '.join(check_cmd)}")
         result = subprocess.run(check_cmd, capture_output=True, text=True)
         
-        state_file = "/tmp/cluster_created"
+        state_file = f"/tmp/{self.project}-{self.zone}-{self.cluster_name}_created"
         
         if result.returncode == 0:
             print(f"Cluster {self.cluster_name} already exists. Getting credentials.")
@@ -60,7 +60,7 @@ class GCPDeployer(Deployer):
                 f.write("true")
 
     def down(self) -> None:
-        state_file = "/tmp/cluster_created"
+        state_file = f"/tmp/{self.project}-{self.zone}-{self.cluster_name}_created"
         created_by_us = True
         if os.path.exists(state_file):
             with open(state_file, "r") as f:


### PR DESCRIPTION
## Description
This PR modifies the `GCPDeployer` to support running evaluations against already existing GKE clusters, making the benchmark harness more flexible and avoiding conflicts.

Previously, the deployer would always attempt to create the cluster and would fail with a 409 conflict if it already existed.
It would also always attempt to delete the cluster at the end of the run.

## Changes
- **`deployers/gcp/gcp_deployer.py`**:
    - Modified `up()` to check if the specified cluster exists using `gcloud container clusters describe`.
    - If it exists, it skips the `kubetest2` creation step and instead fetches credentials for the existing cluster.
    - It tracks whether the cluster was created by this run by writing to a temporary file (`/tmp/cluster_created`).
    - Modified `down()` to read from `/tmp/cluster_created` and skip the deletion step if the cluster was not created by this
run.

## Verification Results
- Verified that when running on an existing cluster, it successfully detected it, skipped creation, and proceeded to the
evaluation phase.
- Verified that it skipped the teardown phase at the end of the run for the pre-existing cluster.