### PR TITLE
feat: add Terraform modules for GPU stress testing and Parallelstore CSI, plus associated benchmark tasks

### DIFF
--- a/tasks/gcp/gpu-stress-test-diagnosis/task.yaml
+++ b/tasks/gcp/gpu-stress-test-diagnosis/task.yaml
@@ -1,3 +1,4 @@
+---
 task_id: 14
 name: "gpu-stress-test-diagnosis"
 infrastructure:
@@ -8,20 +9,27 @@ infrastructure:
     node_count: 1
     machine_type: "g2-standard-4"
 prompt: |
-  An automated alert for high Time to First Token (TTFT) latency has triggered for the 'hypercomputer-agent' service.
-  Review the Cloud Monitoring metrics and Cloud Logging history for the GKE cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}.
+  An automated alert for high Time to First Token (TTFT) latency has triggered
+  for the 'hypercomputer-agent' service in GKE cluster {{GKE_CLUSTER_NAME}} in
+  project {{GCP_PROJECT_ID}}.
 
-  Write an incident post-mortem report named `analysis_report.md` in your workspace detailing:
-  1. The primary storage bottleneck identified in GCS FUSE.
-  2. The autoscaler saturation limits identified.
+  Write an incident post-mortem report named `analysis_report.md` in your
+  workspace detailing:
+  1. The primary storage bottleneck identified and its root cause.
+  2. Any cluster or workload autoscaling limitations identified during the
+     event.
   3. Recommended architectural remediation steps.
 expected_output: |
   critical requirements:
   - Expected file analysis_report.md created in workspace.
-  - Inspect Cloud Logging history for GKE cluster '{{GKE_CLUSTER_NAME}}' in project '{{GCP_PROJECT_ID}}'.
-  - Identify GCS FUSE buffer exhaustion as the primary storage bottleneck in the report.
-  - Identify HorizontalPodAutoscaler (HPA) max-replica saturation (limit 10) in the report.
-  - Detail architectural recommendations (e.g., using Parallelstore/Lustre or optimizing FUSE cache settings and HPA limits).
+  - Inspect Cloud Logging history for GKE cluster '{{GKE_CLUSTER_NAME}}'
+    in project '{{GCP_PROJECT_ID}}'.
+  - Identify GCS FUSE buffer exhaustion as the primary storage bottleneck
+    in the report.
+  - Identify HorizontalPodAutoscaler (HPA) max-replica saturation (limit 10)
+    in the report.
+  - Detail architectural recommendations (e.g., using Parallelstore/Lustre
+    or optimizing FUSE cache settings and HPA limits).
 
   Expected Manifest Generated: N/A, not a manifest generation request.
 

--- a/tasks/gcp/gpu-stress-test-diagnosis/task.yaml
+++ b/tasks/gcp/gpu-stress-test-diagnosis/task.yaml
@@ -6,7 +6,7 @@ infrastructure:
   teardown: true
   variables:
     node_count: 1
-    machine_type: "n1-standard-4"
+    machine_type: "g2-standard-4"
 prompt: |
   An automated alert for high Time to First Token (TTFT) latency has triggered for the 'hypercomputer-agent' service.
   Review the Cloud Monitoring metrics and Cloud Logging history for the GKE cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}.
@@ -25,3 +25,14 @@ expected_output: |
 
   Expected Manifest Generated: N/A, not a manifest generation request.
 
+documentation:
+  - doc_name: "GCS Fuse CSI Driver Guide"
+    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-sidecar"
+    constraints:
+      - text: "GCS FUSE buffer exhaustion"
+        critical: true
+  - doc_name: "HPA Configuration Guide"
+    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/horizontal-pod-autoscaling"
+    constraints:
+      - text: "HPA max-replica saturation"
+        critical: true

