### PR TITLE
Add Ollama provider support (agent + judge)

### DIFF
--- a/pkg/agents/runner/api/llm_adapters.py
+++ b/pkg/agents/runner/api/llm_adapters.py
@@ -1,4 +1,5 @@
 import os
+import json
 import base64
 from google import genai
 from google.genai import types
@@ -209,3 +210,87 @@ class AnthropicClientAdapter(LLMClient):
             ],
         })
     return anthropic_messages
+
+
+class OllamaClientAdapter(LLMClient):
+  """Adapter for Ollama via its OpenAI-compatible API."""
+
+  def __init__(self, model_name=None):
+    from openai import AsyncOpenAI
+    if not model_name:
+      model_name = os.environ.get("AGENT_MODEL", "gemma4:2b")
+    base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+    # api_key is required by the openai client but unused by Ollama
+    self.client = AsyncOpenAI(base_url=base_url, api_key="ollama")
+    self.model_name = model_name
+
+  async def generate_content(self, contents, tools, system_instruction):
+    messages = self._convert_to_openai_messages(contents, system_instruction)
+    kwargs = {"model": self.model_name, "messages": messages}
+    if tools:
+      kwargs["tools"] = tools
+    return await self.client.chat.completions.create(**kwargs)
+
+  def format_tools(self, mcp_tools):
+    return [
+      {
+        "type": "function",
+        "function": {
+          "name": tool.name,
+          "description": tool.description,
+          "parameters": tool.inputSchema if hasattr(tool, "inputSchema") else {},
+        },
+      }
+      for tool in mcp_tools
+    ]
+
+  def extract_function_calls(self, response):
+    calls = []
+    message = response.choices[0].message
+    if message.tool_calls:
+      for tc in message.tool_calls:
+        args = tc.function.arguments
+        if isinstance(args, str):
+          try:
+            args = json.loads(args)
+          except json.JSONDecodeError:
+            args = {}
+        calls.append({"name": tc.function.name, "args": args, "id": tc.id})
+    return calls
+
+  def get_text_content(self, response) -> str:
+    content = response.choices[0].message.content
+    return content if content else ""
+
+  def _convert_to_openai_messages(self, contents, system_instruction):
+    messages = []
+    if system_instruction:
+      messages.append({"role": "system", "content": system_instruction})
+    for msg in contents:
+      role = msg["role"]
+      content = msg["content"]
+      if role == "user":
+        messages.append({"role": "user", "content": content})
+      elif role == "assistant":
+        if "tool_calls" in msg:
+          tool_calls = [
+            {
+              "id": tc.get("id") or f"call_{i}",
+              "type": "function",
+              "function": {
+                "name": tc["name"],
+                "arguments": json.dumps(tc["args"]) if isinstance(tc["args"], dict) else tc["args"],
+              },
+            }
+            for i, tc in enumerate(msg["tool_calls"])
+          ]
+          messages.append({"role": "assistant", "content": content or "", "tool_calls": tool_calls})
+        else:
+          messages.append({"role": "assistant", "content": content})
+      elif role == "tool":
+        messages.append({
+          "role": "tool",
+          "tool_call_id": msg.get("tool_call_id", ""),
+          "content": content,
+        })
+    return messages

