### PR TITLE
Reworked how the infra provisioning is done

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ __pycache__/
 third_party/
 results/
 .deepeval/
+**/.terraform
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl
+*.tfvars
+*.tfvars.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,17 @@ RUN apt-get update && apt-get install -y \
     git \
     make \
     curl \
+    wget \
     gnupg \
+    unzip \
+    lsb-release \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
+    && wget https://releases.hashicorp.com/terraform/1.8.5/terraform_1.8.5_linux_amd64.zip \
+    && unzip terraform_1.8.5_linux_amd64.zip -d /usr/local/bin/ \
+    && rm terraform_1.8.5_linux_amd64.zip \
     && rm -rf /var/lib/apt/lists/*
+
 
 # Install Gemini CLI globally (customizable version)
 ARG GEMINI_CLI_VERSION=latest

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ is an augmented agent integrating layers of optimization to improve reliability 
 
 While our initial results are centered on the scale and sophistication of **Google Kubernetes Engine (GKE)**, this benchmark is designed for the entire cloud-native ecosystem. Whether you are operating on-premises, across hybrid clouds, or on various managed offerings, the fundamental challenges of agentic operations remain the same:
 
-* **Intent to Infrastructure**: Can an agent translate a high-level requirement into a secure, scalable deployment?
+* **Intent to Infrastructure**: Can an agent translate a high-level requirement into a secure, scalable deployment? In fact, the benchmark now supports **Just-In-Time (JIT) Infrastructure provisioning** using Terraform to test agents in dynamic environments.
 
 * **Autonomous Operations**: How effectively can an agent maintain the "desired state" in an unpredictable environment?
 
@@ -82,7 +82,7 @@ You can look at the actual rubrics [here](https://github.com/gke-labs/devops-ben
 Evaluations can be performed by running the benchmark tasks against your agent and manually or programmatically applying the LLM-as-a-judge method using the Skill based rubrics provided in this repository.
 
 ### Step 1: Set up the agent
-You can configure the agent in two ways depending on the capabilities you want to test: 
+You can configure the agent in two ways depending on the capabilities you want to test:
 * **Option 1**: Using only the core Antigravity agent
 This configuration uses the core agent capabilities without external cloud assistance.
 * **Option 2**: Antigravity + Gemini Cloud Assist via the Model Context Protocol (MCP) with agent rules.
@@ -90,6 +90,8 @@ This [configuration](https://github.com/GoogleCloudPlatform/gemini-cloud-assist-
 
 ### Step 2: Run tasks with your agent
 Feed each task to your configured agent and capture the agent's final response for each task, and ideally a trace of the execution steps (tools called, reasoning steps).
+
+**Note on Infrastructure**: The benchmark now supports automated infrastructure setup via Terraform. If a task includes an `infrastructure` block, the evaluator will automatically provision the required environment before running the agent.
 
 ### Step 3: Evaluate Responses with LLM-as-a-Judge
 To evaluate the results, use a capable LLM to score the agent's responses against the specific criteria defined in the repository's [skills](https://github.com/gke-labs/devops-bench/tree/main/skills) directory.
@@ -137,6 +139,7 @@ docker run -it \
   -e JUDGE_PROVIDER="google" \
   -e JUDGE_MODEL="gemini-3.1-pro-preview" \
   -e JUDGE_API_KEY="<YOUR_GEMINI_API_KEY>" \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
   devops-bench:latest
 ```
 
@@ -168,11 +171,12 @@ docker run -it \
 | :--- | :--- |
 | `-it` | Runs the container in interactive mode with a TTY, allowing you to see real-time output. |
 | `-v ~/.config/gcloud:/root/.config/gcloud` | Mounts your local Google Cloud configuration into the container so it can use your existing credentials. |
+| `-e GOOGLE_APPLICATION_CREDENTIALS` | Path to the credentials file (required for Terraform and some agent tools). |
 | `-v $(pwd)/results:/app/results` | Mounts the local `results` directory to the container. This ensures that evaluation outputs generated inside the container are saved to your host machine. |
 | **Infrastructure** | |
 | `-e CLOUD_PROVIDER` | Specifies the cloud provider (e.g., `gcp`). |
 | `-e GCP_PROJECT_ID` | The ID of the Google Cloud Project to run evaluations against. |
-| `-e GKE_CLUSTER_NAME` | The name of the GKE cluster used for the evaluation. |
+| `-e GKE_CLUSTER_NAME` | The name of the GKE cluster used for the evaluation. If JIT infra is used, this may be overwritten by the JIT-created cluster name. |
 | **Benchmark Control** | |
 | `-e BENCH_TASK_FILE` | Path to the specific YAML task file you want to evaluate. |
 | `-e BENCH_AGENT_TYPE` | The type of agent to run (`api` or `cli`). |

--- a/deployers/factory.py
+++ b/deployers/factory.py
@@ -1,0 +1,41 @@
+import os
+from typing import Dict, Any
+from deployers.base import Deployer
+from deployers.gcp.gcp_deployer import GCPDeployer
+from deployers.terraform.tf_deployer import TerraformDeployer
+
+def get_deployer(
+    infra_config: Dict[str, Any],
+    global_project_id: str,
+    global_cluster_name: str,
+    global_location: str = None
+) -> Deployer:
+    """
+    Factory to instantiate the appropriate infrastructure deployer.
+
+    Enforces GCP_LOCATION as the standard environment variable for location.
+    """
+    deployer_type = infra_config.get("deployer", "kubetest2")
+
+    # Resolve Location with strict precedence: argument then GCP_LOCATION env var
+    location = global_location or os.environ.get("GCP_LOCATION", "us-central1-a")
+
+    if deployer_type == "terraform":
+
+        stack = infra_config.get("stack") or "prebuilt/minimum"
+        variables = infra_config.get("variables", {})
+
+        # Ensure critical variables are present, defaulting to globals
+        variables.setdefault("project_id", global_project_id)
+        variables.setdefault("cluster_name", global_cluster_name)
+        variables.setdefault("location", location)
+
+        return TerraformDeployer(tf_dir=stack, variables=variables)
+
+    # Fallback to legacy GCPDeployer (kubetest2)
+    return GCPDeployer(
+        project=global_project_id,
+        location=location,
+
+        cluster_name=global_cluster_name
+    )

--- a/deployers/gcp/gcp_deployer.py
+++ b/deployers/gcp/gcp_deployer.py
@@ -1,22 +1,29 @@
-import os
+from pathlib import Path
 import subprocess
+import os
 from typing import Dict, Any
 from deployers.base import Deployer
 
 class GCPDeployer(Deployer):
     """
     GCP implementation of the Deployer interface using kubetest2 gke.
+    
+    Migrated to pathlib for better cross-platform compatibility and readability.
+    Supports both 'location' and 'zone' in initialization for robust API compatibility.
     """
-    def __init__(self, project: str, zone: str, cluster_name: str, **config):
+    def __init__(self, project: str, location: str = None, cluster_name: str = None, zone: str = None, **config):
         self.project = project
-        self.zone = zone
         self.cluster_name = cluster_name
         self.config = config
-        # Derived relative to this file's location
+        
+        # Robust location resolution for backward compatibility
+        self.location = location or zone or os.environ.get("GCP_LOCATION", "us-central1-a")
+        self.zone = self.location 
+        
         # This file is at deployers/gcp/gcp_deployer.py
         # Project root is 2 levels up.
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-        self.bin_dir = os.path.abspath(os.path.join(current_dir, '..', '..', 'third_party', 'kubetest2', 'bin'))
+        current_dir = Path(__file__).resolve().parent
+        self.bin_dir = str((current_dir.parents[1] / "third_party" / "kubetest2" / "bin").resolve())
         
     def _get_env(self) -> Dict[str, str]:
         env = os.environ.copy()
@@ -26,25 +33,33 @@ class GCPDeployer(Deployer):
 
     def up(self) -> None:
         # Check if cluster exists
-        check_cmd = ["gcloud", "container", "clusters", "describe", self.cluster_name, "--project", self.project, "--zone", self.zone]
+        check_cmd = [
+            "gcloud", "container", "clusters", "describe", self.cluster_name, 
+            "--project", self.project, "--location", self.location
+        ]
         print(f"Checking if cluster exists: {' '.join(check_cmd)}")
         result = subprocess.run(check_cmd, capture_output=True, text=True)
         
-        state_file = f"/tmp/{self.project}-{self.zone}-{self.cluster_name}_created"
+        state_file = Path(f"/tmp/{self.project}-{self.location}-{self.cluster_name}_created")
         
         if result.returncode == 0:
             print(f"Cluster {self.cluster_name} already exists. Getting credentials.")
-            get_cred_cmd = ["gcloud", "container", "clusters", "get-credentials", self.cluster_name, "--project", self.project, "--zone", self.zone]
+            get_cred_cmd = [
+                "gcloud", "container", "clusters", "get-credentials", self.cluster_name, 
+                "--project", self.project, "--location", self.location
+            ]
             subprocess.run(get_cred_cmd, check=True)
             # Record that we didn't create it
-            with open(state_file, "w") as f:
-                f.write("false")
+            state_file.write_text("false")
         else:
-            print(f"Cluster {self.cluster_name} does not exist or error checking. Creating it.")
+            print(
+                f"Cluster {self.cluster_name} does not exist or error checking. "
+                "Creating it."
+            )
             cmd = [
                 "kubetest2", "gke",
                 "--project", self.project,
-                "--zone", self.zone,
+                "--zone", self.location, # Passing resolved location to --zone flag in kubetest2
                 "--cluster-name", self.cluster_name,
             ]
             for key, value in self.config.items():
@@ -56,24 +71,24 @@ class GCPDeployer(Deployer):
             print(f"Running: {' '.join(cmd)}")
             subprocess.run(cmd, env=self._get_env(), check=True)
             # Record that we created it
-            with open(state_file, "w") as f:
-                f.write("true")
+            state_file.write_text("true")
 
     def down(self) -> None:
-        state_file = f"/tmp/{self.project}-{self.zone}-{self.cluster_name}_created"
+        state_file = Path(f"/tmp/{self.project}-{self.location}-{self.cluster_name}_created")
         created_by_us = True
-        if os.path.exists(state_file):
-            with open(state_file, "r") as f:
-                created_by_us = f.read().strip() == "true"
+        if state_file.exists():
+            created_by_us = state_file.read_text().strip() == "true"
                 
         if not created_by_us:
-            print(f"Skipping teardown for pre-existing cluster {self.cluster_name}")
+            print(
+                f"Skipping teardown for pre-existing cluster {self.cluster_name}"
+            )
             return
             
         cmd = [
             "kubetest2", "gke",
             "--project", self.project,
-            "--zone", self.zone,
+            "--zone", self.location,
             "--cluster-name", self.cluster_name,
             "--down"
         ]
@@ -81,10 +96,13 @@ class GCPDeployer(Deployer):
         subprocess.run(cmd, env=self._get_env(), check=True)
 
     def get_cluster_info(self) -> Dict[str, Any]:
-        kubeconfig_path = os.path.expanduser("~/.kube/config")
+        kubeconfig_path = os.environ.get(
+            "KUBECONFIG", str(Path.home() / ".kube" / "config")
+        )
         return {
             "name": self.cluster_name,
-            "zone": self.zone,
+            "location": self.location,
+            "zone": self.location, 
             "project": self.project,
             "kubeconfig_path": kubeconfig_path
         }

--- a/deployers/terraform/tf_deployer.py
+++ b/deployers/terraform/tf_deployer.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+import subprocess
+import json
+import os
+from typing import Dict, Any
+from deployers.base import Deployer
+
+class TerraformDeployer(Deployer):
+    """
+    Terraform implementation of the Deployer interface.
+
+    Supports the standard TF_DATA_DIR environment variable for controlling
+    where Terraform stores its state, enabling idempotent runs.
+    """
+    def __init__(self, tf_dir: str, variables: Dict[str, Any] = None):
+        # Locate project root (3 levels up from this file)
+        repo_root = Path(__file__).resolve().parents[2]
+
+        tf_path = Path(tf_dir)
+        if tf_path.is_absolute():
+            if tf_path.exists():
+                self.tf_dir = str(tf_path)
+            else:
+                raise ValueError(f"Absolute Terraform directory not found: {tf_dir}")
+        else:
+            repo_tf_path = repo_root / "terraform" / tf_path
+            if repo_tf_path.exists():
+                self.tf_dir = str(repo_tf_path)
+            else:
+                raise ValueError(
+                    f"Terraform stack not found in repo: {tf_dir} "
+                    f"(checked {repo_tf_path})"
+                )
+
+        self.variables = variables or {}
+
+    def _run_cmd(
+        self, cmd: list, cwd: str, capture: bool = False
+    ) -> subprocess.CompletedProcess:
+        print(f"Executing: {' '.join(cmd)} in {cwd}")
+        env = os.environ.copy()
+        if "TF_DATA_DIR" in env:
+             print(f"Using TF_DATA_DIR: {env['TF_DATA_DIR']}")
+
+        if capture:
+            return subprocess.run(
+                cmd, cwd=cwd, check=True, capture_output=True, text=True, env=env
+            )
+        else:
+            return subprocess.run(cmd, cwd=cwd, check=True, env=env)
+
+    def up(self) -> None:
+        tf_path = Path(self.tf_dir)
+        if not tf_path.exists():
+            raise ValueError(f"Terraform directory not found: {self.tf_dir}")
+
+        self._run_cmd(["terraform", "init", "-input=false"], cwd=self.tf_dir)
+
+        cmd = ["terraform", "apply", "-auto-approve", "-input=false"]
+        for k, v in self.variables.items():
+            cmd.extend(["-var", f"{k}={v}"])
+
+        self._run_cmd(cmd, cwd=self.tf_dir)
+
+
+    def down(self) -> None:
+        tf_path = Path(self.tf_dir)
+        if not tf_path.exists():
+            print(
+                f"Warning: Terraform directory {self.tf_dir} not found. "
+                "Skipping teardown."
+            )
+            return
+
+        self._run_cmd(["terraform", "init", "-input=false"], cwd=self.tf_dir)
+
+        cmd = ["terraform", "destroy", "-auto-approve", "-input=false"]
+        for k, v in self.variables.items():
+            cmd.extend(["-var", f"{k}={v}"])
+
+        self._run_cmd(cmd, cwd=self.tf_dir)
+
+    def get_cluster_info(self) -> Dict[str, Any]:
+        self._run_cmd(["terraform", "init", "-input=false"], cwd=self.tf_dir)
+
+        result = self._run_cmd(
+            ["terraform", "output", "-json"], cwd=self.tf_dir, capture=True
+        )
+        outputs = json.loads(result.stdout)
+
+        cluster_name = outputs.get("cluster_name", {}).get("value")
+        if not cluster_name:
+            raise ValueError("Failed to retrieve 'cluster_name' from Terraform outputs.")
+
+        location = outputs.get("cluster_location", {}).get("value")
+        if not location:
+            raise ValueError(
+                "Failed to retrieve 'cluster_location' from Terraform outputs."
+            )
+
+        project = self.variables.get("project_id") or os.environ.get("GCP_PROJECT_ID")
+        if not project:
+             raise ValueError("Project ID not found in variables or environment (GCP_PROJECT_ID).")
+
+        print(f"Configuring kubectl for cluster: {cluster_name} in {location}...")
+        subprocess.run([
+            "gcloud", "container", "clusters", "get-credentials", cluster_name,
+            "--location", location, "--project", project
+        ], check=True)
+
+        kubeconfig_path = os.environ.get(
+            "KUBECONFIG", str(Path.home() / ".kube" / "config")
+        )
+
+        return {
+            "name": cluster_name,
+            "location": location,
+            "project": project,
+            "kubeconfig_path": kubeconfig_path
+        }

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -36,15 +36,24 @@ export GKE_CLUSTER_NAME="your-cluster-name"
 python3 pkg/evaluator/evaluate.py tasks/
 ```
 
+#### Infrastructure Configuration
+The evaluator can automatically provision infrastructure via Terraform if defined in the task.
+
+```bash
+# Required for JIT Infra
+export GCP_PROJECT_ID="your-gcp-project"
+export GKE_CLUSTER_NAME="your-cluster-name"
+export GCP_ZONE="us-central1-a"
+```
 
 #### Running the LLM Agent mode with MCP
 The MCP-enabled API agent runner supports multiple LLM providers and optional MCP tool usage. You can set the following configurations:
 
 ```bash
 # Choose provider: 'google' or 'anthropic'
-export AGENT_PROVIDER="google" 
+export AGENT_PROVIDER="google"
 # Toggle MCP tools: 'true' or 'false'
-export BENCH_USE_MCP="true" 
+export BENCH_USE_MCP="true"
 # For Vertex AI support (recommended)
 export GCP_PROJECT_ID="your-gcp-project"
 export GCP_VERTEX_LOCATION="us-central1"

--- a/pkg/evaluator/evaluate.py
+++ b/pkg/evaluator/evaluate.py
@@ -26,6 +26,8 @@ from pkg.agents.runner.gcli import run_cli_agent
 from pkg.evaluator.loader import load_from_tasks_dir, safe_parse_yaml, parse_documentation_from_yaml
 import threading
 from pkg.manager.manager import ScenarioManager
+from deployers.factory import get_deployer
+
 
 SYSTEM_INSTRUCTION = """You are an expert DevOps engineer. When asked to make an app production-ready, do not ask for clarification. Assume standard production requirements. Generate the manifest directly instead of asking the user for details."""
 
@@ -79,8 +81,8 @@ class GeminiDeepEvalModel(DeepEvalBaseLLM):
 
 def replace_placeholders(text, project_id, cluster_name):
   """Replaces placeholders in the text.
-  
-  Note: TARGET_DEPLOYMENT_NAME and NAMESPACE act as the integration contract 
+
+  Note: TARGET_DEPLOYMENT_NAME and NAMESPACE act as the integration contract
   fed dynamically by the upstream Infra Provisioning layer after cluster bring-up.
   """
   app_location = os.environ.get("APP_LOCATION", "")
@@ -132,7 +134,8 @@ def load_evaluation_data(input_path):
               "expected_output": content.get("expected_output", "").strip(),
               "retrieval_context": content.get("retrieval_context", []),
               "chaos_spec": content.get("chaos_spec"),
-              "documentation": docs
+              "documentation": docs,
+              "infrastructure": content.get("infrastructure", {})
           }]
   else:
       with open(input_path, "r") as f:
@@ -145,7 +148,8 @@ def load_evaluation_data(input_path):
           "input": eval_data.get("goal", eval_data.get("input", "")),
           "expected_output": eval_data.get("expected_output", ""),
           "retrieval_context": eval_data.get("retrieval_context", []),
-          "chaos_spec": eval_data.get("chaos_spec")
+          "chaos_spec": eval_data.get("chaos_spec"),
+          "infrastructure": eval_data.get("infrastructure", {})
       }]
   elif isinstance(eval_data, list):
       for item in eval_data:
@@ -384,7 +388,7 @@ def evaluate_metrics_batch(detailed_results, gemini_model):
       parts = re.split(r"(?i)critical requirements\s*:", reqs_section, maxsplit=1)
       if len(parts) > 1:
         reqs_section = parts[1]
-    
+
     if "expected manifest generated:" in reqs_section.lower():
       parts = re.split(r"(?i)expected manifest generated\s*:", reqs_section, maxsplit=1)
       reqs_section = parts[0]
@@ -479,7 +483,7 @@ def evaluate_metrics_batch(detailed_results, gemini_model):
                     "success": metric_data.success,
                     "reason": getattr(metric_data, "reason", None)
                 }
-                
+
     if os.environ.get("BENCH_USE_MCP", "true").lower() == "true":
       tool_result = evaluate([tool_test_case], metrics=[tool_invocation])
       for test_result in tool_result.test_results:
@@ -532,21 +536,21 @@ def evaluate_metrics_batch(detailed_results, gemini_model):
       print(f"Evaluating Planned Chaos Mode and Performance metrics...")
       chaos_report = res.get("chaos_report", {})
       actual_fault = chaos_report.get("injected_fault", "pod deletion")
-      
+
       diag_metric = GEval(
           name="DiagnosisAccuracy",
           criteria=f"Did the agent accurately identify that the fault injected was '{actual_fault}'?",
           evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
           model=gemini_model,
       )
-      
+
       rec_metric = GEval(
           name="GracefulRecovery",
           criteria="Did the agent follow a graceful recovery process (e.g., maintaining uptime, zero downtime)?",
           evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
           model=gemini_model,
       )
-      
+
       try:
         chaos_result = evaluate([all_test_case], metrics=[diag_metric, rec_metric])
         for test_result in chaos_result.test_results:
@@ -595,91 +599,111 @@ def main():
     os.makedirs(run_dir, exist_ok=True)
 
     for item in eval_data:
-        prompt = item["input"]
-        prompt = replace_placeholders(prompt, gcp_project_id, gke_cluster_name)
+        infra_config = item.get("infrastructure", {})
+        deployer = get_deployer(infra_config, gcp_project_id, gke_cluster_name)
 
-        target_deployment = os.environ.get("TARGET_DEPLOYMENT_NAME", "hypercomputer-d1-frontend")
-        namespace = os.environ.get("NAMESPACE", "default")
-        
-        chaos_spec = item.get("chaos_spec")
-        scenario_manager = None
-        
-        if chaos_spec:
-            try:
-                # Replace placeholders in chaos_spec string/dict
-                chaos_spec_processed = replace_placeholders(
-                    json.dumps(chaos_spec) if isinstance(chaos_spec, (dict, list)) else str(chaos_spec),
-                    gcp_project_id, 
-                    gke_cluster_name
-                )
-                spec_list = json.loads(chaos_spec_processed)
-                if spec_list:
-                    spec = spec_list[0]
-                    scenario_manager = ScenarioManager(target_deployment, namespace)
-                    t = threading.Thread(
-                        target=scenario_manager.run_chaos_and_verification, 
-                        args=(spec,)
+        try:
+            print(f"--- Provisioning Infrastructure for: {item['name']} ---")
+            deployer.up()
+            cluster_info = deployer.get_cluster_info()
+
+            # Use dynamic cluster name from deployer for prompt replacement
+            active_cluster_name = cluster_info.get("name", gke_cluster_name)
+            prompt = replace_placeholders(item["input"], gcp_project_id, active_cluster_name)
+
+            target_deployment = os.environ.get("TARGET_DEPLOYMENT_NAME", "hypercomputer-d1-frontend")
+            namespace = os.environ.get("NAMESPACE", "default")
+            
+            chaos_spec = item.get("chaos_spec")
+            scenario_manager = None
+            
+            if chaos_spec:
+                try:
+                    # Replace placeholders in chaos_spec string/dict
+                    chaos_spec_processed = replace_placeholders(
+                        json.dumps(chaos_spec) if isinstance(chaos_spec, (dict, list)) else str(chaos_spec),
+                        gcp_project_id, 
+                        active_cluster_name
                     )
-                    t.daemon = True
-                    t.start()
-            except Exception as e:
-                print(f"Warning: Failed to start ScenarioManager: {e}")
-        
-        if scenario_manager:
-            timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-            print(f"[{timestamp}] Waiting for Chaos Agent to establish the GKE load spike...", flush=True)
-            scenario_manager.chaos_active_event.wait(timeout=45)
-            timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-            print(f"[{timestamp}] GKE load spike is now active. Proceeding with Operator Agent...", flush=True)
-
-        print(f"Executing agent for prompt: {prompt}")
-        
-        before_files = set(os.listdir("."))
-        
-        agent_res = execute_agent(bench_agent_type, agent_target, prompt, {})
+                    spec_list = json.loads(chaos_spec_processed)
+                    if spec_list:
+                        spec = spec_list[0]
+                        scenario_manager = ScenarioManager(target_deployment, namespace)
+                        t = threading.Thread(
+                            target=scenario_manager.run_chaos_and_verification, 
+                            args=(spec,)
+                        )
+                        t.daemon = True
+                        t.start()
+                except Exception as e:
+                    print(f"Warning: Failed to start ScenarioManager: {e}")
             
-        after_files = set(os.listdir("."))
-        new_files = after_files - before_files
-        
-        if new_files:
-            gen_files_dir = os.path.join(run_dir, "generated_files")
-            os.makedirs(gen_files_dir, exist_ok=True)
-            for f in new_files:
-                if os.path.isfile(f):
-                    shutil.copy(f, os.path.join(gen_files_dir, f))
-                    print(f"Stored generated file: {f}")
-        
-        actual_output = agent_res.get("output", "")
-        latency = agent_res.get("latency", 0.0)
-        
-        detailed_results.append({
-            "input": prompt,
-            "output": actual_output,
-            "latency": latency,
-            "tokens": agent_res.get("tokens", {}),
-            "tools": agent_res.get("tools", {}),
-            "trajectory": agent_res.get("trajectory", []),
-            "skills": agent_res.get("skills", [])
-        })
+            if scenario_manager:
+                timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+                print(f"[{timestamp}] Waiting for Chaos Agent to establish the GKE load spike...", flush=True)
+                scenario_manager.chaos_active_event.wait(timeout=45)
+                timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+                print(f"[{timestamp}] GKE load spike is now active. Proceeding with Operator Agent...", flush=True)
 
-        print(f"--- Agent Response ---\n{actual_output}\n----------------------")
+            print(f"Executing agent for prompt: {prompt}")
 
-        expected_output_raw = item.get("expected_output", "")
-        detailed_results[-1]["expected_output"] = replace_placeholders(expected_output_raw, gcp_project_id, gke_cluster_name)
-        detailed_results[-1]["name"] = item["name"]
-        detailed_results[-1]["retrieval_context"] = item.get("retrieval_context", [])
-        detailed_results[-1]["chaos_spec"] = item.get("chaos_spec")
-        
-        chaos_report = {}
-        perf_report = {}
-        if scenario_manager:
-            print("[ScenarioManager] Waiting for background metrics collection to complete...", flush=True)
-            t.join(timeout=90)
-            chaos_report, perf_report = scenario_manager.get_reports()
-            
-        detailed_results[-1]["chaos_report"] = chaos_report
-        detailed_results[-1]["perf_report"] = perf_report
-        detailed_results[-1]["documentation"] = item.get("documentation", [])
+            before_files = set(os.listdir("."))
+            agent_res = execute_agent(bench_agent_type, agent_target, prompt, {})
+            after_files = set(os.listdir("."))
+
+            new_files = after_files - before_files
+            if new_files:
+                gen_files_dir = os.path.join(run_dir, "generated_files")
+                os.makedirs(gen_files_dir, exist_ok=True)
+                for f in new_files:
+                    target_path = os.path.join(gen_files_dir, f)
+                    if os.path.isdir(f):
+                        shutil.copytree(f, target_path, dirs_exist_ok=True)
+                    elif os.path.isfile(f):
+                        shutil.copy(f, target_path)
+
+            actual_output = agent_res.get("output", "")
+            latency = agent_res.get("latency", 0.0)
+
+            expected_output_raw = item.get("expected_output", "")
+            expected_output = replace_placeholders(expected_output_raw, gcp_project_id, active_cluster_name)
+
+            chaos_report = {}
+            perf_report = {}
+            if scenario_manager:
+                print("[ScenarioManager] Waiting for background metrics collection to complete...", flush=True)
+                t.join(timeout=90)
+                chaos_report, perf_report = scenario_manager.get_reports()
+
+            detailed_results.append({
+                "input": prompt,
+                "output": actual_output,
+                "latency": latency,
+                "tokens": agent_res.get("tokens", {}),
+                "tools": agent_res.get("tools", {}),
+                "trajectory": agent_res.get("trajectory", []),
+                "skills": agent_res.get("skills", []),
+                "name": item["name"],
+                "expected_output": expected_output,
+                "expected_output_raw": expected_output_raw,
+                "retrieval_context": item.get("retrieval_context", []),
+                "chaos_spec": item.get("chaos_spec"),
+                "chaos_report": chaos_report if scenario_manager else agent_res.get("chaos_report", {}),
+                "perf_report": perf_report if scenario_manager else agent_res.get("perf_report", {}),
+                "documentation": item.get("documentation", [])
+            })
+
+            print(f"--- Agent Response ---\n{actual_output}\n----------------------")
+
+        except Exception as e:
+            print(f"Critical error during task {item['name']}: {e}")
+        finally:
+            if infra_config.get("teardown", True):
+                print(f"--- Tearing Down Infrastructure for: {item['name']} ---")
+                try:
+                    deployer.down()
+                except Exception as teardown_err:
+                    print(f"Teardown failed (potential resource leak): {teardown_err}")
 
     # Save tasks execution outputs immediately
     with open(os.path.join(run_dir, "results.json"), "w") as f:
@@ -693,7 +717,7 @@ def main():
     with open(os.path.join(run_dir, "results.json"), "w") as f:
         json.dump(detailed_results, f, indent=2)
     print(f"Post-processing evaluation complete. Updated results saved to {run_dir}/results.json")
-    
+
     print("\n=== Detailed Results ===")
     print(json.dumps(detailed_results, indent=2))
     print("=========================")

--- a/pkg/evaluator/loader.py
+++ b/pkg/evaluator/loader.py
@@ -1,62 +1,9 @@
 import os
 import sys
+import yaml
 
 def safe_parse_yaml(content: str) -> dict:
-    """Extracts simple structural elements of YAML definitions without library imports."""
-    lines = content.splitlines()
-    result = {}
-    current_key = None
-    in_scalar = False
-    scalar_val = []
-    indent_level = None
-    
-    for line in lines:
-        stripped = line.rstrip()
-        if not stripped:
-            if in_scalar:
-                scalar_val.append("")
-            continue
-            
-        indent = len(stripped) - len(stripped.lstrip())
-        
-        if in_scalar:
-            if indent_level is None:
-                indent_level = indent
-                
-            if indent >= indent_level:
-                scalar_val.append(stripped[indent_level:])
-                continue
-            else:
-                result[current_key] = "\n".join(scalar_val).strip()
-                in_scalar = False
-                scalar_val = []
-                current_key = None
-                indent_level = None
-                
-        if ":" in stripped:
-            parts = stripped.split(":", 1)
-            key = parts[0].strip()
-            val = parts[1].strip()
-            
-            if val == "|":
-                current_key = key
-                in_scalar = True
-                scalar_val = []
-                indent_level = None
-            else:
-                if (val.startswith('"') and val.endswith('"')) or (val.startswith("'") and val.endswith("'")):
-                    val = val[1:-1]
-                try:
-                    if val.isdigit():
-                        val = int(val)
-                except ValueError:
-                    pass
-                result[key] = val
-                
-    if current_key and scalar_val:
-        result[current_key] = "\n".join(scalar_val).strip()
-        
-    return result
+    return yaml.safe_load(content) or {}
 
 
 def parse_documentation_from_yaml(content: str) -> list:
@@ -66,22 +13,22 @@ def parse_documentation_from_yaml(content: str) -> list:
     in_doc_section = False
     current_doc = None
     current_constraint = None
-    
+
     for line in lines:
         stripped = line.strip()
         if not stripped:
             continue
-        
+
         if line.startswith("documentation:"):
             in_doc_section = True
             continue
-            
+
         indent = len(line) - len(line.lstrip())
         if in_doc_section:
             if indent == 0 and not line.startswith("-"):
                 in_doc_section = False
                 continue
-            
+
             if stripped.startswith("- doc_name:"):
                 if current_doc:
                     docs.append(current_doc)
@@ -102,20 +49,20 @@ def parse_documentation_from_yaml(content: str) -> list:
                 if current_constraint:
                     crit_val = stripped.split("critical:", 1)[1].strip().lower()
                     current_constraint["critical"] = (crit_val == "true")
-                    
+
     if current_doc:
         docs.append(current_doc)
-        
+
     return docs
 
 
 def load_from_tasks_dir(dir_path: str) -> list:
     eval_data = []
-    
+
     if not os.path.exists(dir_path):
         print(f"Error: tasks directory not found at {dir_path}")
         sys.exit(1)
-        
+
     for item in sorted(os.listdir(dir_path)):
         sub_dir = os.path.join(dir_path, item)
         if os.path.isdir(sub_dir):
@@ -133,7 +80,7 @@ def load_from_tasks_dir(dir_path: str) -> list:
                             expected = content.get("expected_output", "")
                             retrieval = content.get("retrieval_context", [])
                             chaos_spec = content.get("chaos_spec")
-                            
+
                             eval_data.append({
                                 "task_id": task_id if task_id is not None else 999,
                                 "name": name,
@@ -141,10 +88,11 @@ def load_from_tasks_dir(dir_path: str) -> list:
                                 "expected_output": expected.strip() if isinstance(expected, str) else str(expected),
                                 "retrieval_context": retrieval if isinstance(retrieval, list) else [],
                                 "chaos_spec": chaos_spec,
-                                "documentation": docs
+                                "documentation": docs,
+                                "infrastructure": content.get("infrastructure", {})
                             })
                 except Exception as e:
                     print(f"Warning: Failed to read task spec in {yaml_path}: {e}")
-                    
+
     eval_data.sort(key=lambda k: k["task_id"])
     return eval_data

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+norecursedirs = third_party pkg/agents

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-deepeval
-pytest
-google-genai
-mcp
-anthropic
+deepeval==4.0.3
+pytest==9.0.3
+google-genai==2.6.0
+mcp==1.27.1
+anthropic==0.104.1
+pyyaml==6.0.3
+pytest-mock==3.15.1

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,59 +1,36 @@
 #!/bin/bash
 set -e
 
-# Verify required environment variables are set
 if [ -z "$CLOUD_PROVIDER" ] || [ -z "$BENCH_TASK_FILE" ]; then
     echo "Error: CLOUD_PROVIDER and BENCH_TASK_FILE environment variables must be set."
-    echo "Usage: docker run -e CLOUD_PROVIDER=<gcp> -e BENCH_TASK_FILE=<file> ..."
     exit 1
 fi
 
-# Step 1: Set up environment (auth) by calling provider-specific script
 AUTH_SCRIPT="./scripts/setup_auth_${CLOUD_PROVIDER}.sh"
 if [ -f "$AUTH_SCRIPT" ]; then
-    echo "Running auth setup for $CLOUD_PROVIDER..."
     source "$AUTH_SCRIPT"
-else
-    echo "Warning: No auth setup script found at $AUTH_SCRIPT"
 fi
+
+# Bypass any host-level GKE API endpoint overrides mounted via gcloud config
+export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
 
 export KUBECONFIG=/tmp/kubeconfig
 
-# Step 2: Call the deployer script to bring up the cluster
-# We assume infra.py reads necessary env vars (like GCP_PROJECT_ID, GKE_CLUSTER_NAME) directly.
-echo "Step 2: Bringing up cluster for $CLOUD_PROVIDER..."
-python3 scripts/infra.py "$CLOUD_PROVIDER" up
-
-# Step 2.5: Create Hello World App
-echo "Step 2.5: Creating Hello World Go App..."
 mkdir -p hello-app
 cat <<EOF > hello-app/main.go
 package main
 import "fmt"
-func main() {
-    fmt.Println("Hello, World! This is a simple Go application.")
-}
+func main() { fmt.Println("Hello, World!") }
 EOF
 
-# Step 3: Call the eval script with the task to eval
-echo "Step 3: Running evaluation..."
 if [ -f "$HOME/deepeval_env/bin/activate" ]; then
-    echo "Activating virtual environment..."
     source "$HOME/deepeval_env/bin/activate"
 fi
 
+echo "Starting Evaluation Engine..."
 python3 pkg/evaluator/evaluate.py "$BENCH_TASK_FILE"
 
-# Step 3.5: Display results
-echo "Step 3.5: Displaying results..."
 LATEST_RESULTS=$(ls -t results/run_*/results.json 2>/dev/null | head -n 1)