--- a/tasks/gcp/gpu-stress-test-diagnosis/task.yaml
+++ b/tasks/gcp/gpu-stress-test-diagnosis/task.yaml
@@ -27,12 +27,12 @@ expected_output: |
 
 documentation:
   - doc_name: "GCS Fuse CSI Driver Guide"
-    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-sidecar"
+    url: "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-sidecar"
     constraints:
       - text: "GCS FUSE buffer exhaustion"
         critical: true
   - doc_name: "HPA Configuration Guide"
-    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/horizontal-pod-autoscaling"
+    url: "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/horizontal-pod-autoscaling"
     constraints:
       - text: "HPA max-replica saturation"
         critical: true

--- a/tasks/gcp/gpu-stress-test-diagnosis/task.yaml
+++ b/tasks/gcp/gpu-stress-test-diagnosis/task.yaml
@@ -1,0 +1,27 @@
+task_id: 14
+name: "gpu-stress-test-diagnosis"
+infrastructure:
+  deployer: "tofu"
+  stack: "prebuilt/gpu-stress-test"
+  teardown: true
+  variables:
+    node_count: 1
+    machine_type: "n1-standard-4"
+prompt: |
+  An automated alert for high Time to First Token (TTFT) latency has triggered for the 'hypercomputer-agent' service.
+  Review the Cloud Monitoring metrics and Cloud Logging history for the GKE cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}.
+
+  Write an incident post-mortem report named `analysis_report.md` in your workspace detailing:
+  1. The primary storage bottleneck identified in GCS FUSE.
+  2. The autoscaler saturation limits identified.
+  3. Recommended architectural remediation steps.
+expected_output: |
+  critical requirements:
+  - Expected file analysis_report.md created in workspace.
+  - Inspect Cloud Logging history for GKE cluster '{{GKE_CLUSTER_NAME}}' in project '{{GCP_PROJECT_ID}}'.
+  - Identify GCS FUSE buffer exhaustion as the primary storage bottleneck in the report.
+  - Identify HorizontalPodAutoscaler (HPA) max-replica saturation (limit 10) in the report.
+  - Detail architectural recommendations (e.g., using Parallelstore/Lustre or optimizing FUSE cache settings and HPA limits).
+
+  Expected Manifest Generated: N/A, not a manifest generation request.
+

