### PR TITLE
Support a local option to test for inner dev loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+Guidance for coding agents (and humans) working in this repository. This file is
+tool-agnostic; it follows the cross-tool [AGENTS.md](https://agents.md) convention.
+
+## Generating benchmark tasks
+
+The repeatable procedure for turning a row of the expert task catalog into a
+runnable `task.yaml` lives in **[`docs/task-generation/`](docs/task-generation/)**,
+which is the source of truth:
+
+- [`methodology.md`](docs/task-generation/methodology.md) — the spec: schema,
+  directory/naming conventions, `task_id` allocation, `expected_output` rules,
+  task classes, and the kind/MCP live-cluster gap. **Read this first.**
+- [`catalog.md`](docs/task-generation/catalog.md) — the expert task catalog
+  (source of truth) and generation-status tracker.
+- [`running.md`](docs/task-generation/running.md) — running tasks locally vs. full,
+  and building a model leaderboard.
+
+### Procedure (summary — methodology is authoritative)
+
+1. Pick a catalog row in `docs/task-generation/catalog.md`; note its name, prompt,
+   success metric, category, difficulty.
+2. Classify it (`manifest-generation` | `investigation` | `live-action` |
+   `plan-only`) — this decides runnability and whether an `infrastructure` block
+   is needed (methodology §9).
+3. Choose the provider dir: `tasks/generic/` (cloud-agnostic) or `tasks/gcp/`
+   (GCP/GKE-specific). Slug = kebab-case of the task name.
+4. Allocate `task_id = 1000 + <row#>` (stable, idempotent, collision-free).
+5. Write `tasks/<provider>/<slug>/task.yaml`: `task_id`, `name`, `prompt`
+   (placeholders per §11), and an `expected_output` whose `critical requirements:`
+   bullets are atomic and derived from the catalog's Success Metric, leading with
+   an `Expected Tool Call:` line. Manifest tasks include a golden
+   `Expected Manifest Generated:` block. Add metadata: `category`, `difficulty`,
+   `task_class`, `source: catalog#<row#>`.
+6. Add any fixtures (e.g. a broken manifest for an investigation task) in the
+   same directory.
+7. Validate the task loads:
+   ```bash
+   python3 -c "from pkg.evaluator.loader import load_from_tasks_dir; \
+     print([(t['task_id'], t['name']) for t in load_from_tasks_dir('tasks')])"
+   ```
+8. Optionally smoke-test manifest/plan tasks (see `running.md`). Investigation and
+   live-action tasks can't be fairly run without a cluster MCP toolserver.
+9. Update the generation-status table in `catalog.md`.
+
+### Conventions
+
+- One requirement per `expected_output` bullet; split compound requirements.
+- Phrase requirements from the catalog's Success Metric — it is ground truth.
+- Keep `task_id`s globally unique; never reuse the 1–12 range used by the
+  hand-authored tasks in `tasks/` and `complextasks/`.
+- Don't confuse `skills/` (LLM-as-judge **rubrics**, read by
+  `pkg/evaluator/evaluate.py`) with task authoring — they are unrelated.
+- Don't invent OpenTofu stacks; reuse `tf/prebuilt/{kind,minimum,secret-rotation}`
+  or flag that a new fixture stack is needed.

--- a/deployers/factory.py
+++ b/deployers/factory.py
@@ -12,6 +12,29 @@ PROVIDER_RESOLVERS = {
     "kind": resolve_kind_vars,
 }
 