-if [ -n "$LATEST_RESULTS" ] && [ -f "$LATEST_RESULTS" ]; then
-    echo "Latest results file: $LATEST_RESULTS"
+if [ -n "$LATEST_RESULTS" ]; then
     cat "$LATEST_RESULTS"
-else
-    echo "Warning: No results file found."
 fi
-
-# Step 4: Call the deployer script to shut the environment down
-echo "Step 4: Tearing down cluster..."
-python3 scripts/infra.py "$CLOUD_PROVIDER" down

--- a/scripts/infra.py
+++ b/scripts/infra.py
@@ -1,53 +1,111 @@
 import os
 import sys
 import argparse
+import json
+
+from pathlib import Path
 
 # Ensure project root is in path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from deployers.gcp.gcp_deployer import GCPDeployer
+project_root = Path(__file__).resolve().parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+
+from deployers.factory import get_deployer
 
 def main():
     parser = argparse.ArgumentParser(description="DevOps Bench Infra Manager")
-    subparsers = parser.add_subparsers(dest="provider", required=True, help="Cloud provider")
-    
+    parser.add_argument(
+        "--use-terraform", action="store_true", help="Use Terraform for deployment"
+    )
+    parser.add_argument(
+        "--stack",
+        help="Infrastructure stack to use (e.g., prebuilt/minimum)",
+        dest="stack"
+    )
+    # Support both --stack and deprecated --env for a smoother transition
+    parser.add_argument("--env", help=argparse.SUPPRESS)
+
+    subparsers = parser.add_subparsers(
+        dest="provider", required=True, help="Cloud provider"
+    )
+
     # GCP Subparser
     gcp_parser = subparsers.add_parser("gcp", help="GCP operations")
