### PR TITLE
Add local end-to-end test harness for the Ollama provider

### DIFF
--- a/scripts/mock_ollama_server.py
+++ b/scripts/mock_ollama_server.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Minimal mock of Ollama's OpenAI-compatible chat API for integration testing.
+
+Detects whether a request is an agent call or a DeepEval GEval call by
+inspecting the prompt, then returns an appropriate canned response.
+"""
+import json
+import time
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+MOCK_MODEL = "gemma4:2b"
+
+AGENT_RESPONSE = (
+    "I'll configure the HTTP-to-HTTPS redirect on public-gw.\n\n"
+    "Here is the HTTPRoute manifest:\n\n"
+    "```yaml\napiVersion: gateway.networking.k8s.io/v1\n"
+    "kind: HTTPRoute\nmetadata:\n  name: https-redirect\n  namespace: default\n"
+    "spec:\n  parentRefs:\n  - group: gateway.networking.k8s.io\n    kind: Gateway\n"
+    "    name: public-gw\n    port: 80\n  rules:\n  - filters:\n"
+    "    - type: RequestRedirect\n      requestRedirect:\n        scheme: https\n"
+    "        statusCode: 301\n```"
+)
+
+# DeepEval GEval asks the judge to produce evaluation *steps* (list) then a *score*.
+# Both must be valid JSON matching the schemas DeepEval expects.
+STEPS_JSON = json.dumps({
+    "steps": [
+        "Check that the output produces a valid Gateway API HTTPRoute manifest.",
+        "Verify the HTTPRoute listens on port 80 and targets public-gw.",
+        "Confirm a RequestRedirect filter sets scheme=https and statusCode=301.",
+    ]
+})
+
+SCORE_JSON = json.dumps({
+    "reason": (
+        "The output is a complete HTTPRoute manifest with a RequestRedirect "
+        "filter targeting port 80 and returning 301 to https."
+    ),
+    "score": 1,
+})
+
+_lock = threading.Lock()
+_call_count = 0
+
+
+def _all_text(body: dict) -> str:
+    return " ".join(m.get("content", "") for m in body.get("messages", []))
+
+
+def _classify(body: dict) -> str:
+    """Return 'steps', 'score', or 'agent'."""
+    text = _all_text(body).lower()
+    # DeepEval GEval step-generation: asks to generate evaluation steps
+    if "generate" in text and "evaluation steps" in text:
+        return "steps"
+    # DeepEval GEval scoring: asks for both score and reason as JSON
+    if '"score"' in text and '"reason"' in text:
+        return "score"
+    return "agent"
+
+
+class MockHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        print(f"[mock] {fmt % args}")
+
+    def _json(self, data, status=200):
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path in ("/v1/models", "/api/tags"):
+            self._json({
+                "object": "list",
+                "data": [{"id": MOCK_MODEL, "object": "model"}],
+                "models": [{"name": MOCK_MODEL}],
+            })
+        else:
+            self._json({"error": "not found"}, 404)
+
+    def do_POST(self):
+        global _call_count
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length))
+
+        with _lock:
+            _call_count += 1
+            n = _call_count
+
+        kind = _classify(body)
+        if kind == "steps":
+            text = STEPS_JSON
+        elif kind == "score":
+            text = SCORE_JSON
+        else:
+            text = AGENT_RESPONSE
+
+        print(f"[mock] call #{n} ({kind})")
+        self._json({
+            "id": f"chatcmpl-{n}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": body.get("model", MOCK_MODEL),
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": text, "tool_calls": None},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 40, "completion_tokens": 80, "total_tokens": 120},
+        })
+
+
+def start(port: int = 11435):
+    srv = HTTPServer(("127.0.0.1", port), MockHandler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    print(f"[mock] listening on http://127.0.0.1:{port}")
+    return srv
+
+
+if __name__ == "__main__":
+    import sys
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 11435
+    srv = start(port)
+    print("Press Ctrl+C to stop.")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        srv.shutdown()

--- a/scripts/run_ollama_e2e_test.sh
+++ b/scripts/run_ollama_e2e_test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# End-to-end test for the Ollama provider integration.
+# Uses a mock Ollama server so no model weights or live cluster are required.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MOCK_PORT="${MOCK_PORT:-11435}"
+TASK_FILE="tasks/generic/gateway-https-redirect/task.yaml"
+
+echo "==> Starting mock Ollama server on port ${MOCK_PORT}"
+python3 scripts/mock_ollama_server.py "${MOCK_PORT}" &
+MOCK_PID=$!
+sleep 1
+curl -sf "http://127.0.0.1:${MOCK_PORT}/v1/models" | python3 -m json.tool || {
+  echo "ERROR: mock server failed to start"; kill "${MOCK_PID}" 2>/dev/null; exit 1
+}
+
+echo ""
+echo "==> Running benchmark task: ${TASK_FILE}"
+echo "    AGENT_PROVIDER=ollama  JUDGE_PROVIDER=ollama  MODEL=gemma4:2b"
+echo ""
+
+export BENCH_AGENT_TYPE=api
+export BENCH_USE_MCP=false
+export BENCH_NO_INFRA=true
+export AGENT_PROVIDER=ollama
+export JUDGE_PROVIDER=ollama
+export AGENT_MODEL=gemma4:2b
+export JUDGE_MODEL=gemma4:2b
+export OLLAMA_BASE_URL="http://127.0.0.1:${MOCK_PORT}/v1"
+export GCP_PROJECT_ID=test-project
+export CLUSTER_NAME=test-cluster
+
+python3 pkg/evaluator/evaluate.py "${TASK_FILE}"
+EXIT_CODE=$?
+
+echo ""
+echo "==> Stopping mock server (PID ${MOCK_PID})"
+kill "${MOCK_PID}" 2>/dev/null || true
+
+exit ${EXIT_CODE}

--- a/scripts/setup_local_env.sh
+++ b/scripts/setup_local_env.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Sets up a local test environment: Ollama (gemma4:2b) + kind cluster.
+# Intended to run as an environment setup script in Claude Code on the web,
+# where its output is cached so subsequent sessions start ready.
+set -euo pipefail
+
+OLLAMA_VERSION="${OLLAMA_VERSION:-v0.30.8}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-gemma4:2b}"
+KIND_CLUSTER="${KIND_CLUSTER:-devops-bench}"
+
+echo "==> Installing system deps"
+apt-get update -qq
+apt-get install -y -qq zstd
+
+echo "==> Installing Ollama ${OLLAMA_VERSION}"
+curl -fL "https://github.com/ollama/ollama/releases/download/${OLLAMA_VERSION}/ollama-linux-amd64.tar.zst" \
+  -o /tmp/ollama.tar.zst
+tar --use-compress-program=unzstd -xf /tmp/ollama.tar.zst -C /usr/local/
+rm /tmp/ollama.tar.zst
+ollama --version
+
+echo "==> Installing kind"
+curl -fsSL "https://github.com/kubernetes-sigs/kind/releases/latest/download/kind-linux-amd64" \
+  -o /usr/local/bin/kind
+chmod +x /usr/local/bin/kind
+kind version
+
+echo "==> Starting Docker daemon"
+dockerd &>/tmp/dockerd.log &
+DOCKERD_PID=$!
+for i in $(seq 1 30); do
+  [ -S /var/run/docker.sock ] && break
+  sleep 1
+done
+
+echo "==> Pre-pulling kind node image (cached for future sessions)"
+docker pull kindest/node:v1.36.1
+
+echo "==> Creating kind cluster: ${KIND_CLUSTER}"
+kind create cluster --name "${KIND_CLUSTER}" --wait 60s
+
+echo "==> Starting Ollama server"
+ollama serve &>/tmp/ollama.log &
+for i in $(seq 1 30); do
+  curl -sf http://localhost:11434/api/tags &>/dev/null && break
+  sleep 1
+done
+
+echo "==> Pulling model: ${OLLAMA_MODEL}"
+ollama pull "${OLLAMA_MODEL}"
+
+echo ""
+echo "Setup complete. To run the benchmark with Ollama + kind:"
+echo "  export AGENT_PROVIDER=ollama JUDGE_PROVIDER=ollama"
+echo "  export AGENT_MODEL=${OLLAMA_MODEL} JUDGE_MODEL=${OLLAMA_MODEL}"
+echo "  export OLLAMA_BASE_URL=http://localhost:11434/v1"


### PR DESCRIPTION
## Summary
Scripts to exercise the local pipeline without model weights or a live cluster.

## Scope
- `scripts/mock_ollama_server.py` — mock of Ollama's OpenAI-compatible chat API; classifies calls as agent/steps/score and returns canned responses so DeepEval GEval metrics complete deterministically
- `scripts/run_ollama_e2e_test.sh` — driver: starts the mock server, sets env, runs `evaluate.py` against a simple task end-to-end
- `scripts/setup_local_env.sh` — one-shot setup of Ollama + kind + node image + model

## Context
**3 of 4** PRs splitting #72. These scripts depend at **runtime** on the Ollama provider (#74) and `NoOpDeployer`/`BENCH_NO_INFRA` (#73) — no file overlap, so it merges cleanly in any order, but it's only *runnable* once those two land. Recommended review/merge order: #73, #74, then this.