### PR TITLE
docs: add AGENTS.md and update .gitignore for Python environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,9 @@ results/
 *-rendered.yaml
 tofu
 
+# Python virtual environments
+.venv/
+venv/
+
 # For the devs using macOS
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,112 @@
+# AGENTS.md
+
+`devops-bench` is a standardized benchmarking suite to evaluate how well different agents or models perform specific DevOps tasks.
+
+## Repository structure
+
+```
+tasks/          # Benchmark task definitions (one task.yaml per subdirectory)
+  gcp/          # GCP/GKE-specific tasks
+  generic/      # Cloud-agnostic tasks
+pkg/
+  evaluator/    # Main evaluation engine (evaluate.py is the entrypoint)
+  agents/       # Agent runner adapters (API and CLI modes)
+  manager/      # Chaos/scenario management
+deployers/      # Infrastructure provisioners (kind, GCP, OpenTofu)
+tf/             # OpenTofu stacks for cluster provisioning
+  prebuilt/kind     # Local kind cluster (no GCP required)
+  prebuilt/minimum  # Minimal GKE cluster
+skills/         # LLM-as-a-judge rubric definitions
+scripts/        # Auth and setup scripts
+```
+
+## Running the benchmark
+
+### 1. Set up the Python environment
+
+```bash
+# System Python is externally managed — bootstrap pip manually
+python3 -m venv .venv
+curl -fsSL https://bootstrap.pypa.io/get-pip.py | .venv/bin/python3
+.venv/bin/python3 -m pip install -r requirements.txt
+
+# Verify
+.venv/bin/python3 -m pytest -q          # expected: all tests pass
+```
+
+### 2. Install OpenTofu (required for cluster provisioning)
+
+```bash
+wget -q https://github.com/opentofu/opentofu/releases/download/v1.8.8/tofu_1.8.8_linux_amd64.zip \
+  -O /tmp/tofu.zip \
+  && unzip -q /tmp/tofu.zip tofu -d ~/bin \
+  && rm /tmp/tofu.zip
+export PATH="$HOME/bin:$PATH"
+```
+
+### 3. Run a task
+
+```bash
+PATH="$HOME/bin:$PATH" \
+  CLOUD_PROVIDER=kind \
+  GCP_PROJECT_ID=local \
+  GKE_CLUSTER_NAME=my-cluster \
+  BENCH_AGENT_TYPE=api \
+  BENCH_USE_MCP=false \
+  AGENT_PROVIDER=google \
+  AGENT_MODEL=gemini-2.5-pro \
+  AGENT_API_KEY=<your-key> \
+  JUDGE_PROVIDER=google \
+  JUDGE_MODEL=gemini-2.5-pro \
+  JUDGE_API_KEY=<your-key> \
+  .venv/bin/python3 pkg/evaluator/evaluate.py tasks/generic/nginx-deploy
+```
+
+Results are written to `results/run_<timestamp>/results.json`.
+
+## Key environment variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `CLOUD_PROVIDER` | `kind` (local Docker) or `gcp` | required |
+| `GCP_PROJECT_ID` | GCP project ID; use `local` for kind runs | required |
+| `GKE_CLUSTER_NAME` | Target cluster name | required |
+| `BENCH_AGENT_TYPE` | `api` (SDK) or `cli` (binary) | `cli` |
+| `BENCH_USE_MCP` | Enable GKE MCP server tools | `true` |
+| `AGENT_PROVIDER` | `google` or `anthropic` | `google` |
+| `AGENT_MODEL` | Model name for the agent | `gemini-3.1-pro-preview` |
+| `AGENT_API_KEY` | Direct API key for the agent (bypasses Vertex AI) | — |
+| `JUDGE_PROVIDER` | `google` or `anthropic` | `google` |
+| `JUDGE_MODEL` | Model name for the LLM judge | `gemini-3.1-pro-preview` |
+| `JUDGE_API_KEY` | Direct API key for the judge (bypasses Vertex AI) | — |
+| `BENCH_NO_TEARDOWN` | Keep cluster alive after the run | `false` |
+
+## Task format
+
+Each task lives in its own directory as a `task.yaml`:
+
+```yaml
+task_id: 20
+name: "my-task"
+infrastructure:          # optional — omit to use an existing cluster
+  deployer: "tofu"
+  stack: "prebuilt/kind" # or "prebuilt/minimum" for GKE
+  teardown: true
+prompt: "Deploy nginx to {{GKE_CLUSTER_NAME}} with 2 replicas..."
+expected_output: |
+  critical requirements:
+  - Deploy nginx image
+  - 2 replicas
+  - ...
+```
+
+## MCP vs no-MCP mode
+
+- **`BENCH_USE_MCP=true`** — agent gets real Kubernetes tools via the GKE MCP server at `third_party/gke-mcp/gke-mcp`. Build it first with `scripts/setup_gke_mcp.sh`.
+- **`BENCH_USE_MCP=false`** — agent runs without tools; useful for smoke-testing the pipeline but scores 0 (no way to act on the cluster).
+
+## Known gotchas
+
+- **`tofu` not on PATH**: OpenTofu must be on `PATH` when the evaluator runs — the subprocess does not inherit a manually-extended shell `PATH`. Prefix evaluation commands with `PATH="$HOME/bin:$PATH"` or add it to your shell profile.
+- **Vertex AI vs direct API**: If `GCP_PROJECT_ID` is set and `AGENT_API_KEY`/`JUDGE_API_KEY` are not, the Gemini client falls back to Vertex AI. For local `kind` runs with `GCP_PROJECT_ID=local`, always set both `*_API_KEY` variables or you'll get a 403.
+- **`BENCH_USE_MCP=true` with no binary**: If the MCP server binary is missing, the run fails immediately at agent startup with a `FileNotFoundError`. Set `BENCH_USE_MCP=false` to verify the rest of the pipeline first.


### PR DESCRIPTION
Closes #68

## Summary

- Adds **AGENTS.md** with context for agents and contributors to navigate and run the benchmark:
  - Repository structure overview
  - Step-by-step setup (Python env, OpenTofu install, evaluator invocation)
  - Key environment variables reference table
  - Task YAML format with a minimal example
  - MCP vs no-MCP mode explanation
  - Known gotchas (tofu PATH, Vertex AI fallback, missing MCP binary)
- Updates **.gitignore** to exclude Python virtual environment directories (`.venv/`, `venv/`)

## Test plan

- [ ] Verify an agent starting cold can follow the AGENTS.md instructions to set up and run a task against a local kind cluster
- [ ] Confirm `.venv/` is no longer tracked by git after creation