### PR TITLE
refactor(neutrality): generalize evaluate.py and extract provider-specific variables

### DIFF
--- a/deployers/factory.py
+++ b/deployers/factory.py
@@ -4,6 +4,14 @@ from deployers.base import Deployer
 from deployers.gcp.gcp_deployer import GCPDeployer
 from deployers.terraform.tf_deployer import TerraformDeployer
 
+from deployers.gcp.variables import resolve_variables as resolve_gcp_vars
+from deployers.kind.variables import resolve_variables as resolve_kind_vars
+
+PROVIDER_RESOLVERS = {
+    "gcp": resolve_gcp_vars,
+    "kind": resolve_kind_vars,
+}
+
 def get_deployer(
     infra_config: Dict[str, Any],
     global_project_id: str,
@@ -26,18 +34,13 @@ def get_deployer(
         stack = infra_config.get("stack") or "prebuilt/kind"
         variables = infra_config.get("variables", {})
 
-        if stack == "prebuilt/kind":
-            cluster_name = global_cluster_name or "devops-bench-kind"
-            variables.setdefault("cluster_name", cluster_name)
-            variables.setdefault("location", "local")
-            import pathlib
-            kubeconfig_path = os.environ.get("KUBECONFIG") or str(pathlib.Path("~/.kube/config").expanduser().resolve())
-            variables.setdefault("kubeconfig_path", kubeconfig_path)
-        else:
-            # Ensure critical variables are present, defaulting to globals
-            variables.setdefault("project_id", global_project_id)
-            variables.setdefault("cluster_name", global_cluster_name)
-            variables.setdefault("location", location)
+        # Deduce provider from stack name or CLOUD_PROVIDER env var
+        provider = cloud_provider or ("kind" if "kind" in stack else "gcp")
+
+        # Dynamically resolve variables based on the cloud provider
+        resolver = PROVIDER_RESOLVERS.get(provider)
+        if resolver:
+            variables = resolver(stack, variables, global_project_id, global_cluster_name, location)
 
         return TerraformDeployer(tf_dir=stack, variables=variables)
 
@@ -47,4 +50,3 @@ def get_deployer(
         location=location,
         cluster_name=global_cluster_name
     )
-

--- a/deployers/gcp/variables.py
+++ b/deployers/gcp/variables.py
@@ -1,0 +1,15 @@
+from typing import Any, Dict
+
+def resolve_variables(
+    stack: str,
+    custom_variables: Dict[str, Any],
+    global_project_id: str,
+    global_cluster_name: str,
+    global_location: str
+) -> Dict[str, Any]:
+    """Resolves default variables for GCP-based Terraform stacks."""
+    variables = custom_variables.copy()
+    variables.setdefault("project_id", global_project_id)
+    variables.setdefault("cluster_name", global_cluster_name)
+    variables.setdefault("location", global_location)
+    return variables

--- a/deployers/kind/variables.py
+++ b/deployers/kind/variables.py
@@ -1,0 +1,22 @@
+import os
+import pathlib
+from typing import Any, Dict
+
+def resolve_variables(
+    stack: str,
+    custom_variables: Dict[str, Any],
+    global_project_id: str,
+    global_cluster_name: str,
+    global_location: str
+) -> Dict[str, Any]:
+    """Resolves default variables for local KinD-based stacks."""
+    variables = custom_variables.copy()
+    cluster_name = global_cluster_name or "devops-bench-kind"
+    variables.setdefault("cluster_name", cluster_name)
+    variables.setdefault("location", "local")
+
+    kubeconfig_path = os.environ.get("KUBECONFIG") or str(
+        pathlib.Path("~/.kube/config").expanduser().resolve()
+    )
+    variables.setdefault("kubeconfig_path", kubeconfig_path)
+    return variables

--- a/pkg/evaluator/evaluate.py
+++ b/pkg/evaluator/evaluate.py
@@ -61,8 +61,8 @@ class GeminiDeepEvalModel(DeepEvalBaseLLM):
             model_name = os.environ.get("JUDGE_MODEL", "gemini-3.1-pro-preview")
 
         self.model_name = model_name
-        project_id = os.environ.get("GCP_PROJECT_ID")
-        location = os.environ.get("GCP_VERTEX_LOCATION", "us-central1")
+        project_id = os.environ.get("PROJECT_ID") or os.environ.get("GCP_PROJECT_ID")
+        location = os.environ.get("LOCATION") or os.environ.get("GCP_VERTEX_LOCATION", "us-central1")
         api_key = os.environ.get("JUDGE_API_KEY")
 
         validate_config(
@@ -103,8 +103,8 @@ class AnthropicDeepEvalModel(DeepEvalBaseLLM):
             model_name = os.environ.get("JUDGE_MODEL", "claude-opus-4-6")
 
         self.model_name = model_name
-        project_id = os.environ.get("GCP_PROJECT_ID")
-        location = os.environ.get("GCP_VERTEX_LOCATION", "us-central1")
+        project_id = os.environ.get("PROJECT_ID") or os.environ.get("GCP_PROJECT_ID")
+        location = os.environ.get("LOCATION") or os.environ.get("GCP_VERTEX_LOCATION", "us-central1")
         api_key = os.environ.get("JUDGE_API_KEY")
 
         validate_config(
@@ -151,7 +151,9 @@ def replace_placeholders(text, project_id, cluster_name):
     target_deployment = os.environ.get("TARGET_DEPLOYMENT_NAME", "hello-app")
     namespace = os.environ.get("NAMESPACE", "production")
     return (
-        text.replace("{{GCP_PROJECT_ID}}", project_id)
+        text.replace("{{PROJECT_ID}}", project_id)
+        .replace("{{GCP_PROJECT_ID}}", project_id)
+        .replace("{{CLUSTER_NAME}}", cluster_name)
         .replace("{{GKE_CLUSTER_NAME}}", cluster_name)
         .replace("{{APP_LOCATION}}", app_location)
         .replace("{{TARGET_DEPLOYMENT_NAME}}", target_deployment)
@@ -161,8 +163,8 @@ def replace_placeholders(text, project_id, cluster_name):
 
 def print_configuration_context(
     cloud_provider,
-    gcp_project_id,
-    gke_cluster_name,
+    project_id,
+    cluster_name,
     bench_agent_type,
     agent_target,
     bench_use_mcp,
@@ -177,8 +179,8 @@ def print_configuration_context(
     print("-" * 50)
     print("Configuration Context:")
     print(f"  - CLOUD_PROVIDER:       {cloud_provider}")
-    print(f"  - GCP_PROJECT_ID:       {gcp_project_id}")
-    print(f"  - GKE_CLUSTER_NAME:     {gke_cluster_name}")
+    print(f"  - PROJECT_ID:           {project_id}")
+    print(f"  - CLUSTER_NAME:         {cluster_name}")
     print(f"  - BENCH_AGENT_TYPE:     {bench_agent_type}")
     print(f"  - AGENT_TARGET:         {agent_target}")
     print(f"  - BENCH_USE_MCP:        {bench_use_mcp}")
@@ -262,11 +264,11 @@ def load_configuration_context():
         judge_model_name = judge_model_name or "gemini-3.1-pro-preview"
         judge_model = GeminiDeepEvalModel(model_name=judge_model_name)
 
-    gcp_project_id = os.environ.get("GCP_PROJECT_ID")
-    gke_cluster_name = os.environ.get("GKE_CLUSTER_NAME")
+    project_id = os.environ.get("PROJECT_ID") or os.environ.get("GCP_PROJECT_ID")
+    cluster_name = os.environ.get("CLUSTER_NAME") or os.environ.get("GKE_CLUSTER_NAME")
 
-    if not gcp_project_id or not gke_cluster_name:
-        print("Error: GCP_PROJECT_ID and GKE_CLUSTER_NAME must be set.")
+    if not project_id or not cluster_name:
+        print("Error: PROJECT_ID (or GCP_PROJECT_ID) and CLUSTER_NAME (or GKE_CLUSTER_NAME) must be set.")
         sys.exit(1)
 
     bench_use_mcp = os.environ.get("BENCH_USE_MCP", "true")
@@ -278,8 +280,8 @@ def load_configuration_context():
 
     print_configuration_context(
         cloud_provider,
-        gcp_project_id,
-        gke_cluster_name,
+        project_id,
+        cluster_name,
         bench_agent_type,
         agent_target,
         bench_use_mcp,
@@ -291,7 +293,7 @@ def load_configuration_context():
         judge_model_name,
     )
 
-    return bench_agent_type, agent_target, judge_model, gcp_project_id, gke_cluster_name
+    return bench_agent_type, agent_target, judge_model, project_id, cluster_name
 
 
 def execute_agent(bench_agent_type, agent_target, prompt, context):
@@ -703,7 +705,7 @@ def main():
         eval_data = eval_data[: int(limit)]
         print(f"Limiting evaluation to the first {limit} cases.")
 
-    bench_agent_type, agent_target, judge_model, gcp_project_id, gke_cluster_name = (
+    bench_agent_type, agent_target, judge_model, project_id, cluster_name = (
         load_configuration_context()
     )
 
@@ -718,7 +720,7 @@ def main():
 
     for item in eval_data:
         infra_config = item.get("infrastructure", {})
-        deployer = get_deployer(infra_config, gcp_project_id, gke_cluster_name)
+        deployer = get_deployer(infra_config, project_id, cluster_name)
 
         try:
             print(f"--- Provisioning Infrastructure for: {item['name']} ---")
@@ -726,9 +728,9 @@ def main():
             cluster_info = deployer.get_cluster_info()
 
             # Use dynamic cluster name from deployer for prompt replacement
-            active_cluster_name = cluster_info.get("name", gke_cluster_name)
+            active_cluster_name = cluster_info.get("name", cluster_name)
             prompt = replace_placeholders(
-                item["input"], gcp_project_id, active_cluster_name
+                item["input"], project_id, active_cluster_name
             )
 
             target_deployment = os.environ.get(
@@ -747,7 +749,7 @@ def main():
                         json.dumps(chaos_spec)
                         if isinstance(chaos_spec, (dict, list))
                         else str(chaos_spec),
-                        gcp_project_id,
+                        project_id,
                         active_cluster_name,
                     )
                     spec_list = json.loads(chaos_spec_processed)
@@ -758,7 +760,7 @@ def main():
                             json.dumps(verification_spec)
                             if isinstance(verification_spec, (dict, list))
                             else str(verification_spec),
-                            gcp_project_id,
+                            project_id,
                             active_cluster_name,
                         )
                         verification_spec_list = json.loads(verification_spec_processed)
@@ -780,7 +782,7 @@ def main():
                     :-3
                 ]
                 print(
-                    f"[{timestamp}] Waiting for Chaos Agent to establish the GKE load spike...",
+                    f"[{timestamp}] Waiting for Chaos Agent to establish the cluster load spike...",
                     flush=True,
                 )
                 scenario_manager.chaos_active_event.wait(timeout=45)
@@ -788,7 +790,7 @@ def main():
                     :-3
                 ]
                 print(
-                    f"[{timestamp}] GKE load spike is now active. Proceeding with Operator Agent...",
+                    f"[{timestamp}] Cluster load spike is now active. Proceeding with Operator Agent...",
                     flush=True,
                 )
 
@@ -814,7 +816,7 @@ def main():
 
             expected_output_raw = item.get("expected_output", "")
             expected_output = replace_placeholders(
-                expected_output_raw, gcp_project_id, active_cluster_name
+                expected_output_raw, project_id, active_cluster_name
             )
 
             chaos_report = {}
@@ -867,7 +869,7 @@ def main():
 
         expected_output_raw = item.get("expected_output", "")
         detailed_results[-1]["expected_output"] = replace_placeholders(
-            expected_output_raw, gcp_project_id, gke_cluster_name
+            expected_output_raw, project_id, cluster_name
         )
         detailed_results[-1]["name"] = item["name"]
         detailed_results[-1]["retrieval_context"] = item.get("retrieval_context", [])

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -116,3 +116,25 @@ def test_get_deployer_location_from_env(base_config):
     assert deployer.zone == "us-west1-b"
 
 
+@patch('deployers.terraform.tf_deployer.Path.exists', return_value=True)
+def test_get_deployer_terraform_kind_stack(mock_exists, base_config):
+    infra_config = {"deployer": "terraform", "stack": "prebuilt/kind"}
+    deployer = get_deployer(
+        infra_config,
+        base_config["project_id"],
+        base_config["cluster_name"],
+        base_config["location"]
+    )
+    assert isinstance(deployer, TerraformDeployer)
+
+    import pathlib
+    expected_kubeconfig = os.environ.get("KUBECONFIG") or str(pathlib.Path("~/.kube/config").expanduser().resolve())
+    expected_vars = {
+        "cluster_name": base_config["cluster_name"],
+        "location": "local",
+        "kubeconfig_path": expected_kubeconfig
+    }
+    assert deployer.variables == expected_vars
+
+    expected_stack_path = str(project_root / "terraform" / "prebuilt/kind")
+    assert deployer.tf_dir == expected_stack_path


### PR DESCRIPTION
Variable resovlers:
- deployers/gcp/variables.py to  handle all default variables for GCP-based Terraform deployer.
- deployers/kind/variables.py to  handle local kinD variables.

Deployer factory:
- Refactored to delegate variables defaults directory to registered modules, so that adding AWS and Azure simply create a  deployers/aws/variables.py dir and register it. No futher modification to factory,py

Cleaned up all GCP specific variables in evaluate.py  