-    gcp_subparsers = gcp_parser.add_subparsers(dest="action", required=True, help="Action")
-    
+    gcp_subparsers = gcp_parser.add_subparsers(
+        dest="action", required=True, help="Action"
+    )
+
     # Add actions for GCP
     for action in ["up", "down", "info"]:
         p = gcp_subparsers.add_parser(action, help=f"Perform {action}")
         p.add_argument("--project", help="GCP Project ID")
         p.add_argument("--cluster-name", help="Name of the cluster")
-        p.add_argument("--zone", default="us-central1-a", help="GCP Zone")
-            
+        p.add_argument(
+            "--location", help="GCP Location (Zone or Region)"
+        )
+
+        # Support deprecated --zone for transition
+        p.add_argument("--zone", help=argparse.SUPPRESS)
+
     args = parser.parse_args()
-    
+
+    # Handle deprecated arguments
+    stack = args.stack or args.env
+    location = args.location
+    if hasattr(args, 'zone') and args.zone:
+         print(
+             "Warning: --zone is deprecated. Use --location instead.",
+             file=sys.stderr
+         )
+         location = args.zone
+
     if args.provider == "gcp":
         project = args.project or os.environ.get("GCP_PROJECT_ID")
         cluster_name = args.cluster_name or os.environ.get("GKE_CLUSTER_NAME")