--- a/tasks/gcp/parallelstore-csi-deployment/task.yaml
+++ b/tasks/gcp/parallelstore-csi-deployment/task.yaml
@@ -1,0 +1,109 @@
+task_id: 13
+name: "parallelstore-csi-deployment"
+infrastructure:
+  deployer: "tofu"
+  stack: "prebuilt/parallelstore-csi"
+  teardown: true
+  variables:
+    node_count: 1
+    machine_type: "n1-standard-4"
+prompt: |
+  Deploy a live vLLM inference server for Gemma 3 onto the GKE cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}.
+  A Parallelstore Lustre instance named 'lustre-{{GKE_CLUSTER_NAME}}' has been pre-provisioned in zone 'us-central1-a'.
+
+  Objectives:
+  1. Create a PersistentVolume named `gemma-pv` referencing the pre-provisioned Parallelstore Lustre instance `lustre-{{GKE_CLUSTER_NAME}}` in zone `us-central1-a` (access points must be queried from the instance).
+  2. Create a PVC named `gemma-pvc` referencing `gemma-pv`.
+  3. Deploy `gemma-inference-staging` using `nginx:alpine` (simulating serving) that:
+     - Requests 1 GPU accelerator (`nvidia.com/gpu: 1`).
+     - Includes the annotation `gke-parallelstore/volumes: "true"` to enable sidecar injection.
+     - Mounts the Parallelstore Lustre volume at `/models`.
+  4. Create a ClusterIP Service named `gemma-service` exposing port 8000.
+expected_output: |
+  critical requirements:
+  - Expected Tool Call: generate_manifest
+  - Create a PersistentVolume with driver parallelstore.csi.storage.gke.io referencing the existing instance.
+  - Set the PV volumeHandle to {{GCP_PROJECT_ID}}/us-central1-a/lustre-{{GKE_CLUSTER_NAME}}/default-pool/default-container.
+  - Query Parallelstore instance access points and specify them in the PV volumeAttributes.
+  - Create a PersistentVolumeClaim named gemma-pvc referencing parallelstore-sc.
+  - Deploy gemma-inference-staging using nginx:alpine.
+  - Include the pod template annotation gke-parallelstore/volumes: "true".
+  - Configure the deployment to request 1 GPU (nvidia.com/gpu: 1) and mount gemma-pvc at /models.
+  - Create a ClusterIP Service named gemma-service exposing port 8000.
+
+  Expected Manifest Generated:
+  apiVersion: v1
+  kind: PersistentVolume
+  metadata:
+    name: gemma-pv
+  spec:
+    storageClassName: parallelstore-sc
+    capacity:
+      storage: 12000Gi
+    accessModes:
+    - ReadWriteMany
+    persistentVolumeReclaimPolicy: Retain
+    volumeMode: Filesystem
+    csi:
+      driver: parallelstore.csi.storage.gke.io
+      volumeHandle: {{GCP_PROJECT_ID}}/us-central1-a/lustre-{{GKE_CLUSTER_NAME}}/default-pool/default-container
+      volumeAttributes:
+        accessPoints: <instance-access-points-ips>
+        network: ps-net-{{GKE_CLUSTER_NAME}}
+  ---
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: gemma-pvc
+    namespace: default
+  spec:
+    accessModes:
+    - ReadWriteMany
+    storageClassName: parallelstore-sc
+    resources:
+      requests:
+        storage: 12000Gi
+  ---
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: gemma-inference-staging
+    namespace: default
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: gemma
+    template:
+      metadata:
+        annotations:
+          gke-parallelstore/volumes: "true"
+        labels:
+          app: gemma
+      spec:
+        containers:
+        - name: gemma-container
+          image: nginx:alpine
+          volumeMounts:
+          - name: model-volume
+            mountPath: /models
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+        volumes:
+        - name: model-volume
+          persistentVolumeClaim:
+            claimName: gemma-pvc
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: gemma-service
+    namespace: default
+  spec:
+    type: ClusterIP
+    ports:
+    - port: 8000
+      targetPort: 80
+    selector:
+      app: gemma

--- a/tasks/gcp/parallelstore-csi-deployment/task.yaml
+++ b/tasks/gcp/parallelstore-csi-deployment/task.yaml
@@ -110,7 +110,7 @@ expected_output: |
 
 documentation:
   - doc_name: "GKE Parallelstore CSI Driver Guide"
-    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/parallelstore-csi-existing-instance"
+    url: "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/parallelstore-csi-existing-instance"
     constraints:
       - text: "driver: parallelstore.csi.storage.gke.io"
         critical: true
@@ -119,7 +119,7 @@ documentation:
       - text: "volumeHandle format: PROJECT_ID/LOCATION/INSTANCE_NAME/default-pool/default-container"
         critical: true
   - doc_name: "GKE GPU Setup Docs"
-    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/gpus"
+    url: "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/gpus"
     constraints:
       - text: "nvidia.com/gpu resource limit of 1"
         critical: true

--- a/tasks/gcp/parallelstore-csi-deployment/task.yaml
+++ b/tasks/gcp/parallelstore-csi-deployment/task.yaml
@@ -1,3 +1,4 @@
+---
 task_id: 13
 name: "parallelstore-csi-deployment"
 infrastructure:
@@ -8,15 +9,22 @@ infrastructure:
     node_count: 1
     machine_type: "g2-standard-4"
 prompt: |
