### PR TITLE
feat: add new advanced GKE manifest generation tasks for ComputeClass, Gateway and HPA

### DIFF
--- a/tasks/computeclass-active-migration/task.yaml
+++ b/tasks/computeclass-active-migration/task.yaml
@@ -1,0 +1,17 @@
+task_id: 8
+name: "computeclass-active-migration"
+prompt: "Configure the performance-tier ComputeClass to use Active Migration. If a workload is currently running on a fallback N2 instance, GKE should automatically move it to a C3 instance as soon as one becomes available."
+expected_output: |
+  critical requirements:
+
+  - Expected Tool Call: generate_manifest
+  - Update/Modify the performance-tier ComputeClass resource.
+  - Configure the spec.activeMigration parameter to true (or optimizeRulePriority).
+
+  Expected Manifest Generated:
+  apiVersion: cloud.google.com/v1
+  kind: ComputeClass
+  metadata:
+    name: performance-tier
+  spec:
+    activeMigration: true

--- a/tasks/computeclass-spot-fallback/task.yaml
+++ b/tasks/computeclass-spot-fallback/task.yaml
@@ -1,0 +1,24 @@
+task_id: 7
+name: "computeclass-spot-fallback"
+prompt: "Create a ComputeClass named cost-optimized-high-cpu. It should prioritize Spot VMs using the C3 machine family, but fall back to On-Demand N2 instances if Spot capacity is unavailable."
+expected_output: |
+  critical requirements:
+
+  - Expected Tool Call: generate_manifest
+  - Create a GKE ComputeClass resource.
+  - Use cost-optimized-high-cpu as the resource name.
+  - Define a priorities hierarchy list with at least two rules.
+  - Rule 1: Spot C3 VMs (spot: true, machineFamily: c3).
+  - Rule 2: On-Demand N2 VMs (spot: false, machineFamily: n2).
+
+  Expected Manifest Generated:
+  apiVersion: cloud.google.com/v1
+  kind: ComputeClass
+  metadata:
+    name: cost-optimized-high-cpu
+  spec:
+    priorities:
+    - spot: true
+      machineFamily: c3
+    - spot: false
+      machineFamily: n2

--- a/tasks/gateway-cloud-armor/task.yaml
+++ b/tasks/gateway-cloud-armor/task.yaml
@@ -1,0 +1,24 @@
+task_id: 9
+name: "gateway-cloud-armor"
+prompt: "Apply a Cloud Armor security policy named block-ddos-policy to the external Gateway public-gw using a GCPBackendPolicy."
+expected_output: |
+  critical requirements:
+
+  - Expected Tool Call: generate_manifest
+  - Create a GKE-specific GCPBackendPolicy resource.
+  - Bind the policy to the external Gateway public-gw in the targetRef.
+  - Reference the exact Cloud Armor policy block-ddos-policy under spec.default.securityPolicy.
+
+  Expected Manifest Generated:
+  apiVersion: networking.gke.io/v1
+  kind: GCPBackendPolicy
+  metadata:
+    name: public-gw-security-policy
+    namespace: default
+  spec:
+    default:
+      securityPolicy: block-ddos-policy
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public-gw

--- a/tasks/gateway-https-redirect/task.yaml
+++ b/tasks/gateway-https-redirect/task.yaml
@@ -1,0 +1,27 @@
+task_id: 10
+name: "gateway-https-redirect"
+prompt: "Configure an HTTP-to-HTTPS redirect on public-gw. All traffic coming in on port 80 should be redirected to port 443 with a 301 status code."
+expected_output: |
+  critical requirements:
+
+  - Expected Tool Call: generate_manifest
+  - Configure redirect filters in HTTPRoute or create a port 80 HTTP listener on the Gateway.
+  - Redirect HTTP traffic from port 80 to port 443 with status code 301.
+
+  Expected Manifest Generated: apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: https-redirect
+    namespace: default
+  spec:
+    parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public-gw
+      port: 80
+    rules:
+    - filters:
+      - type: RequestRedirect
+        requestRedirect:
+          scheme: https
+          statusCode: 301