-        zone = args.zone or os.environ.get("GCP_ZONE", "us-central1-a")
-        
+        # Enforce GCP_LOCATION precedence
+        final_location = (
+            location or os.environ.get("GCP_LOCATION", "us-central1-a")
+        )
+
         if not project or not cluster_name:
-            print("Error: Project and Cluster Name must be specified via flags or environment variables (GCP_PROJECT_ID, GKE_CLUSTER_NAME).", file=sys.stderr)
+
+            print(
+                "Error: Project and Cluster Name must be specified via flags or "
+                "environment variables (GCP_PROJECT_ID, GKE_CLUSTER_NAME).",
+                file=sys.stderr
+            )
             sys.exit(1)
-            
-        deployer = GCPDeployer(project=project, zone=zone, cluster_name=cluster_name)
-        
+
+        infra_config = {
+            "deployer": "terraform" if args.use_terraform else "kubetest2",
+            "stack": stack,
+        }
+        deployer = get_deployer(
+            infra_config, project, cluster_name, global_location=final_location
+        )
+
         if args.action == "up":
-            print(f"Bringing up cluster {cluster_name}...")
+            deploy_type = "Terraform" if args.use_terraform else "kubetest2"
+            print(f"Bringing up infrastructure ({deploy_type})...")
             deployer.up()
         elif args.action == "down":