-  Deploy a live vLLM inference server for Gemma 4 12B SFP8 onto the GKE cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}.
-  A Parallelstore Lustre instance named 'lustre-{{GKE_CLUSTER_NAME}}' has been pre-provisioned in zone 'us-central1-a'.
+  Deploy a live vLLM inference server for Gemma 4 12B SFP8 onto the GKE cluster
+  {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}.
+  A Parallelstore Lustre instance named 'lustre-{{GKE_CLUSTER_NAME}}' has been
+  pre-provisioned in zone 'us-central1-a'.
 
   Objectives:
-  1. Create a PersistentVolume named `gemma-pv` referencing the pre-provisioned Parallelstore Lustre instance `lustre-{{GKE_CLUSTER_NAME}}` in zone `us-central1-a` (access points must be queried from the instance).
+  1. Create a PersistentVolume named `gemma-pv` referencing the
+     pre-provisioned Parallelstore Lustre instance
+     `lustre-{{GKE_CLUSTER_NAME}}` in zone `us-central1-a` (access points
+     must be queried from the instance).
   2. Create a PVC named `gemma-pvc` referencing `gemma-pv`.
-  3. Deploy `gemma-inference-staging` using `nginx:alpine` (simulating serving) that:
+  3. Deploy `gemma-inference-staging` using `nginx:alpine` (simulating serving)
+     that:
      - Requests 1 GPU accelerator (`nvidia.com/gpu: 1`).
-     - Includes the annotation `gke-parallelstore/volumes: "true"` to enable sidecar injection.
+     - Includes the annotation `gke-parallelstore/volumes: "true"` to enable
+       sidecar injection.
      - Mounts the Parallelstore Lustre volume at `/models`.
   4. Create a ClusterIP Service named `gemma-service` exposing port 8000.
 expected_output: |

--- a/tasks/gcp/parallelstore-csi-deployment/task.yaml
+++ b/tasks/gcp/parallelstore-csi-deployment/task.yaml
@@ -6,9 +6,9 @@ infrastructure:
   teardown: true
   variables:
     node_count: 1
-    machine_type: "n1-standard-4"
+    machine_type: "g2-standard-4"
 prompt: |
-  Deploy a live vLLM inference server for Gemma 3 onto the GKE cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}.
+  Deploy a live vLLM inference server for Gemma 4 12B SFP8 onto the GKE cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}.
   A Parallelstore Lustre instance named 'lustre-{{GKE_CLUSTER_NAME}}' has been pre-provisioned in zone 'us-central1-a'.
 
   Objectives:
@@ -107,3 +107,19 @@ expected_output: |
       targetPort: 80
     selector:
       app: gemma
+
+documentation:
+  - doc_name: "GKE Parallelstore CSI Driver Guide"
+    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/parallelstore-csi-existing-instance"
+    constraints:
+      - text: "driver: parallelstore.csi.storage.gke.io"
+        critical: true
+      - text: "gke-parallelstore/volumes: 'true' annotation in Pod metadata"
+        critical: true
+      - text: "volumeHandle format: PROJECT_ID/LOCATION/INSTANCE_NAME/default-pool/default-container"
+        critical: true
+  - doc_name: "GKE GPU Setup Docs"
+    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/gpus"
+    constraints:
+      - text: "nvidia.com/gpu resource limit of 1"
+        critical: true

--- a/tf/prebuilt/gpu-stress-test/main.tf
+++ b/tf/prebuilt/gpu-stress-test/main.tf
@@ -78,8 +78,12 @@ resource "google_container_node_pool" "primary_nodes" {
     ]
 
     guest_accelerator {
-      type  = "nvidia-tesla-t4"
+      type  = "nvidia-l4"
       count = 1
+
+      gpu_driver_installation_config {
+        gpu_driver_version = "DEFAULT"
+      }
     }
   }
 }

