### PR TITLE
Add NoOpDeployer for infrastructure-free local runs

### DIFF
--- a/deployers/factory.py
+++ b/deployers/factory.py
@@ -12,6 +12,29 @@ PROVIDER_RESOLVERS = {
     "kind": resolve_kind_vars,
 }
 
+
+class NoOpDeployer(Deployer):
+    """Pass-through deployer for local testing without infrastructure provisioning."""
+
+    def __init__(self, cluster_name: str, project_id: str):
+        self._cluster_name = cluster_name
+        self._project_id = project_id
+
+    def up(self) -> None:
+        print("[NoOpDeployer] Skipping infrastructure provisioning (BENCH_NO_INFRA=true)")
+
+    def down(self) -> None:
+        print("[NoOpDeployer] Skipping infrastructure teardown (BENCH_NO_INFRA=true)")
+
+    def get_cluster_info(self) -> Dict[str, Any]:
+        return {
+            "name": self._cluster_name,
+            "location": "local",
+            "project": self._project_id,
+            "kubeconfig_path": os.environ.get("KUBECONFIG", ""),
+        }
+
+
 def get_deployer(
     infra_config: Dict[str, Any],
     global_project_id: str,
@@ -31,6 +54,9 @@ def get_deployer(
             deployer_type = cloud_provider
         else:
             deployer_type = "tofu"
+
+    if os.environ.get("BENCH_NO_INFRA", "false").lower() == "true":
+        return NoOpDeployer(cluster_name=global_cluster_name, project_id=global_project_id)
 
     # Resolve Location with strict precedence: argument then GCP_LOCATION env var
     location = global_location or os.environ.get("GCP_LOCATION", "us-central1-a")

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -9,7 +9,7 @@ project_root = Path(__file__).resolve().parents[1]
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
-from deployers.factory import get_deployer
+from deployers.factory import get_deployer, NoOpDeployer
 from deployers.gcp.gcp_deployer import GCPDeployer
 from deployers.tf.tf_deployer import TFDeployer
 
@@ -138,3 +138,48 @@ def test_get_deployer_tofu_kind_stack(mock_exists, base_config):
 
     expected_stack_path = str(project_root / "tf" / "prebuilt/kind")
     assert deployer.tf_dir == expected_stack_path
+
+
+# ---------------------------------------------------------------------------
+# NoOpDeployer
+# ---------------------------------------------------------------------------
+
+@patch.dict(os.environ, {"BENCH_NO_INFRA": "true"})
+def test_get_deployer_no_infra_returns_noop(base_config):
+    deployer = get_deployer(
+        {},
+        base_config["project_id"],
+        base_config["cluster_name"],
+    )
+    assert isinstance(deployer, NoOpDeployer)
+
+
+@patch.dict(os.environ, {"BENCH_NO_INFRA": "true"})
+def test_no_infra_takes_precedence_over_infra_config(base_config):
+    """BENCH_NO_INFRA should short-circuit even when a deployer is specified."""
+    deployer = get_deployer(
+        {"deployer": "tofu", "stack": "prebuilt/kind"},
+        base_config["project_id"],
+        base_config["cluster_name"],
+    )
+    assert isinstance(deployer, NoOpDeployer)
+
+
+def test_noop_deployer_up_is_silent(capsys, base_config):
+    d = NoOpDeployer(cluster_name="test-cluster", project_id="test-project")
+    d.up()
+    assert "NoOpDeployer" in capsys.readouterr().out
+
+
+def test_noop_deployer_down_is_silent(capsys, base_config):
+    d = NoOpDeployer(cluster_name="test-cluster", project_id="test-project")
+    d.down()
+    assert "NoOpDeployer" in capsys.readouterr().out
+
+
+def test_noop_deployer_get_cluster_info(base_config):
+    d = NoOpDeployer(cluster_name="test-cluster", project_id="test-project")
+    info = d.get_cluster_info()
+    assert info["name"] == "test-cluster"
+    assert info["project"] == "test-project"
+    assert info["location"] == "local"


### PR DESCRIPTION
## Summary
Adds a `NoOpDeployer` (activated by `BENCH_NO_INFRA=true`) that skips tofu/GCP cluster provisioning, so the benchmark pipeline can run without infrastructure — useful for testing provider adapters and the evaluator locally. Takes precedence over any task-level `infrastructure` config. Includes unit tests.

## Scope
- `deployers/factory.py` — `NoOpDeployer` + `BENCH_NO_INFRA` handling
- `tests/test_factory.py` — unit tests