--- a/tasks/hpa-metric-filtering/task.yaml
+++ b/tasks/hpa-metric-filtering/task.yaml
@@ -1,0 +1,23 @@
+task_id: 11
+name: "hpa-metric-filtering"
+prompt: "Configure an AutoscalingMetric resource to scrape a Prometheus gauge named http_requests_total but ensure it only scales based on data points where the version label is set to v2."
+expected_output: |
+  critical requirements:
+
+  - Expected Tool Call: generate_manifest
+  - Create an GKE-native AutoscalingMetric resource.
+  - Set target metric to http_requests_total.
+  - Configure Prometheus label filter (version: v2) inside spec.metric.filter.matchLabels.
+
+  Expected Manifest Generated:
+  apiVersion: autoscaling.gke.io/v1
+  kind: AutoscalingMetric
+  metadata:
+    name: http-requests-metric
+    namespace: default
+  spec:
+    metric:
+      name: http_requests_total
+      filter:
+        matchLabels:
+          version: v2

--- a/tasks/hpa-renamed-metric/task.yaml
+++ b/tasks/hpa-renamed-metric/task.yaml
@@ -1,0 +1,42 @@
+task_id: 12
+name: "hpa-renamed-metric"
+prompt: "Configure an HPA to use a metric that has been renamed during export via the exportName field in its AutoscalingMetric definition."
+expected_output: |
+  critical requirements:
+
+  - Expected Tool Call: generate_manifest
+  - Create an GKE AutoscalingMetric resource containing an exportName mapping parameter.
+  - Create a HorizontalPodAutoscaler (HPA) resource.
+  - Reference the exported custom metric in the HPA spec.metrics[] using the exact renamed exportName with the autoscaling.gke.io|... prefix.
+
+  Expected Manifest Generated:
+  apiVersion: autoscaling.gke.io/v1
+  kind: AutoscalingMetric
+  metadata:
+    name: web-metric
+    namespace: default
+  spec:
+    metric:
+      name: original_metric_name
+      exportName: exported-name
+  ---
+  apiVersion: autoscaling/v2
+  kind: HorizontalPodAutoscaler
+  metadata:
+    name: web-hpa
+    namespace: default
+  spec:
+    scaleTargetRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: web-app
+    minReplicas: 1
+    maxReplicas: 10
+    metrics:
+    - type: External
+      external:
+        metric:
+          name: autoscaling.gke.io|web-metric|exported-name
+        target:
+          type: Value
+          value: 100


### PR DESCRIPTION
## Description
This PR introduces 6 new advanced evaluation tasks to the `devops-bench` benchmarking suite, expanding our coverage of sophisticated GKE capabilities and custom resource configurations.
## Added Tasks
### 🖥️ ComputeClass Configurations
- **`computeclass-spot-fallback` (Task ID: 7)**: Evaluates priority rules prioritizing Spot VMs (C3 machine family) with automatic fallback to On-Demand N2 instances.
- **`computeclass-active-migration` (Task ID: 8)**: Configures `activeMigration` to seamlessly transition workloads from fallback instances back to optimal tiers once capacity becomes available.
### 🌐 Gateway & Security Policies
- **`gateway-cloud-armor` (Task ID: 9)**: Assesses binding Cloud Armor DDoS security policies to external Gateways using `GCPBackendPolicy`.
- **`gateway-https-redirect` (Task ID: 10)**: Implements HTTP-to-HTTPS request redirections (port 80 to 443 with 301 status codes) using `HTTPRoute` filters.
### 📈 HorizontalPodAutoscaler & Metrics
- **`hpa-metric-filtering` (Task ID: 11)**: Configures GKE-native `AutoscalingMetric` resources to scrape custom Prometheus gauge metrics with specific label filtering.
- **`hpa-renamed-metric` (Task ID: 12)**: Configures HPAs utilizing custom metric renames mapped via the `exportName` parameter.
## Verification
- Verified all newly introduced manifests strictly adhere to the expected `task.yaml` schema.
- Task IDs sequentially follow existing benchmark definitions without collisions.