--- a/tf/prebuilt/gpu-stress-test/main.tf
+++ b/tf/prebuilt/gpu-stress-test/main.tf
@@ -1,0 +1,107 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.location
+}
+
+resource "google_service_account" "gke_nodes" {
+  account_id   = "gke-nodes-st-${trim(substr(var.cluster_name, 0, 10), "-")}"
+  display_name = "GKE Node Service Account for Stress Test ${var.cluster_name}"
+}
+
+resource "google_project_iam_member" "gke_nodes_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_monitoring_viewer" {
+  project = var.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_metadata_writer" {
+  project = var.project_id
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_artifact_registry_reader" {
+  project = var.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_container_cluster" "primary" {
+  name                     = var.cluster_name
+  location                 = var.location
+  remove_default_node_pool = true
+  initial_node_count       = 1
+  deletion_protection      = false
+
+  ip_allocation_policy {}
+}
+
+resource "google_container_node_pool" "primary_nodes" {
+  name       = "gpu-node-pool"
+  location   = var.location
+  cluster    = google_container_cluster.primary.name
+  node_count = var.node_count
+
+  node_config {
+    preemptible     = false
+    machine_type    = var.machine_type
+    service_account = google_service_account.gke_nodes.email
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    guest_accelerator {
+      type  = "nvidia-tesla-t4"
+      count = 1
+    }
+  }
+}
+
+resource "null_resource" "write_synthetic_logs" {
+  provisioner "local-exec" {
+    command = <<EOT
+      gcloud logging write "container" "{\"message\": \"hypercomputer-agent: GCS FUSE buffer exhaustion during checkpoint load\", \"container_name\": \"hypercomputer-agent\"}" --severity=ERROR --project=${var.project_id} --payload-type=json --monitored-resource-type=k8s_container --monitored-resource-labels=project_id=${var.project_id},location=${var.location},cluster_name=${var.cluster_name},namespace_name=default,pod_name=hypercomputer-agent-deployment-xyz,container_name=hypercomputer-agent
+      gcloud logging write "container" "{\"message\": \"HorizontalPodAutoscaler: HPA max-replica saturation for deployment/hypercomputer-agent (max: 10)\", \"container_name\": \"hpa-controller\"}" --severity=WARNING --project=${var.project_id} --payload-type=json --monitored-resource-type=k8s_container --monitored-resource-labels=project_id=${var.project_id},location=${var.location},cluster_name=${var.cluster_name},namespace_name=default,pod_name=hpa-controller-xyz,container_name=hpa-controller
+    EOT
+  }
+
+  depends_on = [
+    google_container_cluster.primary,
+    google_container_node_pool.primary_nodes
+  ]
+}
+
+output "cluster_name" {
+  value = google_container_cluster.primary.name
+}
+
+output "cluster_location" {
+  value = google_container_cluster.primary.location
+}

--- a/tf/prebuilt/gpu-stress-test/variables.tf
+++ b/tf/prebuilt/gpu-stress-test/variables.tf
@@ -22,5 +22,5 @@ variable "node_count" {
 
 variable "machine_type" {
   type    = string
-  default = "n1-standard-4"
+  default = "g2-standard-4"
 }

--- a/tf/prebuilt/gpu-stress-test/variables.tf
+++ b/tf/prebuilt/gpu-stress-test/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "The name of the GKE cluster"
+  type        = string
+}
+
+variable "location" {
+  description = "GCP location (region or zone)"
+  type        = string
+  default     = "us-central1-a"
+}
+
+
+variable "node_count" {
+  type    = number
+  default = 1
+}
+
+variable "machine_type" {
+  type    = string
+  default = "n1-standard-4"
+}

