### PR TITLE
refactor(neutrality): make evaluator and skills cloud-neutral and add local KinD deployer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 
+
 # Install Gemini CLI globally (customizable version)
 ARG GEMINI_CLI_VERSION=latest
 RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION}

--- a/deployers/base.py
+++ b/deployers/base.py
@@ -24,6 +24,6 @@ class Deployer(ABC):
     def get_cluster_info(self) -> Dict[str, Any]:
         """
         Returns a dictionary with cluster details.
-        Expected keys: 'name', 'zone', 'project', 'kubeconfig_path'
+        Expected keys: 'name', 'location', 'project', 'kubeconfig_path'
         """
         pass

--- a/deployers/factory.py
+++ b/deployers/factory.py
@@ -15,20 +15,29 @@ def get_deployer(
 
     Enforces GCP_LOCATION as the standard environment variable for location.
     """
-    deployer_type = infra_config.get("deployer", "kubetest2")
+    # Check if CLOUD_PROVIDER environment variable overrides the task-level deployer
+    cloud_provider = os.environ.get("CLOUD_PROVIDER", "").lower()
+    deployer_type = cloud_provider if cloud_provider else infra_config.get("deployer", "terraform")
 
     # Resolve Location with strict precedence: argument then GCP_LOCATION env var
     location = global_location or os.environ.get("GCP_LOCATION", "us-central1-a")
 
     if deployer_type == "terraform":
-
-        stack = infra_config.get("stack") or "prebuilt/minimum"
+        stack = infra_config.get("stack") or "prebuilt/kind"
         variables = infra_config.get("variables", {})
 
-        # Ensure critical variables are present, defaulting to globals
-        variables.setdefault("project_id", global_project_id)
-        variables.setdefault("cluster_name", global_cluster_name)
-        variables.setdefault("location", location)
+        if stack == "prebuilt/kind":
+            cluster_name = global_cluster_name or "devops-bench-kind"
+            variables.setdefault("cluster_name", cluster_name)
+            variables.setdefault("location", "local")
+            import pathlib
+            kubeconfig_path = os.environ.get("KUBECONFIG") or str(pathlib.Path("~/.kube/config").expanduser().resolve())
+            variables.setdefault("kubeconfig_path", kubeconfig_path)
+        else:
+            # Ensure critical variables are present, defaulting to globals
+            variables.setdefault("project_id", global_project_id)
+            variables.setdefault("cluster_name", global_cluster_name)
+            variables.setdefault("location", location)
 
         return TerraformDeployer(tf_dir=stack, variables=variables)
 
@@ -36,6 +45,6 @@ def get_deployer(
     return GCPDeployer(
         project=global_project_id,
         location=location,
-
         cluster_name=global_cluster_name
     )
+

--- a/deployers/terraform/tf_deployer.py
+++ b/deployers/terraform/tf_deployer.py
@@ -98,6 +98,19 @@ class TerraformDeployer(Deployer):
                 "Failed to retrieve 'cluster_location' from Terraform outputs."
             )
 
+        kubeconfig_path = os.environ.get(
+            "KUBECONFIG", str(Path.home() / ".kube" / "config")
+        )
+
+        if location == "local":
+            project = self.variables.get("project_id") or os.environ.get("GCP_PROJECT_ID") or "local-kind"
+            return {
+                "name": cluster_name,
+                "location": location,
+                "project": project,
+                "kubeconfig_path": kubeconfig_path
+            }
+
         project = self.variables.get("project_id") or os.environ.get("GCP_PROJECT_ID")
         if not project:
              raise ValueError("Project ID not found in variables or environment (GCP_PROJECT_ID).")
@@ -108,13 +121,10 @@ class TerraformDeployer(Deployer):
             "--location", location, "--project", project
         ], check=True)
 
-        kubeconfig_path = os.environ.get(
-            "KUBECONFIG", str(Path.home() / ".kube" / "config")
-        )
-
         return {
             "name": cluster_name,
             "location": location,
             "project": project,
             "kubeconfig_path": kubeconfig_path
         }
+

--- a/pkg/evaluator/evaluate.py
+++ b/pkg/evaluator/evaluate.py
@@ -856,12 +856,14 @@ def main():
         except Exception as e:
             print(f"Critical error during task {item['name']}: {e}")
         finally:
-            if infra_config.get("teardown", True):
+            global_no_teardown = os.environ.get("BENCH_NO_TEARDOWN", "false").lower() == "true"
+            if infra_config.get("teardown", True) and not global_no_teardown:
                 print(f"--- Tearing Down Infrastructure for: {item['name']} ---")
                 try:
                     deployer.down()
                 except Exception as teardown_err:
                     print(f"Teardown failed (potential resource leak): {teardown_err}")
+
 
         expected_output_raw = item.get("expected_output", "")
         detailed_results[-1]["expected_output"] = replace_placeholders(

--- a/scripts/infra.py
+++ b/scripts/infra.py
@@ -48,17 +48,29 @@ def main():
         # Support deprecated --zone for transition
         p.add_argument("--zone", help=argparse.SUPPRESS)
 
+    # KinD Subparser
+    kind_parser = subparsers.add_parser("kind", help="KinD local operations")
+    kind_subparsers = kind_parser.add_subparsers(
+        dest="action", required=True, help="Action"
+    )
+
+    # Add actions for KinD
+    for action in ["up", "down", "info"]:
+        p = kind_subparsers.add_parser(action, help=f"Perform {action}")
+        p.add_argument("--cluster-name", help="Name of the local KinD cluster")
+
     args = parser.parse_args()
 
     # Handle deprecated arguments
     stack = args.stack or args.env
-    location = args.location
+    location = getattr(args, 'location', None)
     if hasattr(args, 'zone') and args.zone:
          print(
              "Warning: --zone is deprecated. Use --location instead.",
              file=sys.stderr
          )
          location = args.zone
+
 
     if args.provider == "gcp":
         project = args.project or os.environ.get("GCP_PROJECT_ID")
@@ -101,12 +113,37 @@ def main():
                 file=sys.stderr
             )
             sys.exit(1)
+            
+    elif args.provider == "kind":
+        cluster_name = args.cluster_name or os.environ.get("KUBERNETES_CLUSTER_NAME", "devops-bench-kind")
+        infra_config = {
+            "deployer": "terraform",
+            "stack": stack or "prebuilt/kind",
+        }
+        deployer = get_deployer(infra_config, "local-project", cluster_name)
+
+        if args.action == "up":
+            print(f"Bringing up local KinD cluster {cluster_name} (Terraform)...")
+            deployer.up()
+        elif args.action == "down":
+            print(f"Tearing down local KinD cluster {cluster_name}...")
+            deployer.down()
+        elif args.action == "info":
+            print(json.dumps(deployer.get_cluster_info(), indent=2))
+        else:
+            print(
+                f"Critical Error: Unsupported action '{args.action}' "
+                f"for provider 'kind'",
+                file=sys.stderr
+            )
+            sys.exit(1)
     else:
         print(
             f"Critical Error: Unsupported provider '{args.provider}'",
             file=sys.stderr
         )
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/skills/outcome-validity-checklist.md
+++ b/skills/outcome-validity-checklist.md
@@ -5,7 +5,7 @@ description: Evaluates the outcome of an agent's task based on user intent and p
 
 # Instructions
 
-You are an expert GKE Reliability Engineer evaluating the final outcome of an
+You are an expert Kubernetes Reliability Engineer evaluating the final outcome of an
 agent's task. Your goal is to determine if the agent achieved the user's
 requested outcome and if the resulting state is production-ready.
 

--- a/skills/outcome-validity-skill.md
+++ b/skills/outcome-validity-skill.md
@@ -5,7 +5,7 @@ description: Evaluates the outcome of an agent's task based on user intent and p
 
 # Instructions
 
-You are an expert GKE Reliability Engineer evaluating the final outcome of an
+You are an expert Kubernetes Reliability Engineer evaluating the final outcome of an
 agent's task. Your goal is to determine if the agent achieved the user's
 requested outcome and if the resulting state is production-ready.
 

--- a/skills/tool-invocation-skill.md
+++ b/skills/tool-invocation-skill.md
@@ -1,11 +1,11 @@
 ---
 name: tool-invocation
-description: Evaluates tool usage efficiency and correctness for a GKE assistant.
+description: Evaluates tool usage efficiency and correctness for a Kubernetes assistant.
 ---
 
 ## Instructions
 
-You are an expert GKE assistant evaluator focusing on tool usage efficiency
+You are an expert Kubernetes assistant evaluator focusing on tool usage efficiency
 and correctness. Your goal is to evaluate the sequence of actions and tool
 calls the agent made to fulfill the request.
 

--- a/terraform/prebuilt/kind/main.tf
+++ b/terraform/prebuilt/kind/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    kind = {
+      source  = "tehcyx/kind"
+      version = ">= 0.5.0"
+    }
+  }
+}
+
+provider "kind" {}
+
+resource "kind_cluster" "default" {
+  name            = var.cluster_name
+  wait_for_ready  = true
+  kubeconfig_path = pathexpand(var.kubeconfig_path)
+}
+
+output "cluster_name" {
+  value = kind_cluster.default.name
+}
+
+output "cluster_location" {
+  value = "local"
+}

--- a/terraform/prebuilt/kind/variables.tf
+++ b/terraform/prebuilt/kind/variables.tf
@@ -1,0 +1,16 @@
+variable "cluster_name" {
+  type    = string
+  default = "devops-bench-kind"
+}
+
+variable "location" {
+  type    = string
+  default = "local"
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  description = "Path to write the kubeconfig file"
+  default     = "~/.kube/config"
+}
+

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -23,7 +23,8 @@ def base_config():
     }
 
 
-def test_get_deployer_default(base_config):
+@patch('deployers.terraform.tf_deployer.Path.exists', return_value=True)
+def test_get_deployer_default(mock_exists, base_config):
     infra_config = {}
     deployer = get_deployer(
         infra_config,
@@ -31,10 +32,9 @@ def test_get_deployer_default(base_config):
         base_config["cluster_name"],
         base_config["location"]
     )
-    assert isinstance(deployer, GCPDeployer)
-    assert deployer.project == base_config["project_id"]
-    assert deployer.cluster_name == base_config["cluster_name"]
-    assert deployer.zone == base_config["location"]
+    assert isinstance(deployer, TerraformDeployer)
+    expected_stack_path = str(project_root / "terraform" / "prebuilt/kind")
+    assert deployer.tf_dir == expected_stack_path
 
 
 def test_get_deployer_kubetest2(base_config):
@@ -59,14 +59,16 @@ def test_get_deployer_terraform_default_stack(mock_exists, base_config):
     )
     assert isinstance(deployer, TerraformDeployer)
 
+    import pathlib
+    expected_kubeconfig = os.environ.get("KUBECONFIG") or str(pathlib.Path("~/.kube/config").expanduser().resolve())
     expected_vars = {
-        "project_id": base_config["project_id"],
         "cluster_name": base_config["cluster_name"],
-        "location": base_config["location"]
+        "location": "local",
+        "kubeconfig_path": expected_kubeconfig
     }
     assert deployer.variables == expected_vars
 
-    expected_stack_path = str(project_root / "terraform" / "prebuilt/minimum")
+    expected_stack_path = str(project_root / "terraform" / "prebuilt/kind")
     assert deployer.tf_dir == expected_stack_path
 
 
@@ -103,7 +105,7 @@ def test_get_deployer_terraform_custom_stack_and_vars(mock_exists, base_config):
 
 @patch.dict(os.environ, {"GCP_LOCATION": "us-west1-b"})
 def test_get_deployer_location_from_env(base_config):
-    infra_config = {}
+    infra_config = {"deployer": "kubetest2"}
     # Pass None for global_location to trigger env lookup
     deployer = get_deployer(
         infra_config,
@@ -112,3 +114,5 @@ def test_get_deployer_location_from_env(base_config):
         global_location=None
     )
     assert deployer.zone == "us-west1-b"
+
+

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -54,3 +54,24 @@ def test_gcp_terraform_down(mock_down):
     with patch.object(sys, 'argv', test_args):
         main()
     mock_down.assert_called_once()
+
+
+@patch('deployers.terraform.tf_deployer.TerraformDeployer.up')
+def test_kind_up(mock_up):
+    test_args = [
+        "infra.py", "kind", "up", "--cluster-name", "my-local-cluster"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        main()
+    mock_up.assert_called_once()
+
+
+@patch('deployers.terraform.tf_deployer.TerraformDeployer.up')
+def test_kind_terraform_up(mock_up):
+    test_args = [
+        "infra.py", "--use-terraform", "kind", "up", "--cluster-name", "my-local-cluster"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        main()
+    mock_up.assert_called_once()
+

--- a/tests/test_tf_deployer.py
+++ b/tests/test_tf_deployer.py
@@ -147,6 +147,63 @@ def test_get_cluster_info_regional(mock_run, tf_deployer_setup):
     ]
 
 
+@patch('subprocess.run')
+def test_get_cluster_info_local(mock_run, tf_deployer_setup):
+    tf_output = {
+        "cluster_name": {"value": "test-cluster"},
+        "cluster_location": {"value": "local"}
+    }
+    mock_tf_out_process = MagicMock()
+    mock_tf_out_process.stdout = json.dumps(tf_output)
+
+    mock_run.side_effect = [
+        MagicMock(), # init
+        mock_tf_out_process, # output
+    ]
+
+    info = tf_deployer_setup.get_cluster_info()
+
+    assert info["name"] == "test-cluster"
+    assert info["location"] == "local"
+    assert info["project"] == "test-project"
+    assert "kubeconfig_path" in info
+
+    args_list = mock_run.call_args_list
+    assert len(args_list) == 2
+    assert args_list[0][0][0] == ["terraform", "init", "-input=false"]
+    assert args_list[1][0][0] == ["terraform", "output", "-json"]
+    for call_args in args_list:
+        assert "gcloud" not in call_args[0][0]
+
+
+@patch('subprocess.run')
+def test_get_cluster_info_local_no_project(mock_run):
+    # Test that we default project to local-kind when no project is provided
+    with patch.object(Path, 'exists', return_value=True):
+        deployer = TerraformDeployer(tf_dir="prebuilt/minimum", variables={})
+
+    tf_output = {
+        "cluster_name": {"value": "test-cluster"},
+        "cluster_location": {"value": "local"}
+    }
+    mock_tf_out_process = MagicMock()
+    mock_tf_out_process.stdout = json.dumps(tf_output)
+
+    mock_run.side_effect = [
+        MagicMock(), # init
+        mock_tf_out_process, # output
+    ]
+
+    with patch.dict(os.environ, {}, clear=True):
+        info = deployer.get_cluster_info()
+
+    assert info["name"] == "test-cluster"
+    assert info["location"] == "local"
+    assert info["project"] == "local-kind"
+    assert "kubeconfig_path" in info
+
+
+
 @patch.object(Path, 'exists')
 def test_init_path_resolution(mock_exists):
     # Test absolute path


### PR DESCRIPTION
This PR prepares the repo to be vendor-neutral (focus on cluster:

-  Added `KinDDeployer` to enable local cluster provisioning without cloud requirements.
- Refactored the evaluation framework to make GCP project and GKE cluster credentials optional.
- Update `skills/` folder to represent generic Kubernetes Reliability roles.