-            print(f"Tearing down cluster {cluster_name}...")
+            print(f"Tearing down infrastructure...")
             deployer.down()
         elif args.action == "info":
-            import json
             print(json.dumps(deployer.get_cluster_info(), indent=2))
         else:
-            print(f"Critical Error: Unsupported action '{args.action}' for provider 'gcp'", file=sys.stderr)
+            print(
+                f"Critical Error: Unsupported action '{args.action}' "
+                f"for provider 'gcp'",
+                file=sys.stderr
+            )
             sys.exit(1)
     else:
-        print(f"Critical Error: Unsupported provider '{args.provider}'", file=sys.stderr)
+        print(
+            f"Critical Error: Unsupported provider '{args.provider}'",
+            file=sys.stderr
+        )
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/tasks/create-deployment/task.yaml
+++ b/tasks/create-deployment/task.yaml
@@ -1,8 +1,15 @@
 task_id: 2
 name: "create-deployment"
+infrastructure:
+  deployer: "terraform"
+  stack: "prebuilt/minimum"
+  teardown: true
+  variables:
+    node_count: 3
+    machine_type: "e2-standard-2"
 prompt: "Generate Kubernetes manifest for deploying our finetuned Gemma 3 12b model to our GKE {{GKE_CLUSTER_NAME}}. I think the models are stored in GCS in bucket hypercomputer-d1-models-{{GCP_PROJECT_ID}}. Ensure that it can scale up and down with traffic."
 expected_output: |
-  critical requirements: 
+  critical requirements:
 
   - Expected Tool Call: generate_manifest
   - Deploy a vLLM server for the Gemma 3 12B model.

--- a/tasks/deploy-config/task.yaml
+++ b/tasks/deploy-config/task.yaml
@@ -1,5 +1,12 @@
 task_id: 3
 name: "deploy-config"
+infrastructure:
+  deployer: "terraform"
+  stack: "prebuilt/minimum"
+  teardown: true
+  variables:
+    node_count: 3
+    machine_type: "e2-standard-2"
 prompt: |
   Deploy the provided manifests to cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}.
 