--- a/pkg/evaluator/evaluate.py
+++ b/pkg/evaluator/evaluate.py
@@ -29,6 +29,7 @@ sys.path.insert(
 from pkg.agents.runner.api.llm_adapters import (
     AnthropicClientAdapter,
     GeminiClientAdapter,
+    OllamaClientAdapter,
 )
 
 from pkg.agents.runner.api.api import run_api_agent
@@ -44,6 +45,8 @@ from deployers.factory import get_deployer
 
 
 SYSTEM_INSTRUCTION = """You are an expert DevOps engineer. When asked to make an app production-ready or perform operational tasks like secret rotation, you MUST apply the changes directly to the GKE cluster and GCP APIs using your tools. Do NOT output bash scripts, templates, or instructions for the user to run manually. You must complete the entire operation yourself using tool calls."""
+
+SYSTEM_INSTRUCTION_NO_MCP = """You are an expert DevOps engineer. Respond with complete, production-ready Kubernetes manifests and configurations that satisfy the request. Output the full YAML or relevant artifacts directly in your response."""
 
 
 def validate_config(role, provider, model):
@@ -133,6 +136,35 @@ class AnthropicDeepEvalModel(DeepEvalBaseLLM):
                 if hasattr(content, "type") and content.type == "text":
                     text += content.text
         return text
+
+    async def a_generate(self, prompt: str) -> str:
+        return self.generate(prompt)
+
+    def get_model_name(self):
+        return self.model_name
+
+
+class OllamaDeepEvalModel(DeepEvalBaseLLM):
+    """Wrapper for Ollama (OpenAI-compatible API) to be used with DeepEval."""
+
+    def __init__(self, model_name=None):
+        from openai import OpenAI
+        if not model_name:
+            model_name = os.environ.get("JUDGE_MODEL", "gemma4:2b")
+        self.model_name = model_name
+        base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+        self.client = OpenAI(base_url=base_url, api_key="ollama")
+        validate_config("judge", "ollama", self.model_name)
+
+    def load_model(self):
+        return self.client
+
+    def generate(self, prompt: str) -> str:
+        response = self.client.chat.completions.create(
+            model=self.model_name,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message.content or ""
 
     async def a_generate(self, prompt: str) -> str:
         return self.generate(prompt)
@@ -257,6 +289,10 @@ def load_configuration_context():
         if not judge_model_name:
             judge_model_name = "claude-opus-4-6"
         judge_model = AnthropicDeepEvalModel(model_name=judge_model_name)
+    elif judge_provider == "ollama":
+        if not judge_model_name:
+            judge_model_name = "gemma4:2b"
+        judge_model = OllamaDeepEvalModel(model_name=judge_model_name)
     else:
         print(
             f"Warning: Unknown judge provider '{judge_provider}'. Defaulting to Gemini."
@@ -317,17 +353,20 @@ def execute_agent(bench_agent_type, agent_target, prompt, context):
             llm_client = GeminiClientAdapter()
         elif provider == "anthropic":
             llm_client = AnthropicClientAdapter()
+        elif provider == "ollama":
+            llm_client = OllamaClientAdapter()
         else:
             raise ValueError(f"Unknown provider: {provider}")
         bench_use_mcp_env = os.environ.get("BENCH_USE_MCP", "true").lower()
         bench_use_mcp = bench_use_mcp_env == "true"
+        sys_instruction = SYSTEM_INSTRUCTION if bench_use_mcp else SYSTEM_INSTRUCTION_NO_MCP
         return asyncio.run(
             run_api_agent(
                 prompt,
                 mcp_server_path,
                 llm_client,
                 bench_use_mcp=bench_use_mcp,
-                system_instruction=SYSTEM_INSTRUCTION,
+                system_instruction=sys_instruction,
             )
         )
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ pytest==9.0.3
 google-genai==2.6.0
 mcp==1.27.1
 anthropic==0.104.1
+openai>=1.0.0
 pyyaml==6.0.3
 pytest-mock==3.15.1

--- a/scripts/setup_ollama.sh
+++ b/scripts/setup_ollama.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Installs Ollama and pulls the model used for local end-to-end testing.
+set -euo pipefail
+
+MODEL="${OLLAMA_MODEL:-gemma4:2b}"
+
+if ! command -v ollama &>/dev/null; then
+  echo "Installing Ollama..."
+  curl -fsSL https://ollama.com/install.sh | sh
+fi
+
+echo "Starting Ollama server in the background..."
+ollama serve &>/tmp/ollama.log &
+OLLAMA_PID=$!
+
+# Wait for Ollama to be ready
+for i in $(seq 1 30); do
+  if curl -sf http://localhost:11434/api/tags &>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+echo "Pulling model: ${MODEL}"
+ollama pull "${MODEL}"
+
+echo ""
+echo "Ollama is running (PID ${OLLAMA_PID}) with model ${MODEL}."
+echo ""
+echo "To run the benchmark locally with Ollama, set:"
+echo "  export AGENT_PROVIDER=ollama"
+echo "  export JUDGE_PROVIDER=ollama"
+echo "  export AGENT_MODEL=${MODEL}"
+echo "  export JUDGE_MODEL=${MODEL}"
+echo "  export OLLAMA_BASE_URL=http://localhost:11434/v1  # default, can omit"

--- a/tests/test_ollama_adapters.py
+++ b/tests/test_ollama_adapters.py
@@ -1,0 +1,256 @@
+"""Tests for OllamaClientAdapter and OllamaDeepEvalModel."""
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# llm_adapters uses bare imports (from llm_client import ..., from utils import ...)
+# that resolve relative to the api package directory.
+_api_dir = str(Path(__file__).resolve().parents[1] / "pkg/agents/runner/api")
+if _api_dir not in sys.path:
+    sys.path.insert(0, _api_dir)
+
+from llm_adapters import OllamaClientAdapter
+from pkg.evaluator.evaluate import OllamaDeepEvalModel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _adapter(model="gemma4:e2b"):
+    """Create an OllamaClientAdapter with a mock async client."""
+    with patch.dict(os.environ, {"OLLAMA_BASE_URL": "http://fake:11434/v1",
+                                  "AGENT_MODEL": model}):
+        a = OllamaClientAdapter(model_name=model)
+    a.client = MagicMock()
+    return a
+
+
+def _deep_eval_model(model="gemma4:e2b"):
+    """Create an OllamaDeepEvalModel with a mock sync client."""
+    with patch.dict(os.environ, {"OLLAMA_BASE_URL": "http://fake:11434/v1",
+                                  "JUDGE_MODEL": model}):
+        m = OllamaDeepEvalModel(model_name=model)
+    m.client = MagicMock()
+    return m
+
+
+def _make_tool(name="apply_manifest", description="Apply a k8s manifest", schema=None):
+    t = MagicMock()
+    t.name = name
+    t.description = description
+    t.inputSchema = schema or {"type": "object", "properties": {"manifest": {"type": "string"}}}
+    return t
+
+
+def _make_response(content=None, tool_calls=None):
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def _make_tool_call(name, arguments, call_id="call_abc"):
+    func = SimpleNamespace(name=name, arguments=arguments)
+    return SimpleNamespace(id=call_id, function=func)
+
+
+def _completion(content):
+    """Minimal OpenAI ChatCompletion response for OllamaDeepEvalModel."""
+    msg = SimpleNamespace(content=content)
+    return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+
+# ---------------------------------------------------------------------------
+# OllamaClientAdapter — format_tools
+# ---------------------------------------------------------------------------
+
+class TestFormatTools:
+    def test_single_tool(self):
+        result = _adapter().format_tools([_make_tool()])
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["type"] == "function"
+        assert entry["function"]["name"] == "apply_manifest"
+        assert entry["function"]["description"] == "Apply a k8s manifest"
+
+    def test_parameters_passed_through(self):
+        schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+        result = _adapter().format_tools([_make_tool(schema=schema)])
+        assert result[0]["function"]["parameters"] == schema
+
+    def test_multiple_tools(self):
+        tools = [_make_tool("t1"), _make_tool("t2")]
+        result = _adapter().format_tools(tools)
+        assert [e["function"]["name"] for e in result] == ["t1", "t2"]
+
+    def test_tool_without_input_schema_attribute(self):
+        tool = MagicMock(spec=[])        # no inputSchema attribute
+        tool.name = "no_schema"
+        tool.description = "desc"
+        result = _adapter().format_tools([tool])
+        assert result[0]["function"]["parameters"] == {}
+
+    def test_empty_tool_list(self):
+        assert _adapter().format_tools([]) == []
+
+
+# ---------------------------------------------------------------------------
+# OllamaClientAdapter — extract_function_calls
+# ---------------------------------------------------------------------------
+
+class TestExtractFunctionCalls:
+    def test_no_tool_calls(self):
+        assert _adapter().extract_function_calls(_make_response(content="hi")) == []
+
+    def test_dict_args(self):
+        args = {"manifest": "apiVersion: v1"}
+        tc = _make_tool_call("apply", args, call_id="c1")
+        calls = _adapter().extract_function_calls(_make_response(tool_calls=[tc]))
+        assert calls == [{"name": "apply", "args": args, "id": "c1"}]
+
+    def test_json_string_args_are_parsed(self):
+        args = {"namespace": "default"}
+        tc = _make_tool_call("get", json.dumps(args), call_id="c2")
+        calls = _adapter().extract_function_calls(_make_response(tool_calls=[tc]))
+        assert calls[0]["args"] == args
+
+    def test_malformed_json_string_falls_back_to_empty_dict(self):
+        tc = _make_tool_call("bad", "{not: json}", call_id="c3")
+        calls = _adapter().extract_function_calls(_make_response(tool_calls=[tc]))
+        assert calls[0]["args"] == {}
+
+    def test_multiple_tool_calls(self):
+        tcs = [
+            _make_tool_call("a", {"x": 1}, "id_a"),
+            _make_tool_call("b", '{"y": 2}', "id_b"),
+        ]
+        calls = _adapter().extract_function_calls(_make_response(tool_calls=tcs))
+        assert len(calls) == 2
+        assert calls[0]["name"] == "a"
+        assert calls[1]["args"] == {"y": 2}
+
+
+# ---------------------------------------------------------------------------
+# OllamaClientAdapter — get_text_content
+# ---------------------------------------------------------------------------
+
+class TestGetTextContent:
+    def test_returns_content(self):
+        assert _adapter().get_text_content(_make_response(content="ok")) == "ok"
+
+    def test_none_content_returns_empty_string(self):
+        assert _adapter().get_text_content(_make_response(content=None)) == ""
+
+    def test_empty_string_content(self):
+        assert _adapter().get_text_content(_make_response(content="")) == ""
+
+
+# ---------------------------------------------------------------------------
+# OllamaClientAdapter — _convert_to_openai_messages
+# ---------------------------------------------------------------------------
+
+class TestConvertToOpenAIMessages:
+    def test_system_instruction_prepended(self):
+        msgs = _adapter()._convert_to_openai_messages(
+            [{"role": "user", "content": "hello"}],
+            system_instruction="Be helpful.",
+        )
+        assert msgs[0] == {"role": "system", "content": "Be helpful."}
+        assert msgs[1]["role"] == "user"
+
+    def test_no_system_instruction(self):
+        msgs = _adapter()._convert_to_openai_messages(
+            [{"role": "user", "content": "hi"}], system_instruction=None
+        )
+        assert not any(m["role"] == "system" for m in msgs)
+
+    def test_user_message(self):
+        msgs = _adapter()._convert_to_openai_messages(
+            [{"role": "user", "content": "deploy"}], system_instruction=None
+        )
+        assert msgs == [{"role": "user", "content": "deploy"}]
+
+    def test_assistant_message_no_tool_calls(self):
+        msgs = _adapter()._convert_to_openai_messages(
+            [{"role": "assistant", "content": "done"}], system_instruction=None
+        )
+        assert msgs == [{"role": "assistant", "content": "done"}]
+
+    def test_assistant_message_with_tool_calls(self):
+        contents = [{
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "apply", "args": {"x": 1}, "id": "call_x"}],
+        }]
+        msgs = _adapter()._convert_to_openai_messages(contents, system_instruction=None)
+        tc = msgs[0]["tool_calls"][0]
+        assert tc["type"] == "function"
+        assert tc["id"] == "call_x"
+        assert tc["function"]["name"] == "apply"
+        # args must be serialised to a JSON string in the OpenAI wire format
+        assert tc["function"]["arguments"] == json.dumps({"x": 1})
+
+    def test_tool_call_string_args_passed_through_unchanged(self):
+        contents = [{
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "t", "args": '{"k": "v"}', "id": "c"}],
+        }]
+        msgs = _adapter()._convert_to_openai_messages(contents, system_instruction=None)
+        assert msgs[0]["tool_calls"][0]["function"]["arguments"] == '{"k": "v"}'
+
+    def test_tool_result_message(self):
+        contents = [{"role": "tool", "tool_call_id": "c1", "content": "applied"}]
+        msgs = _adapter()._convert_to_openai_messages(contents, system_instruction=None)
+        assert msgs == [{"role": "tool", "tool_call_id": "c1", "content": "applied"}]
+
+    def test_full_conversation_role_order(self):
+        contents = [
+            {"role": "user", "content": "do X"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"name": "t", "args": {}, "id": "c1"}
+            ]},
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+            {"role": "assistant", "content": "done"},
+        ]
+        msgs = _adapter()._convert_to_openai_messages(contents, system_instruction="sys")
+        assert [m["role"] for m in msgs] == [
+            "system", "user", "assistant", "tool", "assistant"
+        ]
+
+
+# ---------------------------------------------------------------------------
+# OllamaDeepEvalModel
+# ---------------------------------------------------------------------------
+
+class TestOllamaDeepEvalModel:
+    def test_generate_returns_text(self):
+        m = _deep_eval_model()
+        m.client.chat.completions.create.return_value = _completion("The score is 9.")
+        assert m.generate("Evaluate this.") == "The score is 9."
+
+    def test_generate_none_content_returns_empty_string(self):
+        m = _deep_eval_model()
+        m.client.chat.completions.create.return_value = _completion(None)
+        assert m.generate("prompt") == ""
+
+    def test_generate_sends_correct_model_and_messages(self):
+        m = _deep_eval_model(model="gemma4:e2b")
+        m.client.chat.completions.create.return_value = _completion("ok")
+        m.generate("my prompt")
+        kwargs = m.client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == "gemma4:e2b"
+        assert kwargs["messages"] == [{"role": "user", "content": "my prompt"}]
+
+    @pytest.mark.asyncio
+    async def test_a_generate_delegates_to_generate(self):
+        m = _deep_eval_model()
+        m.client.chat.completions.create.return_value = _completion("async result")
+        assert await m.a_generate("prompt") == "async result"
+
+    def test_get_model_name(self):
+        assert _deep_eval_model(model="gemma4:e2b").get_model_name() == "gemma4:e2b"


### PR DESCRIPTION
## Summary
Adds an OpenAI-compatible **Ollama** integration so the benchmark can run fully locally (agent and/or judge) against Ollama-served models.

## Scope
- `pkg/agents/runner/api/llm_adapters.py` — `OllamaClientAdapter` (agent) + `OllamaDeepEvalModel` (judge)
- `pkg/evaluator/evaluate.py` — `AGENT_PROVIDER=ollama` / `JUDGE_PROVIDER=ollama` routing; plus `SYSTEM_INSTRUCTION_NO_MCP` so models emit direct YAML when `BENCH_USE_MCP=false` (strict instruction-followers previously returned empty responses)
- `requirements.txt` — `openai` client
- `scripts/setup_ollama.sh` — install Ollama + pull model
- `tests/test_ollama_adapters.py` — unit tests