+
+class NoOpDeployer(Deployer):
+    """Pass-through deployer for local testing without infrastructure provisioning."""
+
+    def __init__(self, cluster_name: str, project_id: str):
+        self._cluster_name = cluster_name
+        self._project_id = project_id
+
+    def up(self) -> None:
+        print("[NoOpDeployer] Skipping infrastructure provisioning (BENCH_NO_INFRA=true)")
+
+    def down(self) -> None:
+        print("[NoOpDeployer] Skipping infrastructure teardown (BENCH_NO_INFRA=true)")
+
+    def get_cluster_info(self) -> Dict[str, Any]:
+        return {
+            "name": self._cluster_name,
+            "location": "local",
+            "project": self._project_id,
+            "kubeconfig_path": os.environ.get("KUBECONFIG", ""),
+        }
+
+
 def get_deployer(
     infra_config: Dict[str, Any],
     global_project_id: str,
@@ -31,6 +54,9 @@ def get_deployer(
             deployer_type = cloud_provider
         else:
             deployer_type = "tofu"
+
+    if os.environ.get("BENCH_NO_INFRA", "false").lower() == "true":
+        return NoOpDeployer(cluster_name=global_cluster_name, project_id=global_project_id)
 
     # Resolve Location with strict precedence: argument then GCP_LOCATION env var
     location = global_location or os.environ.get("GCP_LOCATION", "us-central1-a")

--- a/docs/task-generation/catalog.md
+++ b/docs/task-generation/catalog.md
@@ -1,0 +1,142 @@
+# DevOps Bench — Expert Task Catalog
+
+This is the **source of truth** for the task suite. Each row maps to one
+`task.yaml` via the [generation methodology](./methodology.md). Rows are numbered
+top-to-bottom; `task_id = 1000 + row#` (stable & idempotent).
+
+- **Generation status** is tracked in [§ Generation status](#generation-status).
+- To generate a task from a row, follow the
+  [methodology](./methodology.md) (summarized for agents in [`AGENTS.md`](../../AGENTS.md)).
+
+---
+
+## Catalog
+
+| # | Task Name | Description | Sample Prompt | Success Metric | Category | Difficulty |
+| :-- | :-- | :-- | :-- | :-- | :-- | :-- |
+| 1 | Debug CrashLoop | Investigate a failing container. | "Why is my 'frontend' pod in CrashLoopBackOff? Show me logs." | Root cause (e.g., env var missing) identified. | Dev | Easy |
+| 2 | Log Aggregation | Query logs from multiple pods. | "Search for 'error' in all pods labeled 'app=gateway' in the last hour." | Filtered log output provided. | Dev | Hard |
+| 3 | Trace Latency | Find where a request is slowing down. | "Use Cloud Trace to find why this GKE service is taking 5 seconds." | Trace waterfall shows the slow span. | Dev | Complex |
+| 4 | VPA in Recommender Mode | Get resource advice for a pod. | "Set up Vertical Pod Autoscaler to just give recommendations." | kubectl get vpa shows 'Target' values. | Dev | Hard |
+| 5 | Standard PVC | Request 5Gi of SSD storage. | "Create a 5Gi PVC using the 'premium-rwo' storage class." | PVC status is Bound. | Dev | Easy |
+| 6 | Volume Expansion | Resize an existing 10Gi volume to 20Gi. | "Update my PVC to 20Gi without deleting the pod." | kubectl get pvc reflects new size. | Dev | Hard |
+| 7 | Basic Secret | Create a secret from a literal value. | "Create a secret named 'db-pass' with value 'password123'." | kubectl get secret exists. | Dev | Easy |
+| 8 | Secrets via CSI Store | Sync GCP Secret Manager to GKE pods. | "Mount a GCP Secret Manager secret into my pod as a volume." | File exists inside container at mount path. | Dev | Hard |
+| 9 | ClusterIP Service | Expose a deployment internally. | "Create a Service for my app on port 80." | kubectl get svc shows internal IP. | Dev | Easy |
+| 10 | NodePort Service | Expose an app on a specific node port. | "Expose my 'web' deployment on port 30001." | App accessible via <NodeIP>:30001. | Dev | Easy |
+| 11 | Basic Ingress | Create a rule to route /api to a backend. | "Write an Ingress YAML for path /api to service 'api-svc'." | kubectl get ingress shows host/path. | Dev | Easy |
+| 12 | Create Basic Deployment | Create a deployment with 3 replicas of Nginx. | "Generate a YAML for an nginx deployment with 3 replicas on port 80." | kubectl get deploy shows 3/3 ready. | Dev | Easy |
+| 13 | Set Resource Limits | Add CPU/Mem requests and limits to an existing pod spec. | "Update this YAML to limit CPU to 500m and memory to 512Mi." | Pod describes correct resources section. | Dev | Easy |
+| 14 | Configure Readiness Probe | Add a health check to a deployment. | "Add a readiness probe to my app on path /health at port 8080." | kubectl describe shows probe configured. | Dev | Easy |
+| 15 | CronJob Setup | Create a job that runs every hour to clean a DB. | "Write a CronJob YAML that runs every hour using alpine." | kubectl get cronjob shows valid schedule. | Dev | Easy |
+| 16 | StatefulSet with Volume | Deploy a 3-node MongoDB with persistent storage. | "Create a StatefulSet for MongoDB with a 10Gi volume claim." | PVCs are automatically provisioned. | Dev | Hard |
+| 17 | Rolling Update Strategy | Configure a canary-like rollout with maxUnavailable. | "Modify my deployment to ensure 0 downtime with 25% maxSurge." | strategy.rollingUpdate is correctly set. | Dev | Hard |
+| 18 | Sidecar Injection | Add a logging sidecar to a primary container. | "Add a fluent-bit sidecar to this deployment YAML." | Pod contains two containers in spec. | Dev | Hard |
+| 19 | InitContainer Logic | Set up a container to run DB migrations before start. | "Add an initContainer to wait for the mysql service to be ready." | Pod waits for init to finish before main app. | Dev | Hard |
+| 20 | HPA Configuration | Scale pods based on 70% CPU utilization. | "Configure Horizontal Pod Autoscaler for my web-app." | kubectl get hpa shows target 70%. | Dev | Hard |
+| 21 | Blue/Green via Service | Switch traffic between two deployment versions. | "Write a script to flip the service selector from v1 to v2." | Service endpoint IP points to v2 pods. | Dev | Complex |
+| 22 | Graceful Shutdown | Implement preStop hooks and terminationGracePeriod. | "Handle SIGTERM by adding a 30s sleep in a preStop hook." | Pod logs show graceful exit during deletion. | Dev | Complex |
+| 23 | Gateway API Multi-Service | Route traffic to 'blue' or 'green' svc based on header version. | "Using Gateway API, route traffic to 'blue-svc' if header 'x-version' is 'v1'." | HTTPRoute with matches.headers correctly configured. | Dev | Hard |
+| 24 | Custom Health Check Path | Override default LB health check for a GKE Service. | "My app health check is on /status:8081. Configure GKE BackendConfig to use this for the LB." | BackendConfig healthCheck spec matches app port/path. | Dev | Hard |
+| 25 | Seccomp Profile App | Apply a custom seccomp profile to a high-security container. | "Generate a pod spec that uses a custom seccomp profile stored in /var/lib/kubelet/seccomp/." | securityContext.seccompProfile is correctly set to 'Localhost'. | Dev | Hard |
+| 26 | Vulnerability Scanning Fix | Respond to a 'Critical' CVE in a running GKE image. | "Container Analysis found CVE-XXXX in my image. Provide a plan to patch and rollout without downtime." | Plan includes image rebuild, digest update, and rolling restart. | Dev | Hard |
+| 27 | Filestore Multishare | Mount multiple shares from one Filestore instance. | "Configure GKE to use the Filestore CSI driver to mount two different shares on one pod." | Pod spec shows two volume mounts from the same StorageClass. | Dev | Hard |
+| 28 | Local SSD for Scratch | Use Local SSDs for high-IOPS ephemeral storage. | "Configure a GKE node pool with Local SSDs and mount them in a pod for cache." | Pod uses hostPath or Local volume pointing to the SSD mount. | Dev | Hard |
+| 29 | StatefulSet Scale Down | Safely scale down a Kafka cluster without data loss. | "Provide a script/plan to scale a 5-node Kafka StatefulSet to 3 nodes." | Plan includes data rebalancing (e.g., using Cruise Control) before K8s scale. | Dev | Complex |
+| 30 | Managed Prometheus (GMP) | Scrape app metrics without installing a full Prometheus stack. | "Configure GKE Managed Service for Prometheus to scrape my /metrics endpoint on port 9090." | PodMonitoring resource created; metrics visible in Cloud Monitoring. | Dev | Hard |
+| 31 | Distributed Tracing | Link a GKE frontend and backend in Cloud Trace. | "Add OpenTelemetry instrumentation to my Go app to send traces to Google Cloud Trace." | Traces show span parent-child relationships across services. | Dev | Complex |
+| 32 | Dashboard for HPA | Visualize HPA scaling events vs. CPU usage. | "Create a Cloud Monitoring dashboard that shows HPA replicas vs. actual CPU utilization." | Dashboard JSON or UI steps provided. | Dev | Hard |
+| 33 | Autopilot Compute Classes | Use 'Scale-Out' or 'Performance' classes in Autopilot. | "My Autopilot workload needs high-performance local SSD. How do I request it?" | Deployment includes cloud.google.com/compute-class: "Performance". | Dev | Hard |
+| 34 | Pre-emptible Node Drain | Implement a 30s warning handler for Spot VM termination. | "How do I ensure my app gracefully shuts down when a GKE Spot node is reclaimed?" | Pod uses a termination handler to catch the Metadata Server signal. | Dev | Complex |
+| 35 | Troubleshoot ImagePullBackOff | Debug an image pull error due to GCR/AR permissions. | "My pod is stuck in ImagePullBackOff for a private Artifact Registry image. How do I fix it?" | Identifies missing roles/artifactregistry.reader on the GKE node service account. | Dev | Easy |
+| 36 | Zombie Process Cleanup | Debug a pod that has 100s of "defunct" processes. | "My pod has hundreds of <defunct> processes. How do I fix the PID 1 problem in my Dockerfile?" | Suggests using tini as an entrypoint or shareProcessNamespace. | Dev | Hard |
+| 37 | Cloud Build GKE Deploy | Create a pipeline to build an image and update a deployment. | "Write a cloudbuild.yaml that builds a Docker image and runs 'gcloud clusters get-credentials'." | YAML uses gcr.io/cloud-builders/gke-deploy or kubectl. | Dev | Easy |
+| 38 | Canary Deployment (Istio) | Shift 10% of traffic to version 'v2' using Istio. | "Generate an Istio VirtualService to split traffic 90/10 between v1 and v2 subsets." | VirtualService with weighted destinations is generated. | Dev | Hard |
+| 39 | Standard to Autopilot | Convert a Standard GKE deployment to work on Autopilot. | "My deployment uses a HostPath volume. How do I change this to work on GKE Autopilot?" | Suggests PersistentVolumeClaim or EmptyDir (since HostPath is blocked). | Dev | Hard |
+| 40 | Monolith Decomposition | Identify service boundaries for a legacy GKE app. | "This 5000-line YAML is a monolith. How should I split it into microservices?" | Suggests logic for Service per domain, NetworkPolicies, and ConfigMaps. | Dev | Complex |
+| 41 | TCP Optimization | Tune sysctl parameters for a high-concurrency pod. | "How do I increase the max TCP connections (somaxconn) for an Nginx pod in GKE?" | Uses a securityContext with sysctls or an initContainer. | Dev | Hard |
+| 42 | Node Anti-Affinity | Ensure two replicas of a DB never run on the same node. | "Write a podAntiAffinity rule to spread my 'redis' pods across different nodes." | podAntiAffinity with requiredDuringScheduling... is used. | Dev | Hard |
+| 43 | Check Node Pressure | See why pods won't schedule. | "List all nodes with memory pressure." | kubectl get nodes shows pressure condition. | Platform | Easy |
+| 44 | MTU Mismatch Debug | Resolve networking issues across VPCs. | "Debug packet loss between GKE and an on-prem VM." | MTU/MSS clamping recommendation provided. | Platform | Complex |
+| 45 | Spot VM Node Pool | Create a node pool using Spot instances. | "Add a new node pool to my GKE cluster using Spot VMs." | kubectl get nodes shows spot instance labels. | Platform | Easy |
+| 46 | Cost Allocation Labels | Tag workloads for billing breakdown. | "Add a 'team: mobile' label to all pods in the 'mobile' namespace." | GCP Billing export shows the cost label. | Platform | Hard |
+| 47 | Right-sizing Audit | Identify over-provisioned pods. | "Find all pods where CPU usage is < 10% of their request." | List of underutilized pods generated. | Platform | Complex |
+| 48 | Cluster Autoscaler Tuning | Prevent node deletion for specific pods. | "Annotate a pod so the cluster autoscaler doesn't evict it." | safe-to-evict: false annotation applied. | Platform | Complex |
+| 49 | StorageClass Creation | Define a new class for Filestore. | "Create a StorageClass for GKE Filestore (NFS)." | kubectl get sc shows the new class. | Platform | Hard |
+| 50 | Backup for GKE | Configure a backup plan for a namespace. | "Set up a Backup for GKE plan for my 'production' namespace." | BackupPlan resource is active in GCP. | Platform | Complex |
+| 51 | Snapshot Restore | Recover a volume from a CSI snapshot. | "Create a new PVC from an existing VolumeSnapshot." | New pod mounts data from the snapshot. | Platform | Complex |
+| 52 | View-Only RBAC | Create a role for viewing logs/pods only. | "Create a ClusterRole for a developer to only 'get' and 'list' pods." | auth can-i returns yes for list, no for delete. | Platform | Easy |
+| 53 | Namespace Isolation | Create a namespace for a specific team. | "Create a namespace 'team-alpha' with a resource quota." | Namespace and ResourceQuota exist. | Platform | Easy |
+| 54 | Workload Identity Bind | Link a K8s SA to a GCP SA. | "Configure Workload Identity for K8s SA 'myapp' to GCP SA 'gcp-app'." | Pod can access GCS without local keys. | Platform | Hard |
+| 55 | Pod Security Standards | Enforce 'Baseline' security profile. | "Configure the namespace 'dev' to enforce the baseline pod security." | Privileged pods are rejected in that NS. | Platform | Hard |
+| 56 | Binary Authorization | Only allow signed images to run. | "Enable Binary Authorization on my GKE cluster." | Unsigned images trigger a 'Forbidden' error. | Platform | Complex |
+| 57 | KMS Secret Encryption | Encrypt ETCD secrets using a Cloud KMS key. | "Enable Application-layer Secrets Encryption on my cluster." | Cluster config shows database.encryptionConfig. | Platform | Complex |
+| 58 | RBAC Troubleshooting | Debug why a service account cannot list nodes. | "Check why SA 'test' in 'default' can't view node list." | Correct RoleBinding identified and fixed. | Platform | Complex |
+| 59 | Internal Load Balancer | Create a GCP ILB via annotations. | "Expose my service using a GKE internal load balancer." | Service type is LB with internal IP. | Platform | Hard |
+| 60 | SSL via Managed Certs | Use Google-managed SSL for an Ingress. | "Configure my GKE ingress to use a Google Managed Certificate." | ManagedCertificate resource exists and is bound. | Platform | Hard |
+| 61 | NetworkPolicy: Deny All | Isolate a namespace from all traffic. | "Create a NetworkPolicy to deny all ingress to namespace 'prod'." | Traffic to 'prod' pods times out. | Platform | Hard |
+| 62 | Gateway API Setup | Implement a Gateway for multi-service routing. | "Generate a Gateway and HTTPRoute for two different services." | kubectl get httproute shows valid parents. | Platform | Hard |
+| 63 | Cloud Armor Integration | Attach a WAF policy to a GKE Ingress. | "Add a Google Cloud Armor policy to my GKE frontend service." | BackendConfig references a security policy. | Platform | Complex |
+| 64 | Multi-Cluster Ingress | Route traffic across two GKE clusters. | "Set up a MultiClusterIngress for a global web app." | MCI resource status shows healthy backends. | Platform | Complex |
+| 65 | Service Mesh (ASM) | Enable sidecar injection for a namespace. | "Enable Anthos Service Mesh for the 'billing' namespace." | New pods in namespace have istio-proxy. | Platform | Complex |
+| 66 | Pod Disruption Budget | Ensure high availability during node maintenance. | "Create a PDB for my 'frontend' app to keep 80% available." | kubectl get pdb shows minAvailable set. | Platform | Hard |
+| 67 | Multi-Arch Deployment | Support both x86 and ARM nodes in one deployment. | "Update this spec to run on either ARM or x86 nodes." | nodeAffinity includes multiple arch terms. | Platform | Complex |
+| 68 | PriorityClass Setup | Ensure critical pods preempt lower priority ones. | "Create a PriorityClass for system-critical apps." | priorityClassName is applied to critical pods. | Platform | Complex |
+| 69 | HTTP-to-HTTPS Redirect | Configure a GKE Ingress to automatically redirect port 80 to 443. | "Create a FrontendConfig to force HTTPS redirect and link it to my Ingress." | FrontendConfig exists; Ingress annotation networking.gke.io/v1beta1.FrontendConfig is set. | Platform | Hard |
+| 70 | Shared VPC Deployment | Deploy GKE in a Service Project using a Host Project's VPC. | "Write the gcloud command to create a GKE cluster in a shared VPC with specific subnets." | Command includes --network and --subnetwork pointing to host project. | Platform | Hard |
+| 71 | Private Service Connect | Connect GKE to a managed service via PSC. | "Configure a GKE service to be reachable via a Private Service Connect endpoint." | Service attachment and DNS entries correctly defined. | Platform | Complex |
+| 72 | Multi-Cluster Service (MCS) | Export a service from Cluster A to be discoverable in Cluster B. | "Generate the ServiceExport and ServiceImport YAMLs for cross-cluster communication." | ServiceExport status shows 'Exported'. | Platform | Complex |
+| 73 | Cloud Armor Bot Mgmt | Implement bot management on a GKE Ingress. | "Add a Google Cloud Armor security policy to my GKE ingress to block known bots." | BackendConfig references a security policy with botManagement rules. | Platform | Complex |
+| 74 | ExternalDNS Setup | Auto-sync GKE Ingress hosts to Cloud DNS. | "Configure ExternalDNS to create 'A' records in Cloud DNS for my GKE Ingress resources." | DNS records automatically appear in Cloud DNS after Ingress creation. | Platform | Hard |
+| 75 | Cilium Network Policy | Use L7 (HTTP) filtering in GKE Dataplane V2. | "Create a NetworkPolicy that only allows GET requests to /public in my 'frontend' namespace." | CiliumNetworkPolicy (or DPv2 equivalent) restricts specific HTTP verbs/paths. | Platform | Complex |
+| 76 | Dual-Stack IPv6 | Enable IPv4/IPv6 dual-stack networking for a pod. | "Configure a GKE cluster and a Deployment to support dual-stack IPv6 networking." | Pod status.podIPs contains both IPv4 and IPv6 addresses. | Platform | Complex |
+| 77 | Workload Identity Debug | Identify why a pod cannot access a GCS bucket. | "The pod using SA 'my-k8s-sa' is getting 403 Access Denied for GCS. Troubleshoot the WI bind." | Identifies missing IAM role on GCP SA or missing annotation on K8s SA. | Platform | Hard |
+| 78 | Binary Auth Attestation | Only allow images signed by 'Cloud Build'. | "Create a Binary Authorization policy requiring a signature from a specific attestor." | Deployment fails if image is not signed by the designated attestor. | Platform | Complex |
+| 79 | Policy Controller Guardrail | Prevent LoadBalancers without specific tags. | "Write a ConstraintTemplate to prevent Services of type LoadBalancer unless they have a 'cost-center' label." | kubectl apply of a non-compliant service is rejected by the webhook. | Platform | Complex |
+| 80 | KMS Key Rotation Ops | Handle a GKE cluster when the KMS key is rotated. | "How do I update my GKE cluster after rotating the Cloud KMS key used for secret encryption?" | Correct sequence of gcloud container clusters update provided. | Platform | Hard |
+| 81 | Role-Based Log Filtering | Limit what logs a specific developer can see in Log Explorer. | "Configure GCP IAM so developer 'X' can only see logs from namespace 'dev' in GKE." | IAM Log View definition with correct filter expression. | Platform | Hard |
+| 82 | GKE Sandbox (gVisor) | Run an untrusted workload in a hardened sandbox. | "Configure a node pool and a pod to run using GKE Sandbox (gVisor)." | Pod has runtimeClassName: gvisor. | Platform | Hard |
+| 83 | FIPS 140-2 Compliance | Enable FIPS-validated modules for GKE nodes. | "How do I ensure my GKE node pools are FIPS 140-2 compliant?" | Command uses --enable-fips flag or specific FIPS-enabled OS images. | Platform | Complex |
+| 84 | Automated Secret Rotation | Rotate DB secrets using Berglas or External Secrets Operator. | "Set up External Secrets Operator to sync a Cloud Secret Manager secret to K8s every 1h." | ExternalSecret resource created; K8s secret updates when GCP secret changes. | Platform | Hard |
+| 85 | Regional PD Failover | Configure a DB to use Regional Persistent Disks. | "Create a StorageClass for Regional PDs that replicate across us-central1-a and us-central1-b." | replication-type: regional-pd in SC; PVC exists in two zones. | Platform | Hard |
+| 86 | Volume Snapshot Schedule | Auto-snapshot a DB volume every night at 2 AM. | "Create a VolumeSnapshotClass and a schedule to backup my PVCs daily." | VolumeSnapshot objects created automatically according to schedule. | Platform | Hard |
+| 87 | CSI Migration | Migrate from in-tree volume plugins to CSI driver. | "My old YAML uses 'gcePersistentDisk'. Convert it to use the GCE PD CSI driver." | YAML updated to use csi: driver: pd.csi.storage.gke.io. | Platform | Hard |
+| 88 | Cross-Project Storage | Access a Persistent Disk located in a different GCP project. | "Can my GKE cluster in Project A mount a disk from Project B? Explain how." | Correct answer regarding IAM permissions and gcloud compute disks add-iam-policy-binding. | Platform | Complex |
+| 89 | Custom Log Parsing | Use Fluent Bit to parse JSON logs in GKE. | "My app logs JSON. How do I configure GKE's managed Fluent Bit to parse these fields?" | LogConfig or custom ConfigMap ensures logs appear as structured data in GCP. | Platform | Hard |
+| 90 | SLO-Based Alerting | Create an alert for "99.9% of requests < 200ms". | "Set up a Cloud Monitoring alert for a GKE service based on a Latency SLO." | Alert policy exists with the correct MQL or filter expression. | Platform | Complex |
+| 91 | Node Problem Detector | Alert when a node has a 'KernelDeadlock'. | "How do I use Node Problem Detector in GKE to trigger an automated node drain?" | Remediation controller (like Draino) or logic identified for the event. | Platform | Complex |
+| 92 | Cost Metering Breakdown | See exactly how much 'Namespace A' costs. | "Enable GKE Cost Allocation and query the BigQuery export for 'billing-namespace-a'." | SQL query provided that joins GKE metadata with billing data. | Platform | Hard |
+| 93 | Terraform GKE Module | Create a cluster with private nodes and public master. | "Write a Terraform block for a GKE cluster with private nodes and a master authorized network." | TF code includes private_cluster_config and master_authorized_networks_config. | Platform | Hard |
+| 94 | Blue/Green Cluster Upgrade | Upgrade GKE by creating a new cluster and shifting traffic. | "Write a workflow to migrate workloads from GKE 1.27 to 1.28 using a DNS flip." | Plan covers state migration (PVCs) and global LB updates. | Platform | Complex |
+| 95 | Terraform Drift Repair | Fix a cluster that was manually edited in the GCP Console. | "Terraform plan shows changes I made in the console. How do I sync the state without deleting resources?" | terraform import or manual reconciliation steps provided. | Platform | Hard |
+| 96 | Custom Machine Type | Use a non-standard CPU/Mem ratio for a node pool. | "Create a GKE node pool using custom machine types (e.g., 6 vCPUs, 42GB RAM)." | Command uses --machine-type with custom-6-43008. | Platform | Hard |
+| 97 | Debug 502 Bad Gateway | Resolve 502s happening between GCLB and a GKE pod. | "I'm getting random 502 errors on my Ingress. Check the BackendConfig and pod health." | Recommends checking Keep-Alive timeout (must be > 600s for GCLB). | Platform | Hard |
+| 98 | Resolve PDB Deadlock | Fix a scenario where a cluster cannot drain nodes due to PDBs. | "kubectl drain is hanging because of a PodDisruptionBudget. How do I safely bypass this?" | Recommends minAvailable: 0 or identifying the specific blocking pod. | Platform | Hard |
+| 99 | Kernel OOM Investigation | Determine why a node is rebooting without a Pod OOM. | "A GKE node is crashing, but no pod shows OOMKill. How do I find the kernel log events?" | Command provided to use serial port logs or node-problem-detector. | Platform | Complex |
+| 100 | Recover Deleted Namespace | Plan for recovering resources from a namespace deleted by mistake. | "Someone ran 'kubectl delete ns prod'. What are my options for recovery in GKE?" | Plan includes Backup for GKE restoration or rebuilding from GitOps/State. | Platform | Complex |
+| 101 | Debug DNS Latency | Investigate 5-second delays in K8s DNS lookups. | "Our app has intermittent 5s DNS delays. Is this an ndots:5 issue? How do I verify?" | Identifies UDP packet drops or ndots search path overhead; suggests NodeLocal DNSCache. | Platform | Complex |
+| 102 | Enforce Resource Limits | Use Gatekeeper to reject pods without CPU limits. | "Write a Constraint to ensure every pod in 'production' has a CPU limit set." | Valid YAML for a K8sMaxContainerLimits or similar constraint. | Platform | Hard |
+| 103 | Audit Admin Activity | Find who changed a Service from ClusterIP to LoadBalancer. | "Search Cloud Logging to find the specific IAM user who modified service 'web-svc'." | Correct Log Explorer query: protoPayload.methodName="v1.compute.backendServices.patch". | Platform | Hard |
+| 104 | Multi-Tenant Soft Isolation | Separate Team A and Team B on the same cluster. | "Configure namespaces and RBAC so Team A cannot see Team B's logs or pods." | Includes Namespaces, Roles, RoleBindings, and NetworkPolicies. | Platform | Complex |
+| 105 | Automated Labeling Policy | Use a webhook to add 'owner' labels to all new pods. | "Generate a MutatingAdmissionWebhook to inject a default 'env' label into every pod." | Valid code for a mutating webhook or Policy Controller mutation. | Platform | Complex |
+| 106 | Compliance Reporting | Generate a report of all 'Privileged' containers. | "List all containers in the cluster that are running in privileged mode or as root." | kubectl get pods -o jsonpath or gcloud query provided. | Platform | Hard |
+| 107 | ArgoCD Sync Policy | Configure an app to auto-sync and prune deleted resources. | "Set up an ArgoCD Application spec for my GKE cluster with self-heal enabled." | syncPolicy includes automated, prune, and selfHeal. | Platform | Hard |
+| 108 | Config Sync Setup | Sync GKE cluster state with a Git repository. | "Configure Config Sync on GKE to track a private GitHub repo using an SSH key." | RootSync resource and Secret for SSH key are correctly defined. | Platform | Hard |
+| 109 | Blue/Green with Cloud Deploy | Use Google Cloud Deploy for a GKE delivery pipeline. | "Create a Cloud Deploy pipeline definition with 'dev', 'staging', and 'prod' targets." | DeliveryPipeline and Target YAMLs are syntactically correct. | Platform | Complex |
+| 110 | Anthos Migrate (VM to K8s) | Draft a plan to containerize a legacy Linux VM. | "What are the steps to use Migrate to Containers to move a Java app on VM to GKE?" | Plan includes fit-and-finish check, image generation, and YAML creation. | Platform | Complex |
+| 111 | Cross-Region Migration | Move a stateful workload from us-east1 to us-west1. | "How do I move a StatefulSet and its data from one GKE region to another?" | Plan uses VolumeSnapshots and regional replication strategies. | Platform | Complex |
+| 112 | GPU Workload Setup | Deploy an L4 GPU node pool for ML inference. | "Create a GKE node pool with NVIDIA L4 GPUs and install the necessary drivers." | Command includes --accelerator and mentions the GPU driver installer. | Platform | Hard |
+| 113 | Local SSD Raid 0 | Combine multiple local SSDs for maximum throughput. | "How do I configure a GKE node to RAID 0 three local SSDs for a data-intensive app?" | DaemonSet or startup-script logic provided to mount and strip disks. | Platform | Complex |
+| 114 | Horizontal Pod Autoscaling (Custom Metrics) | Scale pods based on "Pub/Sub unacknowledged messages". | "Configure HPA to scale based on a custom metric from Stackdriver/Cloud Monitoring." | ExternalMetric source is correctly configured in the HPA YAML. | Platform | Complex |
+
+---
+
+## Generation status
+
+`task_id = 1000 + #`. Provider dir per [methodology §2](./methodology.md#2-directory--naming-conventions);
+class per [methodology §9](./methodology.md#9-task-classes--the-live-cluster-gap).
+Rows not listed below are **pending generation**.
+
+| # | task_id | Slug | Provider | Class | Generated | Last run / result |
+| :-- | :-- | :-- | :-- | :-- | :-- | :-- |
+| 1 | 1001 | debug-crashloop | generic | investigation | ✅ | MCP→kind, num_ctx 32768, env forwarded, judge gemma4-mcp:e2b (DEEPEVAL_DISABLE_TIMEOUTS=1). **e4b PASS: ChecklistScore 1.0** (all checks 1.0, OutcomeValidity 1.0, ToolInvocation 1.0) — listed pods then read logs → found DATABASE_URL root cause + fix. **e2b FAIL: ChecklistScore 0.25** — hallucinated pod name `frontend-xxxxx`, never reached logs. Clear capability contrast. Earlier infra fails: no-MCP tool-less; default num_ctx → empty; env not forwarded → "context does not exist". |

--- a/docs/task-generation/methodology.md
+++ b/docs/task-generation/methodology.md
@@ -1,0 +1,213 @@
+# DevOps Bench — Task Generation Methodology
+
+This document is the **repeatable specification** for turning a row of the
+[expert task catalog](./catalog.md) into a valid `task.yaml` that the DevOps Bench
+evaluator can run. Read this before authoring or generating any task. The
+companion [running guide](./running.md) covers executing tasks and building a
+leaderboard.
+
+A summary an agent can follow while working in the repo lives in
+[`AGENTS.md`](../../AGENTS.md); this document is the authoritative spec.
+
+---
+
+## 1. How the harness consumes a task
+
+`pkg/evaluator/loader.py` walks the `tasks/` tree (recursively) and loads every
+`task.yaml` it finds. Each file is parsed by `yaml.safe_load`, so **unknown keys
+are ignored** — we can safely add tracking metadata (`category`, `difficulty`,
+`source`, `task_class`) without breaking the loader.
+
+The fields the loader/evaluator actually read:
+
+| Field | Required | Purpose |
+| :-- | :-- | :-- |
+| `task_id` | yes | Sort key & identity. Must be globally unique (see §3). |
+| `name` | yes | Human/slug name; defaults to the directory name. |
+| `prompt` | yes | The instruction handed to the agent under test. |
+| `expected_output` | yes | The grading rubric (see §4). |
+| `infrastructure` | no | Provisioning block (see §6). |
+| `chaos_spec` | no | Fault-injection spec for dynamic tasks (see §7). |
+| `verification_spec` | no | Live cluster-state assertions for dynamic tasks (see §7). |
+| `documentation` | no | Grounding constraints scored for citation accuracy (see §8). |
+| `retrieval_context` | no | Optional RAG context list. |
+
+## 2. Directory & naming conventions
+
+```
+tasks/<provider>/<task-slug>/task.yaml
+```
+
+- `<provider>`:
+  - `generic` — cloud-agnostic Kubernetes tasks that run on any cluster (kind, GKE, EKS…).
+  - `gcp` — tasks that depend on GCP/GKE-specific resources (Cloud Armor, Workload
+    Identity, Filestore, BackendConfig, FrontendConfig, Binary Auth, etc.).
+  - Add new provider dirs (`aws`, `azure`) only when a task is provider-specific.
+- `<task-slug>` — lowercase kebab-case, derived from the catalog **Task Name**
+  (e.g. `Debug CrashLoop` → `debug-crashloop`, `HPA Configuration` → `hpa-configuration`).
+- Supporting fixtures (manifests, app source) live alongside `task.yaml` in the same dir.
+
+> The top-level split is **by cloud**, not by the catalog's Dev/Platform column.
+> Dev/Platform and Easy/Hard/Complex are captured as metadata fields (§5), not directories.
+
+## 3. `task_id` allocation
+
+`task_id` is the loader's sort and identity key. Today IDs collide across
+`tasks/` and `complextasks/` (multiple `1`s and `2`s) — a latent bug. **Do not add
+to the collision.**
+
+Rule for catalog-generated tasks:
+
+- Allocate from the reserved **1000+ block** so generated tasks never clash with
+  the hand-authored tasks (currently 1–12).
+- The ID is **stable and idempotent**: `task_id = 1000 + <catalog row number>`
+  (1-indexed, top to bottom of [catalog.md](./catalog.md)). Re-generating a task
+  yields the same ID, so reruns and leaderboard joins stay stable.
+- Example: `Debug CrashLoop` is catalog row 1 → `task_id: 1001`.
+
+## 4. `expected_output` — the grading rubric
+
+`expected_output` is the most important field. The evaluator turns it into
+DeepEval **GEval** metrics: an overall `OutcomeValidity` score, a `ToolInvocation`
+score, and **one dynamic checklist metric per bullet** under `critical requirements:`.
+Each bullet is graded pass/fail independently and rolled into `ChecklistScore`.
+
+Structure every `expected_output` like this:
+
+```yaml
+expected_output: |
+  critical requirements:
+
+  - Expected Tool Call: <tool or kubectl verb the agent should invoke>
+  - <one verifiable requirement per line>
+  - <each line becomes its own pass/fail check — keep them atomic>
+
+  Expected Manifest Generated: <optional golden YAML for manifest tasks>
+  apiVersion: ...
+  kind: ...
+```
+
+Authoring rules:
+
+- **One requirement per bullet.** Compound bullets ("create X and bind Y") grade
+  poorly — split them.
+- **Make each bullet independently verifiable** from the agent's response/trace.
+- Start with an `Expected Tool Call:` line naming the tool/verb expected
+  (e.g. `generate_manifest`, `kubectl logs`, `kubectl get pods`). This drives the
+  `ToolInvocation` metric and matches existing tasks.
+- For **manifest-generation** tasks, include a golden manifest under
+  `Expected Manifest Generated:` so the judge can check semantic integrity
+  (ports, images, names, namespaces).
+- For **investigation** tasks, the bullets should assert the *root cause* and the
+  *recommended fix*, since success = "root cause identified" (there is no manifest).
+- Phrase from the catalog's **Success Metric** column — that column is the ground truth.
+
+## 5. Metadata fields (tracking)
+
+Add these keys for traceability and leaderboard slicing. The loader ignores them.
+
+```yaml
+category: Dev            # Dev | Platform (from catalog)
+difficulty: Easy         # Easy | Hard | Complex (from catalog)
+task_class: investigation  # see §9
+source: catalog#1        # catalog row reference
+```
+
+## 6. `infrastructure` — provisioning block
+
+Omit this block (or set `BENCH_NO_INFRA=true`) for pure manifest-generation tasks
+that need no live cluster. Use it when the task must run against real state.
+
+```yaml
+infrastructure:
+  deployer: "tofu"            # tofu | gcp | kind
+  stack: "prebuilt/kind"      # OpenTofu stack dir under tf/
+  teardown: true              # tear down after the task
+  variables: {}               # optional stack overrides
+```
+
+- `prebuilt/kind` brings up a **bare** kind cluster only — it provisions **no
+  workloads/fixtures**. Investigation tasks that need a broken pod, a specific
+  deployment, etc. require an additional fixture stack or pre-applied manifest
+  (see §9 / the "live cluster gap" note below).
+- `prebuilt/minimum` and `prebuilt/secret-rotation` are GKE/OpenTofu stacks.
+- Setting `BENCH_NO_INFRA=true` swaps in the `NoOpDeployer` regardless of the block.
+
+## 7. `chaos_spec` & `verification_spec` — dynamic tasks
+
+For tasks that must withstand a runtime event (load spikes, pod kills) the
+framework can inject a fault and assert cluster state **itself** (via kubectl),
+independent of the agent. See `complextasks/optimize-scale/task.yaml` for the
+canonical example. Use these only for resilience/autoscaling tasks; most catalog
+rows don't need them.
+
+## 8. `documentation` — grounding constraints
+
+Optional. Lets the judge score whether the agent honored documented constraints
+and cited the right source. Format:
+
+```yaml
+documentation:
+  - doc_name: "GKE Gateway"
+    url: "https://..."
+    constraints:
+      - text: "Redirects must use a dedicated HTTP listener"
+        critical: true
+```
+
+## 9. Task classes & the live-cluster gap
+
+Classify every task — it determines whether it can be run locally today.
+
+| `task_class` | What the agent must do | Runs locally now? |
+| :-- | :-- | :-- |
+| `manifest-generation` | Emit YAML / config from the prompt | ✅ Yes — no infra, no MCP. The proven local path. |
+| `investigation` | Inspect a live cluster, identify a root cause | ⚠️ Needs an MCP toolserver wired to the cluster |
+| `live-action` | Apply/modify resources on a live cluster | ⚠️ Needs an MCP toolserver + provisioned cluster |
+| `plan-only` | Produce a written plan/runbook (no execution) | ✅ Yes — graded as text |
+
+**Cluster access:** the agent's *only* channel to a cluster is an **MCP server**
+(`MCP_SERVER_PATH`, default the GKE MCP binary `third_party/gke-mcp/gke-mcp`). With
+`BENCH_USE_MCP=false` the agent runs **tool-less** and can only produce text, so
+`investigation`/`live-action` tasks then only test the plumbing + judge.
+
+The GKE MCP server is installed via `scripts/setup_gke_mcp.sh`. Its `*_k8s_*` tools
+(`get_k8s_logs`, `describe_k8s_resource`, `list_k8s_events`, `get_k8s_resource`,
+`apply_k8s_manifest`, …) resolve a **kubeconfig context** named
+`gke_<project>_<location>_<cluster>` (see `pkg/tools/k8s/client.go`) — they do *not*
+call the GCP API to connect. So they can drive **any** cluster, including local
+**kind**, if a context with that name exists in the active kubeconfig.
+
+To run investigation/live-action tasks on kind: seed a `gke_<project>_<location>_<cluster>`
+context that points at the kind cluster (matching the `PROJECT_ID`/`LOCATION`/`CLUSTER_NAME`
+the harness passes), run with `BENCH_USE_MCP=true`, and apply the task's fixture
+first. See [running.md §"Investigation/live-action on kind"](./running.md). Known
+quirk: `get_k8s_logs --previous` fails on kind (containerd GCs previous-container
+logs); current logs work and carry the root cause.
+
+## 10. Authoring checklist
+
+Before considering a task done:
+
+1. ☐ Directory is `tasks/<provider>/<slug>/` and slug matches the catalog name.
+2. ☐ `task_id` is from the 1000+ block, `1000 + <row#>`, and unique.
+3. ☐ `prompt` matches the catalog **Sample Prompt** (placeholders templated, §11).
+4. ☐ `expected_output` has atomic `critical requirements:` bullets derived from the
+      **Success Metric**, leading with `Expected Tool Call:`.
+5. ☐ Manifest tasks include a golden `Expected Manifest Generated:` block.
+6. ☐ Metadata fields set (`category`, `difficulty`, `task_class`, `source`).
+7. ☐ `infrastructure` block present iff the task needs live state.
+8. ☐ **Validates**: `python3 -c "from pkg.evaluator.loader import load_from_tasks_dir; print([t['name'] for t in load_from_tasks_dir('tasks')])"` lists the task with no warning.
+9. ☐ Catalog row status updated in [catalog.md](./catalog.md).
+
+## 11. Placeholders
+
+The evaluator substitutes these at run time (`replace_placeholders`):
+
+- `{{GCP_PROJECT_ID}}` / `{{PROJECT_ID}}`
+- `{{GKE_CLUSTER_NAME}}` / `{{CLUSTER_NAME}}`
+- `{{NAMESPACE}}` (env `NAMESPACE`)
+- `{{TARGET_DEPLOYMENT_NAME}}` (env `TARGET_DEPLOYMENT_NAME`)
+
+Use them in `prompt`, `chaos_spec`, and `verification_spec` so a task is portable
+across projects/clusters.

--- a/docs/task-generation/running.md
+++ b/docs/task-generation/running.md
@@ -1,0 +1,154 @@
+# DevOps Bench — Running Tasks & Building a Leaderboard
+
+How to run generated tasks against the framework, collect outcomes, and aggregate
+them into a model leaderboard. Pairs with the
+[generation methodology](./methodology.md).
+
+---
+
+## 1. Run modes & what they validate
+
+| Mode | Agent tools | Infra | What it proves |
+| :-- | :-- | :-- | :-- |
+| **Local smoke** (gemma4:e2b, no MCP) | none | `BENCH_NO_INFRA=true` | Generation → harness → judge plumbing works; manifest tasks can pass |
+| **Local + kind** | needs kind MCP (not wired yet) | kind cluster | Investigation/live-action on a free cluster |
+| **Full / leaderboard** | GKE MCP | real GKE + GCP creds | Meaningful per-model scores across the catalog |
+
+> Local smoke with `gemma4:e2b` as both agent and judge is a **pipeline check, not
+> leaderboard data**. A real leaderboard needs capable agent models
+> (e.g. Gemini 3 Pro, Claude Opus) + a strong judge + GCP for live-infra tasks.
+> See [methodology §9](./methodology.md#9-task-classes--the-live-cluster-gap) for
+> the kind/MCP gap.
+
+## 2. Local smoke run (the working local path)
+
+Uses Ollama `gemma4:e2b` as agent + judge, no MCP, no infra. Mirrors
+`scripts/run_ollama_e2e_test.sh`.
+
+```bash
+# Ollama must be serving and have gemma4:e2b pulled:
+#   ollama serve & ; ollama pull gemma4:e2b
+
+export BENCH_AGENT_TYPE=api
+export BENCH_USE_MCP=false
+export BENCH_NO_INFRA=true
+export AGENT_PROVIDER=ollama   JUDGE_PROVIDER=ollama
+export AGENT_MODEL=gemma4:e2b  JUDGE_MODEL=gemma4:e2b
+export OLLAMA_BASE_URL="http://127.0.0.1:11434/v1"
+export GCP_PROJECT_ID=test-project CLUSTER_NAME=test-cluster
+
+python3 pkg/evaluator/evaluate.py tasks/generic/debug-crashloop/task.yaml
+```
+
+To run the whole suite, point the script at the `tasks/` directory instead of a
+single file (the loader walks recursively).
+
+## 2b. Investigation / live-action on kind (GKE MCP → kind)
+
+The GKE MCP server (`third_party/gke-mcp/gke-mcp`, built by
+`scripts/setup_gke_mcp.sh`) lets the agent read/act on a cluster. Its `*_k8s_*`
+tools connect via a kubeconfig context named `gke_<project>_<location>_<cluster>`,
+not the GCP API — so they work against **kind** once such a context is seeded.
+
+```bash
+# 1) Seed a gke_<proj>_<loc>_<cluster> context pointing at the kind cluster,
+#    matching the identifiers the harness/agent will use:
+PROJ=test-project; LOC=us-central1; CLU=test-cluster
+CTX="gke_${PROJ}_${LOC}_${CLU}"
+kubectl config --kubeconfig ~/.kube/config_kind get-contexts   # find the kind context
+# duplicate the kind context under the gke_ name (see methodology §9), then:
+kubectl --context "$CTX" get nodes      # verify it reaches kind
+
+# 2) Apply the task's fixture so there is something to inspect/act on:
+kubectl --context "$CTX" apply -f tasks/generic/debug-crashloop/frontend-crashloop.yaml
+
+# 3) Run the task WITH MCP tools:
+export KUBECONFIG=~/.kube/config_kind
+export BENCH_AGENT_TYPE=api BENCH_USE_MCP=true
+export MCP_SERVER_PATH=third_party/gke-mcp/gke-mcp
+export AGENT_PROVIDER=ollama AGENT_MODEL=gemma4:e2b
+export JUDGE_PROVIDER=ollama JUDGE_MODEL=gemma4:e2b
+export OLLAMA_BASE_URL="http://127.0.0.1:11434/v1"
+export GCP_PROJECT_ID=$PROJ GCP_LOCATION=$LOC CLUSTER_NAME=$CLU NAMESPACE=default
+python3 pkg/evaluator/evaluate.py tasks/generic/debug-crashloop/task.yaml
+```
+
+The agent must pass `project_id`/`location`/`cluster_name` to each k8s tool; ensure
+the task prompt/context makes these available. Known quirk: `get_k8s_logs
+--previous` fails on kind (containerd GCs previous-container logs) — current logs
+work. Note: GKE-only tools (`list_clusters`, `create_cluster`, `query_logs`,
+`list_recommendations`, …) still require real GCP and won't work against kind.
+
+**Ollama context window (required for MCP runs).** The GKE MCP tool schema is large
+(~6.9k tokens for all 34 tools). Ollama defaults `num_ctx` to 4096 and the
+OpenAI-compatible endpoint **ignores** `extra_body.options.num_ctx`, so the tool
+list gets truncated and the model returns an **empty** response with no tool calls.
+Fix: bake a larger context into a derived model (applies on the OpenAI endpoint):
+
+```bash
+printf 'FROM gemma4:e2b\nPARAMETER num_ctx 32768\n' > /tmp/Modelfile.gemma4mcp
+ollama create gemma4-mcp:e2b -f /tmp/Modelfile.gemma4mcp
+# then set AGENT_MODEL=gemma4-mcp:e2b (JUDGE can stay gemma4:e2b)
+```
+
+Alternatively start the server with `OLLAMA_CONTEXT_LENGTH=32768 ollama serve` to
+raise the default for all models. With this, gemma4:e2b drives the full 34-tool set
+(verified: it calls `get_k8s_resource`/`describe_k8s_resource`/`get_k8s_logs`).
+At small tool counts (5–10) the 2B model still reasons weakly; for more robust
+tool-use a larger Gemma 4 (e.g. `e4b`) helps, but `e2b` works for the MCP path.
+
+## 3. Full run (per model, for the leaderboard)
+
+```bash
+export BENCH_AGENT_TYPE=api
+export BENCH_USE_MCP=true                 # GKE MCP for live tasks
+export AGENT_PROVIDER=google AGENT_MODEL=gemini-3.1-pro-preview AGENT_API_KEY=...
+export JUDGE_PROVIDER=google JUDGE_MODEL=gemini-3.1-pro-preview JUDGE_API_KEY=...
+export GCP_PROJECT_ID=<proj> GKE_CLUSTER_NAME=<cluster>
+export GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/application_default_credentials.json
+
+python3 pkg/evaluator/evaluate.py tasks/        # whole catalog
+```
+
+Swap `AGENT_PROVIDER`/`AGENT_MODEL` (e.g. `anthropic` / `claude-opus-4-8`) to add a
+model to the board. **Keep the judge fixed across models** so scores are comparable.
+
+## 4. Where results land
+
+Each run writes `results/run_<YYYYMMDD_HHMMSS>/`:
+
+- `results.json` — per-task inputs, agent output, trajectory, latency, tokens, and
+  `scores` (OutcomeValidity, ToolInvocation, per-bullet checks, ChecklistScore).
+- `generated_files/` — any artifacts the agent produced.
+
+A task is considered **passed** when its checks report `success: true` (GEval
+normalizes the judge's 0–10 to 0–1; threshold ≈ 0.5; `ChecklistScore` is
+fraction of bullets passed).
+
+## 5. Building the leaderboard
+
+Recommended layout for comparable runs — one results dir per model:
+
+```
+results/leaderboard/<model-id>/run_.../results.json
+```
+
+Aggregation approach (to be scripted as the suite grows):
+
+1. For each model, load every task's `ChecklistScore.score` and `OutcomeValidity`.
+2. Compute per-model: tasks passed / total, mean ChecklistScore, mean latency,
+   mean total tokens. Slice by `category` and `difficulty` (from task metadata).
+3. Emit a markdown table:
+
+   | Model | Pass rate | Mean checklist | Easy | Hard | Complex | Mean latency | Mean tokens |
+   | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
+
+Keep the judge model and task set identical across rows; note both in the
+leaderboard header so results stay reproducible.
+
+## 6. Reproducibility notes
+
+- Pin `AGENT_MODEL` / `JUDGE_MODEL` versions in the leaderboard header.
+- Record the task-set git SHA (the catalog evolves).
+- LLM judges are stochastic — for borderline tasks, average ≥3 runs or fix
+  temperature where the provider allows.

--- a/pkg/agents/runner/api/llm_adapters.py
+++ b/pkg/agents/runner/api/llm_adapters.py
@@ -1,4 +1,5 @@
 import os
+import json
 import base64
 from google import genai
 from google.genai import types
@@ -209,3 +210,87 @@ class AnthropicClientAdapter(LLMClient):
             ],
         })
     return anthropic_messages
+
+
+class OllamaClientAdapter(LLMClient):
+  """Adapter for Ollama via its OpenAI-compatible API."""
+
+  def __init__(self, model_name=None):
+    from openai import AsyncOpenAI
+    if not model_name:
+      model_name = os.environ.get("AGENT_MODEL", "gemma4:2b")
+    base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+    # api_key is required by the openai client but unused by Ollama
+    self.client = AsyncOpenAI(base_url=base_url, api_key="ollama")
+    self.model_name = model_name
+
+  async def generate_content(self, contents, tools, system_instruction):
+    messages = self._convert_to_openai_messages(contents, system_instruction)
+    kwargs = {"model": self.model_name, "messages": messages}
+    if tools:
+      kwargs["tools"] = tools
+    return await self.client.chat.completions.create(**kwargs)
+
+  def format_tools(self, mcp_tools):
+    return [
+      {
+        "type": "function",
+        "function": {
+          "name": tool.name,
+          "description": tool.description,
+          "parameters": tool.inputSchema if hasattr(tool, "inputSchema") else {},
+        },
+      }
+      for tool in mcp_tools
+    ]
+
+  def extract_function_calls(self, response):
+    calls = []
+    message = response.choices[0].message
+    if message.tool_calls:
+      for tc in message.tool_calls:
+        args = tc.function.arguments
+        if isinstance(args, str):
+          try:
+            args = json.loads(args)
+          except json.JSONDecodeError:
+            args = {}
+        calls.append({"name": tc.function.name, "args": args, "id": tc.id})
+    return calls
+
+  def get_text_content(self, response) -> str:
+    content = response.choices[0].message.content
+    return content if content else ""
+
+  def _convert_to_openai_messages(self, contents, system_instruction):
+    messages = []
+    if system_instruction:
+      messages.append({"role": "system", "content": system_instruction})
+    for msg in contents:
+      role = msg["role"]
+      content = msg["content"]
+      if role == "user":
+        messages.append({"role": "user", "content": content})
+      elif role == "assistant":
+        if "tool_calls" in msg:
+          tool_calls = [
+            {
+              "id": tc.get("id") or f"call_{i}",
+              "type": "function",
+              "function": {
+                "name": tc["name"],
+                "arguments": json.dumps(tc["args"]) if isinstance(tc["args"], dict) else tc["args"],
+              },
+            }
+            for i, tc in enumerate(msg["tool_calls"])
+          ]
+          messages.append({"role": "assistant", "content": content or "", "tool_calls": tool_calls})
+        else:
+          messages.append({"role": "assistant", "content": content})
+      elif role == "tool":
+        messages.append({
+          "role": "tool",
+          "tool_call_id": msg.get("tool_call_id", ""),
+          "content": content,
+        })
+    return messages

--- a/pkg/agents/runner/api/mcp_client.py
+++ b/pkg/agents/runner/api/mcp_client.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import AsyncExitStack
 from deepeval.tracing import observe
 from mcp.client.session import ClientSession
@@ -11,7 +12,13 @@ class MCPClient:
     self.session = None
 
   async def __aenter__(self):
-    server_params = StdioServerParameters(command=self.server_path)
+    # Forward the full environment so the MCP server inherits KUBECONFIG and
+    # cloud credentials (GOOGLE_APPLICATION_CREDENTIALS, etc.). The MCP SDK
+    # otherwise launches the server with a stripped default environment, which
+    # leaves it unable to resolve the target cluster's kubeconfig context.
+    server_params = StdioServerParameters(
+        command=self.server_path, env=os.environ.copy()
+    )
     stdio_transport = await self.exit_stack.enter_async_context(
         stdio_client(server_params)
     )

--- a/pkg/evaluator/evaluate.py
+++ b/pkg/evaluator/evaluate.py
@@ -46,6 +46,8 @@ from deployers.factory import get_deployer
 
 SYSTEM_INSTRUCTION = """You are an expert DevOps engineer. When asked to make an app production-ready or perform operational tasks like secret rotation, you MUST apply the changes directly to the GKE cluster and GCP APIs using your tools. Do NOT output bash scripts, templates, or instructions for the user to run manually. You must complete the entire operation yourself using tool calls."""
 
+SYSTEM_INSTRUCTION_NO_MCP = """You are an expert DevOps engineer. Respond with complete, production-ready Kubernetes manifests and configurations that satisfy the request. Output the full YAML or relevant artifacts directly in your response."""
+
 
 def validate_config(role, provider, model):
     """Logs the detected configuration. TODO: Add consistency checks."""
@@ -357,13 +359,14 @@ def execute_agent(bench_agent_type, agent_target, prompt, context):
             raise ValueError(f"Unknown provider: {provider}")
         bench_use_mcp_env = os.environ.get("BENCH_USE_MCP", "true").lower()
         bench_use_mcp = bench_use_mcp_env == "true"
+        sys_instruction = SYSTEM_INSTRUCTION if bench_use_mcp else SYSTEM_INSTRUCTION_NO_MCP
         return asyncio.run(
             run_api_agent(
                 prompt,
                 mcp_server_path,
                 llm_client,
                 bench_use_mcp=bench_use_mcp,
-                system_instruction=SYSTEM_INSTRUCTION,
+                system_instruction=sys_instruction,
             )
         )
     else:

--- a/pkg/evaluator/evaluate.py
+++ b/pkg/evaluator/evaluate.py
@@ -29,6 +29,7 @@ sys.path.insert(
 from pkg.agents.runner.api.llm_adapters import (
     AnthropicClientAdapter,
     GeminiClientAdapter,
+    OllamaClientAdapter,
 )
 
 from pkg.agents.runner.api.api import run_api_agent
@@ -133,6 +134,35 @@ class AnthropicDeepEvalModel(DeepEvalBaseLLM):
                 if hasattr(content, "type") and content.type == "text":
                     text += content.text
         return text
+
+    async def a_generate(self, prompt: str) -> str:
+        return self.generate(prompt)
+
+    def get_model_name(self):
+        return self.model_name
+
+
+class OllamaDeepEvalModel(DeepEvalBaseLLM):
+    """Wrapper for Ollama (OpenAI-compatible API) to be used with DeepEval."""
+
+    def __init__(self, model_name=None):
+        from openai import OpenAI
+        if not model_name:
+            model_name = os.environ.get("JUDGE_MODEL", "gemma4:2b")
+        self.model_name = model_name
+        base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+        self.client = OpenAI(base_url=base_url, api_key="ollama")
+        validate_config("judge", "ollama", self.model_name)
+
+    def load_model(self):
+        return self.client
+
+    def generate(self, prompt: str) -> str:
+        response = self.client.chat.completions.create(
+            model=self.model_name,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message.content or ""
 
     async def a_generate(self, prompt: str) -> str:
         return self.generate(prompt)
@@ -257,6 +287,10 @@ def load_configuration_context():
         if not judge_model_name:
             judge_model_name = "claude-opus-4-6"
         judge_model = AnthropicDeepEvalModel(model_name=judge_model_name)
+    elif judge_provider == "ollama":
+        if not judge_model_name:
+            judge_model_name = "gemma4:2b"
+        judge_model = OllamaDeepEvalModel(model_name=judge_model_name)
     else:
         print(
             f"Warning: Unknown judge provider '{judge_provider}'. Defaulting to Gemini."
@@ -317,6 +351,8 @@ def execute_agent(bench_agent_type, agent_target, prompt, context):
             llm_client = GeminiClientAdapter()
         elif provider == "anthropic":
             llm_client = AnthropicClientAdapter()
+        elif provider == "ollama":
+            llm_client = OllamaClientAdapter()
         else:
             raise ValueError(f"Unknown provider: {provider}")
         bench_use_mcp_env = os.environ.get("BENCH_USE_MCP", "true").lower()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ pytest==9.0.3
 google-genai==2.6.0
 mcp==1.27.1
 anthropic==0.104.1
+openai>=1.0.0
 pyyaml==6.0.3
 pytest-mock==3.15.1

--- a/scripts/mock_ollama_server.py
+++ b/scripts/mock_ollama_server.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Minimal mock of Ollama's OpenAI-compatible chat API for integration testing.
+
+Detects whether a request is an agent call or a DeepEval GEval call by
+inspecting the prompt, then returns an appropriate canned response.
+"""
+import json
+import time
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+MOCK_MODEL = "gemma4:2b"
+
+AGENT_RESPONSE = (
+    "I'll configure the HTTP-to-HTTPS redirect on public-gw.\n\n"
+    "Here is the HTTPRoute manifest:\n\n"
+    "```yaml\napiVersion: gateway.networking.k8s.io/v1\n"
+    "kind: HTTPRoute\nmetadata:\n  name: https-redirect\n  namespace: default\n"
+    "spec:\n  parentRefs:\n  - group: gateway.networking.k8s.io\n    kind: Gateway\n"
+    "    name: public-gw\n    port: 80\n  rules:\n  - filters:\n"
+    "    - type: RequestRedirect\n      requestRedirect:\n        scheme: https\n"
+    "        statusCode: 301\n```"
+)
+
+# DeepEval GEval asks the judge to produce evaluation *steps* (list) then a *score*.
+# Both must be valid JSON matching the schemas DeepEval expects.
+STEPS_JSON = json.dumps({
+    "steps": [
+        "Check that the output produces a valid Gateway API HTTPRoute manifest.",
+        "Verify the HTTPRoute listens on port 80 and targets public-gw.",
+        "Confirm a RequestRedirect filter sets scheme=https and statusCode=301.",
+    ]
+})
+
+SCORE_JSON = json.dumps({
+    "reason": (
+        "The output is a complete HTTPRoute manifest with a RequestRedirect "
+        "filter targeting port 80 and returning 301 to https."
+    ),
+    "score": 1,
+})
+
+_lock = threading.Lock()
+_call_count = 0
+
+
+def _all_text(body: dict) -> str:
+    return " ".join(m.get("content", "") for m in body.get("messages", []))
+
+
+def _classify(body: dict) -> str:
+    """Return 'steps', 'score', or 'agent'."""
+    text = _all_text(body).lower()
+    # DeepEval GEval step-generation: asks to generate evaluation steps
+    if "generate" in text and "evaluation steps" in text:
+        return "steps"
+    # DeepEval GEval scoring: asks for both score and reason as JSON
+    if '"score"' in text and '"reason"' in text:
+        return "score"
+    return "agent"
+
+
+class MockHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        print(f"[mock] {fmt % args}")
+
+    def _json(self, data, status=200):
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path in ("/v1/models", "/api/tags"):
+            self._json({
+                "object": "list",
+                "data": [{"id": MOCK_MODEL, "object": "model"}],
+                "models": [{"name": MOCK_MODEL}],
+            })
+        else:
+            self._json({"error": "not found"}, 404)
+
+    def do_POST(self):
+        global _call_count
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length))
+
+        with _lock:
+            _call_count += 1
+            n = _call_count
+
+        kind = _classify(body)
+        if kind == "steps":
+            text = STEPS_JSON
+        elif kind == "score":
+            text = SCORE_JSON
+        else:
+            text = AGENT_RESPONSE
+
+        print(f"[mock] call #{n} ({kind})")
+        self._json({
+            "id": f"chatcmpl-{n}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": body.get("model", MOCK_MODEL),
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": text, "tool_calls": None},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 40, "completion_tokens": 80, "total_tokens": 120},
+        })
+
+
+def start(port: int = 11435):
+    srv = HTTPServer(("127.0.0.1", port), MockHandler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    print(f"[mock] listening on http://127.0.0.1:{port}")
+    return srv
+
+
+if __name__ == "__main__":
+    import sys
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 11435
+    srv = start(port)
+    print("Press Ctrl+C to stop.")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        srv.shutdown()

--- a/scripts/run_ollama_e2e_test.sh
+++ b/scripts/run_ollama_e2e_test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# End-to-end test for the Ollama provider integration.
+# Uses a mock Ollama server so no model weights or live cluster are required.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MOCK_PORT="${MOCK_PORT:-11435}"
+TASK_FILE="tasks/generic/gateway-https-redirect/task.yaml"
+
+echo "==> Starting mock Ollama server on port ${MOCK_PORT}"
+python3 scripts/mock_ollama_server.py "${MOCK_PORT}" &
+MOCK_PID=$!
+sleep 1
+curl -sf "http://127.0.0.1:${MOCK_PORT}/v1/models" | python3 -m json.tool || {
+  echo "ERROR: mock server failed to start"; kill "${MOCK_PID}" 2>/dev/null; exit 1
+}
+
+echo ""
+echo "==> Running benchmark task: ${TASK_FILE}"
+echo "    AGENT_PROVIDER=ollama  JUDGE_PROVIDER=ollama  MODEL=gemma4:2b"
+echo ""
+
+export BENCH_AGENT_TYPE=api
+export BENCH_USE_MCP=false
+export BENCH_NO_INFRA=true
+export AGENT_PROVIDER=ollama
+export JUDGE_PROVIDER=ollama
+export AGENT_MODEL=gemma4:2b
+export JUDGE_MODEL=gemma4:2b
+export OLLAMA_BASE_URL="http://127.0.0.1:${MOCK_PORT}/v1"
+export GCP_PROJECT_ID=test-project
+export CLUSTER_NAME=test-cluster
+
+python3 pkg/evaluator/evaluate.py "${TASK_FILE}"
+EXIT_CODE=$?
+
+echo ""
+echo "==> Stopping mock server (PID ${MOCK_PID})"
+kill "${MOCK_PID}" 2>/dev/null || true
+
+exit ${EXIT_CODE}

--- a/scripts/setup_local_env.sh
+++ b/scripts/setup_local_env.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Sets up a local test environment: Ollama (gemma4:2b) + kind cluster.
+# Intended to run as an environment setup script in Claude Code on the web,
+# where its output is cached so subsequent sessions start ready.
+set -euo pipefail
+
+OLLAMA_VERSION="${OLLAMA_VERSION:-v0.30.8}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-gemma4:2b}"
+KIND_CLUSTER="${KIND_CLUSTER:-devops-bench}"
+
+echo "==> Installing system deps"
+apt-get update -qq
+apt-get install -y -qq zstd
+
+echo "==> Installing Ollama ${OLLAMA_VERSION}"
+curl -fL "https://github.com/ollama/ollama/releases/download/${OLLAMA_VERSION}/ollama-linux-amd64.tar.zst" \
+  -o /tmp/ollama.tar.zst
+tar --use-compress-program=unzstd -xf /tmp/ollama.tar.zst -C /usr/local/
+rm /tmp/ollama.tar.zst
+ollama --version
+
+echo "==> Installing kind"
+curl -fsSL "https://github.com/kubernetes-sigs/kind/releases/latest/download/kind-linux-amd64" \
+  -o /usr/local/bin/kind
+chmod +x /usr/local/bin/kind
+kind version
+
+echo "==> Starting Docker daemon"
+dockerd &>/tmp/dockerd.log &
+DOCKERD_PID=$!
+for i in $(seq 1 30); do
+  [ -S /var/run/docker.sock ] && break
+  sleep 1
+done
+
+echo "==> Pre-pulling kind node image (cached for future sessions)"
+docker pull kindest/node:v1.36.1
+
+echo "==> Creating kind cluster: ${KIND_CLUSTER}"
+kind create cluster --name "${KIND_CLUSTER}" --wait 60s
+
+echo "==> Starting Ollama server"
+ollama serve &>/tmp/ollama.log &
+for i in $(seq 1 30); do
+  curl -sf http://localhost:11434/api/tags &>/dev/null && break
+  sleep 1
+done
+
+echo "==> Pulling model: ${OLLAMA_MODEL}"
+ollama pull "${OLLAMA_MODEL}"
+
+echo ""
+echo "Setup complete. To run the benchmark with Ollama + kind:"
+echo "  export AGENT_PROVIDER=ollama JUDGE_PROVIDER=ollama"
+echo "  export AGENT_MODEL=${OLLAMA_MODEL} JUDGE_MODEL=${OLLAMA_MODEL}"
+echo "  export OLLAMA_BASE_URL=http://localhost:11434/v1"

--- a/scripts/setup_ollama.sh
+++ b/scripts/setup_ollama.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Installs Ollama and pulls the model used for local end-to-end testing.
+set -euo pipefail
+
+MODEL="${OLLAMA_MODEL:-gemma4:2b}"
+
+if ! command -v ollama &>/dev/null; then
+  echo "Installing Ollama..."
+  curl -fsSL https://ollama.com/install.sh | sh
+fi
+
+echo "Starting Ollama server in the background..."
+ollama serve &>/tmp/ollama.log &
+OLLAMA_PID=$!
+
+# Wait for Ollama to be ready
+for i in $(seq 1 30); do
+  if curl -sf http://localhost:11434/api/tags &>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+echo "Pulling model: ${MODEL}"
+ollama pull "${MODEL}"
+
+echo ""
+echo "Ollama is running (PID ${OLLAMA_PID}) with model ${MODEL}."
+echo ""
+echo "To run the benchmark locally with Ollama, set:"
+echo "  export AGENT_PROVIDER=ollama"
+echo "  export JUDGE_PROVIDER=ollama"
+echo "  export AGENT_MODEL=${MODEL}"
+echo "  export JUDGE_MODEL=${MODEL}"
+echo "  export OLLAMA_BASE_URL=http://localhost:11434/v1  # default, can omit"

--- a/tasks/generic/debug-crashloop/frontend-crashloop.yaml
+++ b/tasks/generic/debug-crashloop/frontend-crashloop.yaml
@@ -1,0 +1,35 @@
+# Fixture for the debug-crashloop task.
+# A deliberately broken 'frontend' deployment: the container's entrypoint requires
+# the DATABASE_URL environment variable and exits non-zero when it is absent,
+# producing a CrashLoopBackOff. Apply this to the task cluster before the agent runs.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: busybox:1.36
+        # Fails fast when DATABASE_URL is unset -> non-zero exit -> CrashLoopBackOff.
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            if [ -z "$DATABASE_URL" ]; then
+              echo "FATAL: required environment variable DATABASE_URL is not set" >&2
+              exit 1
+            fi
+            echo "frontend started, connecting to $DATABASE_URL"
+            sleep 3600
+        ports:
+        - containerPort: 8080

--- a/tasks/generic/debug-crashloop/task.yaml
+++ b/tasks/generic/debug-crashloop/task.yaml
@@ -1,0 +1,29 @@
+task_id: 1001
+name: "debug-crashloop"
+category: Dev
+difficulty: Easy
+task_class: investigation
+source: catalog#1
+# Investigation task: the agent must inspect the live cluster to find the root
+# cause. A fair run requires the cluster fixture below AND an MCP toolserver that
+# gives the agent kubectl access (see docs/task-generation/methodology.md §9).
+infrastructure:
+  deployer: "tofu"
+  stack: "prebuilt/kind"
+  teardown: true
+  # The broken workload fixture (frontend-crashloop.yaml) must be applied to the
+  # cluster before the agent runs. prebuilt/kind brings up a bare cluster only;
+  # apply the fixture manifest in this directory as part of provisioning.
+prompt: |
+  You are operating on GKE cluster "{{GKE_CLUSTER_NAME}}" in project
+  "{{GCP_PROJECT_ID}}", location "us-central1". The 'frontend' deployment in the
+  '{{NAMESPACE}}' namespace is unhealthy and its pod is stuck in CrashLoopBackOff.
+  Use your tools to investigate why the 'frontend' pod keeps restarting and show me
+  the relevant logs. Identify the root cause and tell me how to fix it.
+expected_output: |
+  critical requirements:
+
+  - Expected Tool Call: kubectl get pods (or describe pod) to observe the CrashLoopBackOff state.
+  - Inspects the failing container's logs (e.g. kubectl logs frontend-...) to gather evidence.
+  - Correctly identifies the root cause: the container exits on startup because a required environment variable (DATABASE_URL) is not set.
+  - Recommends a concrete fix: provide the missing DATABASE_URL environment variable to the container (e.g. via env, a ConfigMap, or a Secret) so the process can start.

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -9,7 +9,7 @@ project_root = Path(__file__).resolve().parents[1]
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
-from deployers.factory import get_deployer
+from deployers.factory import get_deployer, NoOpDeployer
 from deployers.gcp.gcp_deployer import GCPDeployer
 from deployers.tf.tf_deployer import TFDeployer
 
@@ -138,3 +138,48 @@ def test_get_deployer_tofu_kind_stack(mock_exists, base_config):
 
     expected_stack_path = str(project_root / "tf" / "prebuilt/kind")
     assert deployer.tf_dir == expected_stack_path
+
+
+# ---------------------------------------------------------------------------
+# NoOpDeployer
+# ---------------------------------------------------------------------------
+
+@patch.dict(os.environ, {"BENCH_NO_INFRA": "true"})
+def test_get_deployer_no_infra_returns_noop(base_config):
+    deployer = get_deployer(
+        {},
+        base_config["project_id"],
+        base_config["cluster_name"],
+    )
+    assert isinstance(deployer, NoOpDeployer)
+
+
+@patch.dict(os.environ, {"BENCH_NO_INFRA": "true"})
+def test_no_infra_takes_precedence_over_infra_config(base_config):
+    """BENCH_NO_INFRA should short-circuit even when a deployer is specified."""
+    deployer = get_deployer(
+        {"deployer": "tofu", "stack": "prebuilt/kind"},
+        base_config["project_id"],
+        base_config["cluster_name"],
+    )
+    assert isinstance(deployer, NoOpDeployer)
+
+
+def test_noop_deployer_up_is_silent(capsys, base_config):
+    d = NoOpDeployer(cluster_name="test-cluster", project_id="test-project")
+    d.up()
+    assert "NoOpDeployer" in capsys.readouterr().out
+
+
+def test_noop_deployer_down_is_silent(capsys, base_config):
+    d = NoOpDeployer(cluster_name="test-cluster", project_id="test-project")
+    d.down()
+    assert "NoOpDeployer" in capsys.readouterr().out
+
+
+def test_noop_deployer_get_cluster_info(base_config):
+    d = NoOpDeployer(cluster_name="test-cluster", project_id="test-project")
+    info = d.get_cluster_info()
+    assert info["name"] == "test-cluster"
+    assert info["project"] == "test-project"
+    assert info["location"] == "local"

--- a/tests/test_ollama_adapters.py
+++ b/tests/test_ollama_adapters.py
@@ -1,0 +1,256 @@
+"""Tests for OllamaClientAdapter and OllamaDeepEvalModel."""
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# llm_adapters uses bare imports (from llm_client import ..., from utils import ...)
+# that resolve relative to the api package directory.
+_api_dir = str(Path(__file__).resolve().parents[1] / "pkg/agents/runner/api")
+if _api_dir not in sys.path:
+    sys.path.insert(0, _api_dir)
+
+from llm_adapters import OllamaClientAdapter
+from pkg.evaluator.evaluate import OllamaDeepEvalModel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _adapter(model="gemma4:e2b"):
+    """Create an OllamaClientAdapter with a mock async client."""
+    with patch.dict(os.environ, {"OLLAMA_BASE_URL": "http://fake:11434/v1",
+                                  "AGENT_MODEL": model}):
+        a = OllamaClientAdapter(model_name=model)
+    a.client = MagicMock()
+    return a
+
+
+def _deep_eval_model(model="gemma4:e2b"):
+    """Create an OllamaDeepEvalModel with a mock sync client."""
+    with patch.dict(os.environ, {"OLLAMA_BASE_URL": "http://fake:11434/v1",
+                                  "JUDGE_MODEL": model}):
+        m = OllamaDeepEvalModel(model_name=model)
+    m.client = MagicMock()
+    return m
+
+
+def _make_tool(name="apply_manifest", description="Apply a k8s manifest", schema=None):
+    t = MagicMock()
+    t.name = name
+    t.description = description
+    t.inputSchema = schema or {"type": "object", "properties": {"manifest": {"type": "string"}}}
+    return t
+
+
+def _make_response(content=None, tool_calls=None):
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def _make_tool_call(name, arguments, call_id="call_abc"):
+    func = SimpleNamespace(name=name, arguments=arguments)
+    return SimpleNamespace(id=call_id, function=func)
+
+
+def _completion(content):
+    """Minimal OpenAI ChatCompletion response for OllamaDeepEvalModel."""
+    msg = SimpleNamespace(content=content)
+    return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+
+# ---------------------------------------------------------------------------
+# OllamaClientAdapter — format_tools
+# ---------------------------------------------------------------------------
+
+class TestFormatTools:
+    def test_single_tool(self):
+        result = _adapter().format_tools([_make_tool()])
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["type"] == "function"
+        assert entry["function"]["name"] == "apply_manifest"
+        assert entry["function"]["description"] == "Apply a k8s manifest"
+
+    def test_parameters_passed_through(self):
+        schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+        result = _adapter().format_tools([_make_tool(schema=schema)])
+        assert result[0]["function"]["parameters"] == schema
+
+    def test_multiple_tools(self):
+        tools = [_make_tool("t1"), _make_tool("t2")]
+        result = _adapter().format_tools(tools)
+        assert [e["function"]["name"] for e in result] == ["t1", "t2"]
+
+    def test_tool_without_input_schema_attribute(self):
+        tool = MagicMock(spec=[])        # no inputSchema attribute
+        tool.name = "no_schema"
+        tool.description = "desc"
+        result = _adapter().format_tools([tool])
+        assert result[0]["function"]["parameters"] == {}
+
+    def test_empty_tool_list(self):
+        assert _adapter().format_tools([]) == []
+
+
+# ---------------------------------------------------------------------------
+# OllamaClientAdapter — extract_function_calls
+# ---------------------------------------------------------------------------
+
+class TestExtractFunctionCalls:
+    def test_no_tool_calls(self):
+        assert _adapter().extract_function_calls(_make_response(content="hi")) == []
+
+    def test_dict_args(self):
+        args = {"manifest": "apiVersion: v1"}
+        tc = _make_tool_call("apply", args, call_id="c1")
+        calls = _adapter().extract_function_calls(_make_response(tool_calls=[tc]))
+        assert calls == [{"name": "apply", "args": args, "id": "c1"}]
+
+    def test_json_string_args_are_parsed(self):
+        args = {"namespace": "default"}
+        tc = _make_tool_call("get", json.dumps(args), call_id="c2")
+        calls = _adapter().extract_function_calls(_make_response(tool_calls=[tc]))
+        assert calls[0]["args"] == args
+
+    def test_malformed_json_string_falls_back_to_empty_dict(self):
+        tc = _make_tool_call("bad", "{not: json}", call_id="c3")
+        calls = _adapter().extract_function_calls(_make_response(tool_calls=[tc]))
+        assert calls[0]["args"] == {}
+
+    def test_multiple_tool_calls(self):
+        tcs = [
+            _make_tool_call("a", {"x": 1}, "id_a"),
+            _make_tool_call("b", '{"y": 2}', "id_b"),
+        ]
+        calls = _adapter().extract_function_calls(_make_response(tool_calls=tcs))
+        assert len(calls) == 2
+        assert calls[0]["name"] == "a"
+        assert calls[1]["args"] == {"y": 2}
+
+
+# ---------------------------------------------------------------------------
+# OllamaClientAdapter — get_text_content
+# ---------------------------------------------------------------------------
+
+class TestGetTextContent:
+    def test_returns_content(self):
+        assert _adapter().get_text_content(_make_response(content="ok")) == "ok"
+
+    def test_none_content_returns_empty_string(self):
+        assert _adapter().get_text_content(_make_response(content=None)) == ""
+
+    def test_empty_string_content(self):
+        assert _adapter().get_text_content(_make_response(content="")) == ""
+
+
+# ---------------------------------------------------------------------------
+# OllamaClientAdapter — _convert_to_openai_messages
+# ---------------------------------------------------------------------------
+
+class TestConvertToOpenAIMessages:
+    def test_system_instruction_prepended(self):
+        msgs = _adapter()._convert_to_openai_messages(
+            [{"role": "user", "content": "hello"}],
+            system_instruction="Be helpful.",
+        )
+        assert msgs[0] == {"role": "system", "content": "Be helpful."}
+        assert msgs[1]["role"] == "user"
+
+    def test_no_system_instruction(self):
+        msgs = _adapter()._convert_to_openai_messages(
+            [{"role": "user", "content": "hi"}], system_instruction=None
+        )
+        assert not any(m["role"] == "system" for m in msgs)
+
+    def test_user_message(self):
+        msgs = _adapter()._convert_to_openai_messages(
+            [{"role": "user", "content": "deploy"}], system_instruction=None
+        )
+        assert msgs == [{"role": "user", "content": "deploy"}]
+
+    def test_assistant_message_no_tool_calls(self):
+        msgs = _adapter()._convert_to_openai_messages(
+            [{"role": "assistant", "content": "done"}], system_instruction=None
+        )
+        assert msgs == [{"role": "assistant", "content": "done"}]
+
+    def test_assistant_message_with_tool_calls(self):
+        contents = [{
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "apply", "args": {"x": 1}, "id": "call_x"}],
+        }]
+        msgs = _adapter()._convert_to_openai_messages(contents, system_instruction=None)
+        tc = msgs[0]["tool_calls"][0]
+        assert tc["type"] == "function"
+        assert tc["id"] == "call_x"
+        assert tc["function"]["name"] == "apply"
+        # args must be serialised to a JSON string in the OpenAI wire format
+        assert tc["function"]["arguments"] == json.dumps({"x": 1})
+
+    def test_tool_call_string_args_passed_through_unchanged(self):
+        contents = [{
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "t", "args": '{"k": "v"}', "id": "c"}],
+        }]
+        msgs = _adapter()._convert_to_openai_messages(contents, system_instruction=None)
+        assert msgs[0]["tool_calls"][0]["function"]["arguments"] == '{"k": "v"}'
+
+    def test_tool_result_message(self):
+        contents = [{"role": "tool", "tool_call_id": "c1", "content": "applied"}]
+        msgs = _adapter()._convert_to_openai_messages(contents, system_instruction=None)
+        assert msgs == [{"role": "tool", "tool_call_id": "c1", "content": "applied"}]
+
+    def test_full_conversation_role_order(self):
+        contents = [
+            {"role": "user", "content": "do X"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"name": "t", "args": {}, "id": "c1"}
+            ]},
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+            {"role": "assistant", "content": "done"},
+        ]
+        msgs = _adapter()._convert_to_openai_messages(contents, system_instruction="sys")
+        assert [m["role"] for m in msgs] == [
+            "system", "user", "assistant", "tool", "assistant"
+        ]
+
+
+# ---------------------------------------------------------------------------
+# OllamaDeepEvalModel
+# ---------------------------------------------------------------------------
+
+class TestOllamaDeepEvalModel:
+    def test_generate_returns_text(self):
+        m = _deep_eval_model()
+        m.client.chat.completions.create.return_value = _completion("The score is 9.")
+        assert m.generate("Evaluate this.") == "The score is 9."
+
+    def test_generate_none_content_returns_empty_string(self):
+        m = _deep_eval_model()
+        m.client.chat.completions.create.return_value = _completion(None)
+        assert m.generate("prompt") == ""
+
+    def test_generate_sends_correct_model_and_messages(self):
+        m = _deep_eval_model(model="gemma4:e2b")
+        m.client.chat.completions.create.return_value = _completion("ok")
+        m.generate("my prompt")
+        kwargs = m.client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == "gemma4:e2b"
+        assert kwargs["messages"] == [{"role": "user", "content": "my prompt"}]
+
+    @pytest.mark.asyncio
+    async def test_a_generate_delegates_to_generate(self):
+        m = _deep_eval_model()
+        m.client.chat.completions.create.return_value = _completion("async result")
+        assert await m.a_generate("prompt") == "async result"
+
+    def test_get_model_name(self):
+        assert _deep_eval_model(model="gemma4:e2b").get_model_name() == "gemma4:e2b"


### PR DESCRIPTION
Closes #70

## Summary

- Adds `OllamaClientAdapter` and `OllamaDeepEvalModel` so benchmarks can run fully offline using a local Ollama server instead of a cloud LLM provider
- Adds `scripts/setup_local_env.sh` to install Ollama, kind, and pull the model in a single step for CI and dev setup
- Adds `NoOpDeployer` (activated by `BENCH_NO_INFRA=true`) to skip OpenTofu provisioning when a cluster is already available locally
- Fixes empty agent responses when `BENCH_USE_MCP=false` by using a separate `SYSTEM_INSTRUCTION_NO_MCP` that does not require tool calls
- Adds `scripts/mock_ollama_server.py` and `scripts/run_ollama_e2e_test.sh` for fully offline end-to-end testing without network access to Ollama's registry
- Adds 31 unit tests covering adapter formatting, message conversion, tool-call extraction, judge model generation, and the NoOpDeployer

## Test plan

- [ ] `pytest tests/test_ollama_adapters.py tests/test_factory.py` passes (31 tests)
- [ ] `bash scripts/run_ollama_e2e_test.sh` completes end-to-end with the mock server
- [ ] With Ollama running locally (`ollama serve`) and `gemma4:e2b` pulled, run a task with `AGENT_PROVIDER=ollama JUDGE_PROVIDER=ollama BENCH_NO_INFRA=true BENCH_USE_MCP=false`