@@ -113,7 +120,7 @@ prompt: |
       name: hypercomputer-d1-vllm-server
   ```
 expected_output: |
-  critical requirements: 
+  critical requirements:
 
   - Execute the deployment of the provided manifests to the '{{GKE_CLUSTER_NAME}}' in project '{{GCP_PROJECT_ID}}'.
   - Confirm that the 'hypercomputer-d1-vllm-server' deployment was successfully applied to the cluster.

--- a/tasks/deploy-hello-app/task.yaml
+++ b/tasks/deploy-hello-app/task.yaml
@@ -1,8 +1,15 @@
 task_id: 6
 name: "deploy-hello-app"
+infrastructure:
+  deployer: "terraform"
+  stack: "prebuilt/minimum"
+  teardown: true
+  variables:
+    node_count: 3
+    machine_type: "e2-standard-2"
 prompt: "Generate a production-ready Kubernetes manifest for the application located at {{APP_LOCATION}} and then deploy it to cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}. I know the app is just a simple hello world, pretend it is a complex app that needs full productionization."
 expected_output: |
-  critical requirements: 
+  critical requirements:
   - Convert program to HTTP server
   - Add health check to code
   - Container build

--- a/tasks/fix-config/task.yaml
+++ b/tasks/fix-config/task.yaml
@@ -1,5 +1,12 @@
 task_id: 5
 name: "fix-config"
+infrastructure:
+  deployer: "terraform"
+  stack: "prebuilt/minimum"
+  teardown: true
+  variables:
+    node_count: 3
+    machine_type: "e2-standard-2"
 prompt: |
   Apply the manifest change to cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}.
 
@@ -41,7 +48,7 @@ prompt: |
         serviceAccountName: hypercomputer-d1-vllm-sa
   ```
 expected_output: |
-  critical requirements: 
+  critical requirements:
 
   - Identify the intent to update the 'hypercomputer-d1-frontend' deployment in cluster '{{GKE_CLUSTER_NAME}}' and project '{{GCP_PROJECT_ID}}'.
   - Confirm that 'USE_GEMINI_API' is set to 'false' and 'VLLM_API_URL' is correctly pointed to the local service.

--- a/tasks/get-app-architecture/task.yaml
+++ b/tasks/get-app-architecture/task.yaml
@@ -1,8 +1,15 @@
 task_id: 1
 name: "get-app-architecture"
+infrastructure:
+  deployer: "terraform"
+  stack: "prebuilt/minimum"
+  teardown: true
+  variables:
+    node_count: 3
+    machine_type: "e2-standard-2"
 prompt: "summarize the hypercomputer d1 app in project {{GCP_PROJECT_ID}}"
 expected_output: |
-  critical requirements: 
+  critical requirements:
 
   - Identify the app as 'hypercomputer d1' in project '{{GCP_PROJECT_ID}}'.
   - List core Kubernetes components (e.g., frontend-deployment, vllm-service).

--- a/tasks/modify-deployment/task.yaml
+++ b/tasks/modify-deployment/task.yaml
@@ -1,5 +1,12 @@
 task_id: 4
 name: "modify-deployment"
+infrastructure:
+  deployer: "terraform"
+  stack: "prebuilt/minimum"
+  teardown: true
+  variables:
+    node_count: 3
+    machine_type: "e2-standard-2"
 prompt: |
   Modify this given Kubernetes manifest for the hypercomputer-d1-frontend app in {{GCP_PROJECT_ID}} project from using the Gemini API to a locally hosted model ```
   apiVersion: apps/v1
@@ -39,7 +46,7 @@ prompt: |
         serviceAccountName: hypercomputer-d1-vllm-sa
   ```
 expected_output: |
-  critical requirements: 
+  critical requirements:
 
   - Switch the 'hypercomputer-d1-frontend' from Gemini API to the local vLLM model hosting.
   - Set the environment variable 'USE_GEMINI_API' to 'false'.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,31 @@
+# Terraform Infrastructure
+
+This directory contains the Terraform modules and prebuilt configurations used to provision infrastructure for the benchmarks.
+
+## Directory Structure
+
+- `modules/`: Reusable infrastructure components (e.g., GKE cluster, Networking).
+- `prebuilt/`: Standard, reusable environment configurations (e.g., `minimum` 3-node cluster).
+- `tasks/`: Task-specific infrastructure definitions (not yet used, but supported).
+
+## Usage in tasks
+
+Tasks can specify their infrastructure requirements in their `task.yaml` file:
+
+```yaml
+infrastructure:
+  deployer: "terraform"
+  stack: "prebuilt/minimum"
+  teardown: true
+  variables:
+    node_count: 3
+    machine_type: "e2-standard-2"
+```
+
+## Available Prebuilt Stacks
+
+### `minimum`
+A basic GKE cluster with:
+- 3 nodes
+- Machine type: `e2-standard-2`
+- GKE Standard cluster w/ default configuration