--- a/tf/prebuilt/parallelstore-csi/main.tf
+++ b/tf/prebuilt/parallelstore-csi/main.tf
@@ -1,0 +1,148 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 5.0.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.location
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.location
+}
+
+resource "google_service_account" "gke_nodes" {
+  account_id   = "gke-nodes-ps-${trim(substr(var.cluster_name, 0, 10), "-")}"
+  display_name = "GKE Node Service Account for Parallelstore CSI ${var.cluster_name}"
+}
+
+resource "google_project_iam_member" "gke_nodes_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_monitoring_viewer" {
+  project = var.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_metadata_writer" {
+  project = var.project_id
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_artifact_registry_reader" {
+  project = var.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_compute_network" "custom" {
+  provider                = google-beta
+  name                    = "ps-net-${var.cluster_name}"
+  auto_create_subnetworks = true
+}
+
+resource "google_compute_global_address" "private_ip_alloc" {
+  provider      = google-beta
+  name          = "ps-ip-${var.cluster_name}"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.custom.id
+}
+
+resource "google_service_networking_connection" "default" {
+  provider                = google-beta
+  network                 = google_compute_network.custom.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
+}
+
+resource "google_container_cluster" "primary" {
+  provider                 = google-beta
+  name                     = var.cluster_name
+  location                 = var.location
+  network                  = google_compute_network.custom.id
+  remove_default_node_pool = true
+  initial_node_count       = 1
+  deletion_protection      = false
+
+  ip_allocation_policy {}
+
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  addons_config {
+    parallelstore_csi_driver_config {
+      enabled = true
+    }
+  }
+
+  depends_on = [
+    google_service_networking_connection.default
+  ]
+}
+
+resource "google_container_node_pool" "primary_nodes" {
+  name       = "gpu-node-pool"
+  location   = var.location
+  cluster    = google_container_cluster.primary.name
+  node_count = var.node_count
+
+  node_config {
+    preemptible     = false
+    machine_type    = var.machine_type
+    service_account = google_service_account.gke_nodes.email
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    guest_accelerator {
+      type  = "nvidia-tesla-t4"
+      count = 1
+    }
+  }
+}
+
+resource "google_parallelstore_instance" "instance" {
+  provider     = google-beta
+  instance_id  = "lustre-${var.cluster_name}"
+  location     = var.zone
+  network      = google_compute_network.custom.id
+  capacity_gib = 12000
+
+  depends_on = [
+    google_service_networking_connection.default
+  ]
+}
+
+output "cluster_name" {
+  value = google_container_cluster.primary.name
+}
+
+output "cluster_location" {
+  value = google_container_cluster.primary.location
+}

--- a/tf/prebuilt/parallelstore-csi/main.tf
+++ b/tf/prebuilt/parallelstore-csi/main.tf
@@ -121,8 +121,12 @@ resource "google_container_node_pool" "primary_nodes" {
     ]
 
     guest_accelerator {
-      type  = "nvidia-tesla-t4"
+      type  = "nvidia-l4"
       count = 1
+
+      gpu_driver_installation_config {
+        gpu_driver_version = "DEFAULT"
+      }
     }
   }
 }

--- a/tf/prebuilt/parallelstore-csi/variables.tf
+++ b/tf/prebuilt/parallelstore-csi/variables.tf
@@ -1,0 +1,31 @@
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "The name of the GKE cluster"
+  type        = string
+}
+
+variable "location" {
+  description = "GCP location (region or zone)"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "zone" {
+  description = "GCP zone for the cluster nodes and Parallelstore instance"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "node_count" {
+  type    = number
+  default = 1
+}
+
+variable "machine_type" {
+  type    = string
+  default = "n1-standard-4"
+}

--- a/tf/prebuilt/parallelstore-csi/variables.tf
+++ b/tf/prebuilt/parallelstore-csi/variables.tf
@@ -27,5 +27,5 @@ variable "node_count" {
 
 variable "machine_type" {
   type    = string
-  default = "n1-standard-4"
+  default = "g2-standard-4"
 }


### PR DESCRIPTION
Adds two new `devops-bench` tasks and their respective prebuilt Terraform environments:
- **GPU Stress Test Diagnosis**: Configures a GPU-enabled GKE cluster with synthetic diagnostic logs and a least-privilege node service account.
- **Parallelstore CSI Deployment**: Sets up a GKE cluster with Parallelstore CSI addon, Workload Identity Federation, VPC peering, and a Parallelstore instance.