--- a/terraform/modules/gke/main.tf
+++ b/terraform/modules/gke/main.tf
@@ -1,0 +1,62 @@
+resource "google_service_account" "gke_nodes" {
+  account_id   = "gke-nodes-${trim(substr(var.cluster_name, 0, 15), "-")}"
+  display_name = "GKE Node Service Account for ${var.cluster_name}"
+}
+
+resource "google_project_iam_member" "gke_nodes_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_monitoring_viewer" {
+  project = var.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_metadata_writer" {
+  project = var.project_id
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_container_cluster" "primary" {
+  name     = var.cluster_name
+  location = var.location
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+  deletion_protection      = false
+}
+
+resource "google_container_node_pool" "primary_nodes" {
+  name       = "primary-node-pool"
+  location   = var.location
+  cluster    = google_container_cluster.primary.name
+  node_count = var.node_count
+
+  node_config {
+    preemptible     = false
+    machine_type    = var.machine_type
+    service_account = google_service_account.gke_nodes.email
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
+}
+
+output "cluster_name" {
+  value = google_container_cluster.primary.name
+}
+
+output "cluster_location" {
+  value = google_container_cluster.primary.location
+}

--- a/terraform/modules/gke/variables.tf
+++ b/terraform/modules/gke/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "location" {
+  description = "The GCP zone or region"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "cluster_name" {
+  description = "The name of the GKE cluster"
+  type        = string
+}
+
+variable "node_count" {
+  description = "Number of nodes in the standard pool"
+  type        = number
+  default     = 3
+}
+
+variable "machine_type" {
+  description = "Machine type for the nodes"
+  type        = string
+  default     = "e2-standard-2"
+}

--- a/terraform/prebuilt/minimum/main.tf
+++ b/terraform/prebuilt/minimum/main.tf
@@ -1,0 +1,22 @@
+provider "google" {
+  project = var.project_id
+  zone    = var.location
+}
+
+module "gke" {
+  source       = "../../modules/gke"
+  project_id   = var.project_id
+  cluster_name = var.cluster_name
+  location     = var.location
+  node_count   = var.node_count
+  machine_type = var.machine_type
+}
+
+
+output "cluster_name" {
+  value = module.gke.cluster_name
+}
+
+output "cluster_location" {
+  value = module.gke.cluster_location
+}

--- a/terraform/prebuilt/minimum/variables.tf
+++ b/terraform/prebuilt/minimum/variables.tf
@@ -1,0 +1,12 @@
+variable "project_id" {}
+variable "cluster_name" {}
+
+variable "location" { default = "us-central1-a" }
+variable "node_count" {
+  type    = number
+  default = 3
+}
+variable "machine_type" {
+  type    = string
+  default = "e2-standard-2"
+}

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,114 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+from pathlib import Path
+
+# Ensure project root is in path
+project_root = Path(__file__).resolve().parents[1]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from deployers.factory import get_deployer
+from deployers.gcp.gcp_deployer import GCPDeployer
+from deployers.terraform.tf_deployer import TerraformDeployer
+
+
+@pytest.fixture
+def base_config():
+    return {
+        "project_id": "test-project",
+        "cluster_name": "test-cluster",
+        "location": "us-central1-a"
+    }
+
+
+def test_get_deployer_default(base_config):
+    infra_config = {}
+    deployer = get_deployer(
+        infra_config,
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"]
+    )
+    assert isinstance(deployer, GCPDeployer)
+    assert deployer.project == base_config["project_id"]
+    assert deployer.cluster_name == base_config["cluster_name"]
+    assert deployer.zone == base_config["location"]
+
+
+def test_get_deployer_kubetest2(base_config):
+    infra_config = {"deployer": "kubetest2"}
+    deployer = get_deployer(
+        infra_config,
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"]
+    )
+    assert isinstance(deployer, GCPDeployer)
+
+
+@patch('deployers.terraform.tf_deployer.Path.exists', return_value=True)
+def test_get_deployer_terraform_default_stack(mock_exists, base_config):
+    infra_config = {"deployer": "terraform"}
+    deployer = get_deployer(
+        infra_config,
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"]
+    )
+    assert isinstance(deployer, TerraformDeployer)
+
+    expected_vars = {
+        "project_id": base_config["project_id"],
+        "cluster_name": base_config["cluster_name"],
+        "location": base_config["location"]
+    }
+    assert deployer.variables == expected_vars
+
+    expected_stack_path = str(project_root / "terraform" / "prebuilt/minimum")
+    assert deployer.tf_dir == expected_stack_path
+
+
+@patch('deployers.terraform.tf_deployer.Path.exists', return_value=True)
+def test_get_deployer_terraform_custom_stack_and_vars(mock_exists, base_config):
+    infra_config = {
+        "deployer": "terraform",
+        "stack": "custom/stack",
+        "variables": {
+            "node_count": 5,
+            "machine_type": "n2-standard-4",
+            "cluster_name": "custom-cluster" # Should override global
+        }
+    }
+    deployer = get_deployer(
+        infra_config,
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"]
+    )
+    assert isinstance(deployer, TerraformDeployer)
+
+    expected_vars = {
+        "project_id": base_config["project_id"],
+        "cluster_name": "custom-cluster",
+        "location": base_config["location"],
+        "node_count": 5,
+        "machine_type": "n2-standard-4"
+    }
+    assert deployer.variables == expected_vars
+    expected_stack_path = str(project_root / "terraform" / "custom/stack")
+    assert deployer.tf_dir == expected_stack_path
+
+
+@patch.dict(os.environ, {"GCP_LOCATION": "us-west1-b"})
+def test_get_deployer_location_from_env(base_config):
+    infra_config = {}
+    # Pass None for global_location to trigger env lookup
+    deployer = get_deployer(
+        infra_config,
+        base_config["project_id"],
+        base_config["cluster_name"],
+        global_location=None
+    )
+    assert deployer.zone == "us-west1-b"

--- a/tests/test_gcp_deployer.py
+++ b/tests/test_gcp_deployer.py
@@ -1,75 +1,126 @@
-import unittest
+import pytest
 from unittest.mock import patch, MagicMock
 import os
 import sys
+from pathlib import Path
 
-# Add project root to path to resolve imports correctly
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if project_root not in sys.path:
-    sys.path.insert(0, project_root)
+# Ensure project root is in path
+project_root = Path(__file__).resolve().parents[1]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
 
 from deployers.gcp.gcp_deployer import GCPDeployer
 
-class TestGCPDeployer(unittest.TestCase):
-    def setUp(self):
-        self.project = "test-project"
-        self.zone = "test-zone"
-        self.cluster_name = "test-cluster"
-        self.deployer = GCPDeployer(self.project, self.zone, self.cluster_name)
 
-    @patch('subprocess.run')
-    def test_up(self, mock_run):
-        # Mock describe check to return failure so that GKE cluster is created
-        mock_run.return_value = MagicMock(returncode=1)
-        self.deployer.up()
-        self.assertEqual(mock_run.call_count, 2)
-        args, kwargs = mock_run.call_args_list[1]
-        cmd = args[0]
-        self.assertIn("kubetest2", cmd)
-        self.assertIn("gke", cmd)
-        self.assertIn("--up", cmd)
-        self.assertIn(self.project, cmd)
-        
-        # Verify env has bin_dir in PATH
-        env = kwargs.get('env')
-        self.assertIsNotNone(env)
-        self.assertIn(self.deployer.bin_dir, env['PATH'])
-        
-    @patch('subprocess.run')
-    def test_up_with_config(self, mock_run):
-        # Mock describe check to return failure so that GKE cluster is created
-        mock_run.return_value = MagicMock(returncode=1)
-        deployer = GCPDeployer(self.project, self.zone, self.cluster_name, machine_type="n1-standard-4", num_nodes=5)
-        deployer.up()
-        self.assertEqual(mock_run.call_count, 2)
-        args, kwargs = mock_run.call_args_list[1]
-        cmd = args[0]
-        self.assertIn("--machine-type", cmd)
-        self.assertIn("n1-standard-4", cmd)
-        self.assertIn("--num-nodes", cmd)
-        self.assertIn("5", cmd)
+@pytest.fixture
+def gcp_deployer_setup():
+    project = "test-project"
+    location = "us-central1-a"
+    cluster_name = "test-cluster"
+    return {
+        "project": project,
+        "location": location,
+        "cluster_name": cluster_name,
+        "deployer": GCPDeployer(project, location, cluster_name)
+    }
 
-    @patch('subprocess.run')
-    def test_down(self, mock_run):
-        self.deployer.down()
-        mock_run.assert_called_once()
-        args, kwargs = mock_run.call_args
-        cmd = args[0]
-        self.assertIn("kubetest2", cmd)
-        self.assertIn("gke", cmd)
-        self.assertIn("--down", cmd)
-        self.assertIn(self.project, cmd)
-        
-        env = kwargs.get('env')
-        self.assertIsNotNone(env)
-        self.assertIn(self.deployer.bin_dir, env['PATH'])
 
-    def test_get_cluster_info(self):
-        info = self.deployer.get_cluster_info()
-        self.assertEqual(info['name'], self.cluster_name)
-        self.assertEqual(info['zone'], self.zone)
-        self.assertEqual(info['project'], self.project)
-        self.assertTrue('kubeconfig_path' in info)
+@patch('subprocess.run')
+# Patch Path.write_text to avoid actually writing to /tmp during tests
+@patch.object(Path, 'write_text')
+def test_up(mock_write_text, mock_run, gcp_deployer_setup):
+    deployer = gcp_deployer_setup["deployer"]
 
-if __name__ == '__main__':
-    unittest.main()
+    mock_desc_process = MagicMock()
+    mock_desc_process.returncode = 1
+
+    mock_run.side_effect = [
+        mock_desc_process, # describe
+        MagicMock() # kubetest2
+    ]
+
+    deployer.up()
+
+    args_list = mock_run.call_args_list
+    assert len(args_list) == 2
+
+    assert args_list[0][0][0] == [
+        "gcloud", "container", "clusters", "describe",
+        gcp_deployer_setup["cluster_name"],
+        "--project", gcp_deployer_setup["project"],
+        "--location", gcp_deployer_setup["location"]
+    ]
+
+    cmd = args_list[1][0][0]
+    assert "kubetest2" in cmd
+    assert "gke" in cmd
+    assert "--up" in cmd
+    assert gcp_deployer_setup["project"] in cmd
+
+    env = args_list[1][1].get('env')
+    assert env is not None
+    assert deployer.bin_dir in env['PATH']
+    mock_write_text.assert_called_once_with("true")
+
+
+@patch('subprocess.run')
+@patch.object(Path, 'write_text')
+def test_up_with_config(mock_write_text, mock_run, gcp_deployer_setup):
+    deployer = GCPDeployer(
+        gcp_deployer_setup["project"],
+        gcp_deployer_setup["location"],
+        gcp_deployer_setup["cluster_name"],
+        machine_type="n1-standard-4",
+        num_nodes=5
+    )
+
+    mock_desc_process = MagicMock()
+    mock_desc_process.returncode = 1
+
+    mock_run.side_effect = [
+        mock_desc_process, # describe
+        MagicMock() # kubetest2
+    ]
+
+    deployer.up()
+
+    args_list = mock_run.call_args_list
+    assert len(args_list) == 2
+
+    cmd = args_list[1][0][0]
+    assert "--machine-type" in cmd
+    assert "n1-standard-4" in cmd
+    assert "--num-nodes" in cmd
+    assert "5" in cmd
+    mock_write_text.assert_called_once_with("true")
+
+
+@patch('subprocess.run')
+def test_down(mock_run, gcp_deployer_setup):
+    deployer = gcp_deployer_setup["deployer"]
+
+    with patch.object(Path, 'exists', return_value=True):
+        with patch.object(Path, 'read_text', return_value="true"):
+            deployer.down()
+
+            mock_run.assert_called_once()
+            args, kwargs = mock_run.call_args
+            cmd = args[0]
+            assert "kubetest2" in cmd
+            assert "gke" in cmd
+            assert "--down" in cmd
+            assert gcp_deployer_setup["project"] in cmd
+
+            env = kwargs.get('env')
+            assert env is not None
+            assert deployer.bin_dir in env['PATH']
+
+
+def test_get_cluster_info(gcp_deployer_setup):
+    deployer = gcp_deployer_setup["deployer"]
+    info = deployer.get_cluster_info()
+    assert info['name'] == gcp_deployer_setup["cluster_name"]
+    assert info['location'] == gcp_deployer_setup["location"]
+    assert info['zone'] == gcp_deployer_setup["location"]
+    assert info['project'] == gcp_deployer_setup["project"]
+    assert 'kubeconfig_path' in info

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -1,27 +1,56 @@
-import unittest
+import pytest
 from unittest.mock import patch, MagicMock
 import sys
 import os
+from pathlib import Path
 
 # Ensure project root is in path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+project_root = Path(__file__).resolve().parents[1]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
 from scripts.infra import main
 
-class TestInfraCLI(unittest.TestCase):
 
-    @patch('deployers.gcp.gcp_deployer.GCPDeployer.up')
-    def test_gcp_up(self, mock_up):
-        test_args = ["infra.py", "gcp", "up", "--project", "my-project", "--cluster-name", "my-cluster"]
-        with patch.object(sys, 'argv', test_args):
-            main()
-        mock_up.assert_called_once()
+@patch('deployers.gcp.gcp_deployer.GCPDeployer.up')
+def test_gcp_up(mock_up):
+    test_args = [
+        "infra.py", "gcp", "up", "--project", "my-project", "--cluster-name",
+        "my-cluster"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        main()
+    mock_up.assert_called_once()
 
-    @patch('deployers.gcp.gcp_deployer.GCPDeployer.down')
-    def test_gcp_down(self, mock_down):
-        test_args = ["infra.py", "gcp", "down", "--project", "my-project", "--cluster-name", "my-cluster"]
-        with patch.object(sys, 'argv', test_args):
-            main()
-        mock_down.assert_called_once()
 
-if __name__ == '__main__':
-    unittest.main()
+@patch('deployers.gcp.gcp_deployer.GCPDeployer.down')
+def test_gcp_down(mock_down):
+    test_args = [
+        "infra.py", "gcp", "down", "--project", "my-project", "--cluster-name",
+        "my-cluster"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        main()
+    mock_down.assert_called_once()
+
+
+@patch('deployers.terraform.tf_deployer.TerraformDeployer.up')
+def test_gcp_terraform_up(mock_up):
+    test_args = [
+        "infra.py", "--use-terraform", "gcp", "up", "--project", "my-project",
+        "--cluster-name", "my-cluster"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        main()
+    mock_up.assert_called_once()
+
+
+@patch('deployers.terraform.tf_deployer.TerraformDeployer.down')
+def test_gcp_terraform_down(mock_down):
+    test_args = [
+        "infra.py", "--use-terraform", "gcp", "down", "--project", "my-project",
+        "--cluster-name", "my-cluster"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        main()
+    mock_down.assert_called_once()

--- a/tests/test_tf_deployer.py
+++ b/tests/test_tf_deployer.py
@@ -1,0 +1,171 @@
+import pytest
+from unittest.mock import patch, MagicMock, call
+import os
+import sys
+import subprocess
+import json
+from pathlib import Path
+
+# Ensure project root is in path
+project_root = Path(__file__).resolve().parents[1]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from deployers.terraform.tf_deployer import TerraformDeployer
+
+
+@pytest.fixture
+def tf_deployer_setup():
+    variables = {
+        "project_id": "test-project",
+        "cluster_name": "test-cluster",
+        "location": "us-central1-a",
+        "node_count": 3
+    }
+    # We need to mock Path.exists because TerraformDeployer.__init__ calls it
+    with patch.object(Path, 'exists', return_value=True):
+        deployer = TerraformDeployer(tf_dir="prebuilt/minimum", variables=variables)
+    return deployer
+
+
+@patch('subprocess.run')
+def test_up(mock_run, tf_deployer_setup):
+    tf_deployer_setup.up()
+
+    expected_init = call(
+        ["terraform", "init", "-input=false"],
+        cwd=tf_deployer_setup.tf_dir,
+        env=os.environ
+    )
+    # Wait, in my refactored tf_deployer.py, I passed `env=env` where `env = os.environ.copy()`.
+    # Let's check how `mock.call` handles `env`. It will be a dict.
+    # In tests, comparing dicts exactly can be tricky if env has extra stuff,
+    # but since it's `os.environ.copy()`, it should match `os.environ` if we don't modify it in the test.
+
+    expected_apply = call([
+        "terraform", "apply", "-auto-approve", "-input=false",
+        "-var", "project_id=test-project",
+        "-var", "cluster_name=test-cluster",
+        "-var", "location=us-central1-a",
+        "-var", "node_count=3"
+    ], cwd=tf_deployer_setup.tf_dir, env=os.environ)
+
+    # We need to be careful about `env` in `mock_run.assert_has_calls`.
+    # Let's see if we can assert calls without strict `env` matching, or provide the exact expected env.
+    # Since `tf_deployer.py` uses `os.environ.copy()`, we can just check the args.
+
+    args_list = mock_run.call_args_list
+    assert len(args_list) == 2
+    assert args_list[0][0][0] == ["terraform", "init", "-input=false"]
+    assert args_list[0][1]['cwd'] == tf_deployer_setup.tf_dir
+
+    assert args_list[1][0][0] == [
+        "terraform", "apply", "-auto-approve", "-input=false",
+        "-var", "project_id=test-project",
+        "-var", "cluster_name=test-cluster",
+        "-var", "location=us-central1-a",
+        "-var", "node_count=3"
+    ]
+    assert args_list[1][1]['cwd'] == tf_deployer_setup.tf_dir
+
+
+@patch('subprocess.run')
+def test_down(mock_run, tf_deployer_setup):
+    tf_deployer_setup.down()
+
+    args_list = mock_run.call_args_list
+    assert len(args_list) == 2
+    assert args_list[0][0][0] == ["terraform", "init", "-input=false"]
+    assert args_list[1][0][0] == [
+        "terraform", "destroy", "-auto-approve", "-input=false",
+        "-var", "project_id=test-project",
+        "-var", "cluster_name=test-cluster",
+        "-var", "location=us-central1-a",
+        "-var", "node_count=3"
+    ]
+
+
+@patch('subprocess.run')
+def test_get_cluster_info(mock_run, tf_deployer_setup):
+    tf_output = {
+        "cluster_name": {"value": "test-cluster"},
+        "cluster_location": {"value": "us-central1-a"}
+    }
+    mock_tf_out_process = MagicMock()
+    mock_tf_out_process.stdout = json.dumps(tf_output)
+
+    mock_run.side_effect = [
+        MagicMock(), # init
+        mock_tf_out_process, # output
+        MagicMock() # gcloud
+    ]
+
+    info = tf_deployer_setup.get_cluster_info()
+
+    assert info["name"] == "test-cluster"
+    assert info["location"] == "us-central1-a"
+    assert info["project"] == "test-project"
+    assert "kubeconfig_path" in info
+
+    args_list = mock_run.call_args_list
+    assert len(args_list) == 3
+    assert args_list[0][0][0] == ["terraform", "init", "-input=false"]
+    assert args_list[1][0][0] == ["terraform", "output", "-json"]
+    # Check gcloud call with --location
+    assert args_list[2][0][0] == [
+        "gcloud", "container", "clusters", "get-credentials", "test-cluster",
+        "--location", "us-central1-a", "--project", "test-project"
+    ]
+
+
+@patch('subprocess.run')
+def test_get_cluster_info_regional(mock_run, tf_deployer_setup):
+    tf_output = {
+        "cluster_name": {"value": "test-cluster"},
+        "cluster_location": {"value": "us-central1"}
+    }
+    mock_tf_out_process = MagicMock()
+    mock_tf_out_process.stdout = json.dumps(tf_output)
+
+    mock_run.side_effect = [
+        MagicMock(), # init
+        mock_tf_out_process, # output
+        MagicMock() # gcloud
+    ]
+
+    info = tf_deployer_setup.get_cluster_info()
+
+    assert info["name"] == "test-cluster"
+    assert info["location"] == "us-central1"
+    assert info["project"] == "test-project"
+
+    args_list = mock_run.call_args_list
+    assert len(args_list) == 3
+    assert args_list[2][0][0] == [
+        "gcloud", "container", "clusters", "get-credentials", "test-cluster",
+        "--location", "us-central1", "--project", "test-project"
+    ]
+
+
+@patch.object(Path, 'exists')
+def test_init_path_resolution(mock_exists):
+    # Test absolute path
+    abs_path = "/tmp/my-tf-stack"
+    mock_exists.return_value = True
+    deployer = TerraformDeployer(tf_dir=abs_path)
+    assert deployer.tf_dir == abs_path
+
+    # Test relative path in repo (terraform/<dir>)
+    # We need to be careful mocking Path.exists for the fallback logic
+    # In our refactored code:
+    # 1. Path(tf_dir).is_absolute()
+    # 2. repo_tf_path = repo_root / "terraform" / tf_path
+    # 3. repo_tf_path.exists()
+
+    with patch.object(Path, 'exists', side_effect=lambda *args, **kwargs: True):
+        deployer = TerraformDeployer(tf_dir="my-repo-stack")
+        assert deployer.tf_dir == str(project_root / "terraform" / "my-repo-stack")
+
+    # Wait, my refactored code removed the "CWD" check as requested by Comment 3!
+    # "Simplify supported Terraform directory paths in tf_deployer.py to just repo_root/terraform and explicitly specified directory."
+    # So I should NOT test the CWD fallback.


### PR DESCRIPTION
Now the task yaml can specify an `infrastructure` block that specifies a terraform stack. If the task doesn't specify one, the infra provisioning will fall back to use kubetest2.

