### PR TITLE
docs(migration): add kubernetes-sigs migration plan and validation toolkit

### DIFF
--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -1,0 +1,102 @@
+# Installs at: .github/workflows/guardrails.yml in BOTH gke-labs and kubernetes-sigs.
+# CI guardrail: uv sync, ruff, license headers, unit tests. The `detect` job keeps it
+# a green no-op until pyproject.toml + devops_bench/ exist, so it is safe to install before the
+# reorg. The migrated-readonly job is gke-labs-only. Label (labeled/unlabeled) events only run the
+# migrated-readonly flip guard — the build/lint/test matrix is skipped, since labels don't change
+# code. See docs/migration/.
+name: guardrails
+
+on:
+  pull_request:
+    branches: [main]
+    # labeled/unlabeled so applying the 'migrated-override' label re-runs the flip guard
+    # immediately. The build/lint/test jobs skip on label events (per-job `if`s below), so
+    # unrelated label churn never reruns the full matrix.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    # Has the reorg landed? Keeps the workflow a no-op until it has.
+    # Skip on label events: labels don't change code, so there's nothing to build/lint/test.
+    # `guardrails` (needs: detect) cascades to skipped as well; only `migrated-readonly` runs on labels.
+    if: github.event.action != 'labeled' && github.event.action != 'unlabeled'
+    runs-on: ubuntu-latest
+    outputs:
+      ready: ${{ steps.check.outputs.ready }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        run: |
+          set -euo pipefail
+          if [[ -f pyproject.toml && -d devops_bench ]]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+            echo "Target layout present (pyproject.toml + devops_bench/): running full guardrails."
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Target layout not present yet (no pyproject.toml and/or devops_bench/);"
+            echo "::notice::guardrails are a green no-op until the foundation reorg PR lands."
+          fi
+
+  guardrails:
+    needs: detect
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Floor is requires-python (>=3.12); 3.14 is the dev default in .python-version.
+        python-version: ["3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        if: needs.detect.outputs.ready == 'true'
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      - name: Sync (build + install, strict library mode)
+        if: needs.detect.outputs.ready == 'true'
+        run: uv sync --frozen
+
+      - name: Lint
+        if: needs.detect.outputs.ready == 'true'
+        # Lint paths come from [tool.ruff] in pyproject.toml; `.` avoids hardcoding devops_bench.
+        run: uv run ruff check .
+
+      - name: License headers
+        if: needs.detect.outputs.ready == 'true'
+        run: uv run python hack/boilerplate.py --dry-run
+
+      - name: Unit tests
+        if: needs.detect.outputs.ready == 'true'
+        run: uv run pytest tests -q
+
+  migrated-readonly:
+    # gke-labs only: block PRs that edit migrated (upstream-owned) paths. No-op while migrated.bara.sky is
+    # empty. Exempt the back-sync bot's PRs (head branch backsync/*) — mirroring into migrated paths
+    # is exactly its job. Runs on code pushes to a PR and, for label events, ONLY when the
+    # 'migrated-override' label itself changes — so unrelated label churn triggers no CI at all.
+    if: >-
+      github.event_name == 'pull_request'
+      && github.repository == 'gke-labs/devops-bench'
+      && !startsWith(github.head_ref, 'backsync/')
+      && ((github.event.action != 'labeled' && github.event.action != 'unlabeled')
+      || github.event.label.name == 'migrated-override')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # need the base branch to diff the PR range
+      - name: Block edits to migrated (read-only) paths
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          # Override hook: the 'migrated-override' label (passed via env, not interpolated).
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+        run: ./hack/check-migrated-readonly.sh

--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -1,9 +1,9 @@
 # Installs at: .github/workflows/guardrails.yml in BOTH gke-labs and kubernetes-sigs.
-# CI guardrail: uv sync, ruff, license headers, unit tests. The `detect` job keeps it
-# a green no-op until pyproject.toml + devops_bench/ exist, so it is safe to install before the
-# reorg. The migrated-readonly job is gke-labs-only. Label (labeled/unlabeled) events only run the
-# migrated-readonly flip guard — the build/lint/test matrix is skipped, since labels don't change
-# code. See docs/migration/.
+# CI guardrail: uv sync, ruff, unit tests. Lint/test are scoped to the devops_bench
+# component (devops_bench/ + tests/unit/) — the rest of the repo is not yet compliant, so it is
+# deliberately left out of scope. The migrated-readonly job is gke-labs-only. Label
+# (labeled/unlabeled) events only run the migrated-readonly flip guard — the build/lint/test matrix
+# is skipped, since labels don't change code. See docs/migration/.
 name: guardrails
 
 on:
@@ -20,30 +20,10 @@ permissions:
   contents: read
 
 jobs:
-  detect:
-    # Has the reorg landed? Keeps the workflow a no-op until it has.
-    # Skip on label events: labels don't change code, so there's nothing to build/lint/test.
-    # `guardrails` (needs: detect) cascades to skipped as well; only `migrated-readonly` runs on labels.
-    if: github.event.action != 'labeled' && github.event.action != 'unlabeled'
-    runs-on: ubuntu-latest
-    outputs:
-      ready: ${{ steps.check.outputs.ready }}
-    steps:
-      - uses: actions/checkout@v4
-      - id: check
-        run: |
-          set -euo pipefail
-          if [[ -f pyproject.toml && -d devops_bench ]]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-            echo "Target layout present (pyproject.toml + devops_bench/): running full guardrails."
-          else
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Target layout not present yet (no pyproject.toml and/or devops_bench/);"
-            echo "::notice::guardrails are a green no-op until the foundation reorg PR lands."
-          fi
-
   guardrails:
-    needs: detect
+    # Skip on label events: labels don't change code, so there's nothing to build/lint/test.
+    # Only `migrated-readonly` runs on label changes.
+    if: github.event.action != 'labeled' && github.event.action != 'unlabeled'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -54,28 +34,20 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        if: needs.detect.outputs.ready == 'true'
         uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
       - name: Sync (build + install, strict library mode)
-        if: needs.detect.outputs.ready == 'true'
         run: uv sync --frozen
 
       - name: Lint
-        if: needs.detect.outputs.ready == 'true'
-        # Lint paths come from [tool.ruff] in pyproject.toml; `.` avoids hardcoding devops_bench.
-        run: uv run ruff check .
-
-      - name: License headers
-        if: needs.detect.outputs.ready == 'true'
-        run: uv run python hack/boilerplate.py --dry-run
+        # Scoped to the devops_bench component; the rest of the repo is not yet compliant.
+        run: uv run ruff check devops_bench tests/unit
 
       - name: Unit tests
-        if: needs.detect.outputs.ready == 'true'
-        run: uv run pytest tests -q
+        run: uv run pytest tests/unit -q
 
   migrated-readonly:
     # gke-labs only: block PRs that edit migrated (upstream-owned) paths. No-op while migrated.bara.sky is

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,0 +1,252 @@
+# Migrating `devops-bench` to kubernetes-sigs: maintainer runbook
+
+This document is the official, step-by-step action plan for **`gke-labs` repository maintainers** migrating `devops-bench` to its permanent upstream home in `kubernetes-sigs`.
+
+---
+
+## 1. The migration model in one minute
+
+```text
+                              [PHASE 1]
+                     Restructure gke-labs in-place
+                     (All code under devops_bench/)
+                                  |
+                                  v
++------------------+          [PHASE 2]           +-------------------+
+|     gke-labs     |  ------------------------->  |  kubernetes-sigs  |
+|  (devops-bench)  |     (A) Forward PR export    |  (devops-bench)   |
+|                  |     (Using prep-export.sh)   |                   |
+|                  |                              |                   |
+|  Source of truth |  <-------------------------  |  Source of truth  |
+|   for remaining  |       (B) Back-sync bot      |    for migrated   |
+|      modules     |     (copy.bara.sky + GHA)    |      modules      |
++------------------+                              +-------------------+
+                                  |
+                                  v
+                              [PHASE 3]
+                     All modules migrated; archive
+                         and retire gke-labs
+```
+
+- **Phase 1 (Restructure)**: Restructure the `gke-labs` repository in-place into the target layout before exporting any files upstream.
+- **Phase 2 (Migrate Module-by-Module)**: Export files chunk-by-chunk. For each migrated module:
+  - **Flow A (Export)**: Create an upstream PR. Once merged, uncomment its paths in `migrated.bara.sky` (this "flips" the source of truth).
+  - **Flow B (Back-sync)**: A scheduled, automated Copybara bot syncs upstream edits back to `gke-labs` so the remaining modules can import them and keep building.
+- **Phase 3 (Retire)**: Once 100% of required modules are migrated, archive and retire the `gke-labs` repository.
+
+### Document index
+- For the target directory layout and path mapping, see [directory-structure.md](./directory-structure.md).
+- For a deep dive into component design and principles, see [component-design.md](./component-design.md).
+- For the Stage-by-Stage PR sequence, see [pr-plan.md](./pr-plan.md).
+- For instructions on validating the setup on a test branch, see [VALIDATION.md](./VALIDATION.md).
+
+---
+
+## 2. Maintainer prerequisites
+
+Before executing any commands, ensure you have:
+1. Created a personal fork of `kubernetes-sigs/devops-bench` on GitHub.
+2. Signed the **CNCF CLA (Contributor License Agreement)**.
+3. Authenticated your local GitHub CLI (`gh auth login`).
+4. Set your local git identity to match your CNCF CLA email (`git config --global user.email`).
+
+---
+
+## 3. Phase 1: Restructure `gke-labs` in-place
+
+Restructure `gke-labs` before pushing any code upstream. No upstream PRs should be created until this stage is green.
+
+1. **Set Up the Toolchain**: 
+   - Add `pyproject.toml` (referencing Hatchling and `ruff` configurations), `uv.lock`, and `.python-version` to the `gke-labs` repo. (`.github/workflows/guardrails.yml` and the `hack/check-migrated-readonly.sh` guard it invokes are **pre-installed in the repository and act as a green no-op (see [Section 6](#6-toolkit-installation-locations)) and stay a green no-op until these manifests and `devops_bench/` land.)
+2. **Reorganize Code Paths**:
+   - Move `pkg/` into the `devops_bench/` namespace.
+   - Restructure submodules and write companion unit tests directly inside `tests/`.
+   - Reorganize Terraform files from `tf/` to `infra/`.
+3. **Verify Locally**:
+   - Run the local testing and linting suite:
+     ```bash
+     uv sync --all-extras
+     uv run ruff check .
+     uv run pytest tests/ -v
+     ```
+4. **Merge and Verify CI**:
+   - Merge the restructure PR into the `gke-labs` `main` branch. Ensure the GitHub Actions `guardrails.yml` run is green.
+
+---
+
+## 4. Phase 2: Migrate module by module
+
+Follow the 5-stage order defined in [pr-plan.md](./pr-plan.md).
+
+### Step 2.1: Export a module (Flow A)
+
+For each module (e.g., `gemini` CLI agent):
+
+#### Remote Setup Strategy
+
+Before executing Flow A, ensure your local repository is set up with three distinct remotes:
+- `origin`: Points to your personal GitHub fork (e.g., `https://github.com/YOUR_USERNAME/devops-bench.git`).
+- `gkelabs`: Points to the source incubator repository (`https://github.com/gke-labs/devops-bench.git`).
+- `upstream`: Points to the canonical target repository (`https://github.com/kubernetes-sigs/devops-bench.git`).
+
+If you cloned directly from `gke-labs`, rename the default `origin` remote first:
+```bash
+git remote rename origin gkelabs
+git remote add origin https://github.com/YOUR_USERNAME/devops-bench.git
+git remote add upstream https://github.com/kubernetes-sigs/devops-bench.git
+```
+
+1. Set up remote endpoints in your local clone:
+   ```bash
+   git remote add gkelabs  https://github.com/gke-labs/devops-bench.git
+   git remote add upstream https://github.com/kubernetes-sigs/devops-bench.git
+   ```
+2. Run `prep-export.sh` to compile a clean, scoped branch containing only the desired files and their unit tests, branched directly off `upstream/main`:
+   ```bash
+   ./hack/prep-export.sh \
+     --branch add-gemini-agent \
+     --paths "devops_bench/agents/cli/gemini.py tests/test_factory.py"
+   ```
+3. Push the branch to your fork and submit an upstream Pull Request:
+   ```bash
+   git push origin add-gemini-agent
+   gh pr create --repo kubernetes-sigs/devops-bench --base main --fill
+   ```
+4. Respond to upstream review comments and complete the merge into `kubernetes-sigs/devops-bench`.
+
+---
+
+### Step 2.2: Flip the module frontier (Optional / Automated)
+
+Once the upstream PR merges, its ownership must be flipped in `gke-labs`. While you can do this manually, **this step is automated** by the periodic `suggest-flips` workflow, which uncomments the paths and submits a flip PR automatically.
+
+#### Automated path (Recommended)
+Simply wait for the periodic `suggest-flips` GitHub Action to detect the upstream merge. It will automatically:
+1. Identify the newly merged paths.
+2. Uncomment them in `migrated.bara.sky`.
+3. Open a pull request in `gke-labs` to lock the paths and activate the back-sync bot.
+
+#### Manual path (Fallback)
+If you need to flip the frontier immediately without waiting for the scheduled workflow:
+
+1. Open `migrated.bara.sky` at the `gke-labs` repository root.
+2. **Uncomment** the lines corresponding to the migrated paths (both implementation and unit tests):
+   ```python
+   MIGRATED = [
+       # ...
+       "devops_bench/agents/cli/**",
+       "tests/agents/**",
+       # ...
+   ]
+   ```
+3. Verify the status locally:
+   ```bash
+   ./hack/migration-status.sh
+   ```
+   *Expected Outcome*: The uncommented paths will move from "not started" to the "Migrated" list.
+4. Merge this change into the `gke-labs` `main` branch via a standard pull request.
+
+> [!NOTE]
+> Uncommenting a line activates the **Read-Only Guard** in `gke-labs` CI. From this moment, any PR in `gke-labs` that attempts to mutate those paths will be rejected by `check-migrated-readonly.sh`. Edits must now be made upstream.
+
+---
+
+### Step 2.3: Manage the back-sync bot (Flow B)
+
+With the frontier updated, the back-sync bot mirrors upstream changes back to `gke-labs`, ensuring remaining modules can import them and build successfully.
+
+#### Bot automation setup (one-time)
+The back-sync runs as a dedicated, allowlisted bot account,
+[`devops-bench-sync-bot`](https://github.com/devops-bench-sync-bot) (committer
+`devops-bench-sync-bot@google.com`), **not** the built-in `github-actions[bot]`. This keeps the bot's
+push/PR identity stable and allowlistable for the migration.
+
+1. Ensure the `devops-bench-sync-bot` GitHub account has write access to `gke-labs/devops-bench`.
+2. Create a (fine-grained) **PAT** for that account scoped to push branches and open PRs on the repo.
+3. In `gke-labs` settings, add it as the repository secret **`SYNC_BOT_TOKEN`** (the name
+   `backsync.yml` reads). A PAT acts as a normal user, so the *"Allow GitHub Actions to create and
+   approve pull requests"* setting is **not** required.
+
+The bot runs `.github/workflows/backsync.yml` daily via cron or on demand via `workflow_dispatch`,
+authenticating with `SYNC_BOT_TOKEN`.
+
+#### Running locally or debugging
+```bash
+# Real run (push/PR as the bot): use the bot's PAT
+export GITHUB_TOKEN="$SYNC_BOT_TOKEN"
+./hack/backsync.sh
+
+# Dry-run only: your own token is fine (nothing is pushed, no PR is opened)
+export GITHUB_TOKEN="$(gh auth token)"
+./hack/backsync.sh --dry-run
+```
+The git **committer** is stamped as `devops-bench-sync-bot` regardless of the token; **authors** stay
+as the original upstream contributors (see the CLA note below).
+
+> [!WARNING]
+> **CLA Enforcement on Back-Syncs**: The back-sync bot runs Copybara in `ITERATIVE` mode with `pass_thru` author preservation. If an upstream commit is authored by a contributor who has **not** signed the `gke-labs` CLA, the back-sync PR in `gke-labs` will be blocked until they sign. Do not change this configuration; squashing commits into a bot-authored commit violates license tracking and bypasses the security gate.
+
+---
+
+### Step 2.4: Leverage `suggest-flips` automation
+
+To reduce manual tracking, the **`suggest-flips`** automated workflow (`.github/workflows/suggest-flips.yml`) runs weekly or on-demand:
+1. It compares local paths against what currently exists on `upstream/main`.
+2. It automatically uncomments any paths in `migrated.bara.sky` that have successfully landed upstream.
+3. It opens a Pull Request in `gke-labs` with the suggested flips for maintainer review.
+
+---
+
+## 5. Phase 3: Archive and retire `gke-labs`
+
+When `migrated.bara.sky` includes 100% of paths:
+1. Verify that `kubernetes-sigs/devops-bench` is fully functional and running tests successfully.
+2. Disable the `.github/workflows/backsync.yml` and `suggest-flips.yml` pipelines in `gke-labs`.
+3. Put a deprecation banner on the `gke-labs` `README.md` redirecting users to the upstream repo.
+4. Archive the `gke-labs/devops-bench` repository.
+
+---
+
+## 6. Toolkit installation locations
+
+Most files in `docs/migration/` are **inert templates**: GitHub Actions only runs workflows under
+`.github/workflows/`, and Copybara plus the `hack/` scripts resolve `copy.bara.sky` and
+`migrated.bara.sky` from the repo root. To activate, each must be copied to the destination below. The
+active copies are kept **byte-identical** to these templates (so they can be diffed); the templates
+remain the source for the eventual `kubernetes-sigs` install.
+
+**Initially, only the CI guardrail is installed in `gke-labs`** (see the note below). Every row
+marked ⛔ is still an inert template that **must still be installed** in a later step.
+
+| Source File in `docs/migration/` | Active Target Destination | Host Repository | Status | Purpose |
+|---|---|---|---|---|
+| `workflows/guardrails.yml` | `.github/workflows/guardrails.yml` | **Both** | ✅ Installed in `gke-labs` (this PR); ⛔ TODO in `kubernetes-sigs` | CI testing, ruff lints, header checks |
+| `hack/check-migrated-readonly.sh` | `hack/check-migrated-readonly.sh` | `gke-labs` | ✅ Installed (this PR) — invoked by `guardrails.yml` | Blocks edits to migrated files |
+| `migrated.bara.sky` | `migrated.bara.sky` (Root) | `gke-labs` | ⛔ Not yet installed | Single source-of-truth frontier |
+| `copy.bara.sky` | `copy.bara.sky` (Root) | `gke-labs` | ⛔ Not yet installed | Back-sync bot configuration |
+| `workflows/backsync.yml` | `.github/workflows/backsync.yml` | `gke-labs` | ⛔ Not yet installed (needs `SYNC_BOT_TOKEN`) | Automated back-sync GHA pipeline |
+| `workflows/suggest-flips.yml` | `.github/workflows/suggest-flips.yml` | `gke-labs` | ⛔ Not yet installed | Suggests flips in `migrated.bara.sky` |
+| `hack/prep-export.sh` | `hack/prep-export.sh` | `gke-labs` | ⛔ Not yet installed | Pulls files and stages upstream branch |
+| `hack/backsync.sh` | `hack/backsync.sh` | `gke-labs` | ⛔ Not yet installed | Runs Copybara locally or via CI |
+| `hack/migration-status.sh` | `hack/migration-status.sh` | `gke-labs` | ⛔ Not yet installed | Migration progress CLI tracker |
+
+> [!IMPORTANT]
+> **`guardrails.yml` is live and active in `gke-labs`, but the rest of the toolkit is not; it still must be installed.**
+> - The workflow is a deliberate **green no-op until the Phase-1 toolchain lands**: its `detect` job
+>   short-circuits the build/lint/test matrix until `pyproject.toml` + `devops_bench/` exist.
+> - Its `migrated-readonly` job (gke-labs only) shells out to `hack/check-migrated-readonly.sh`, so that
+>   one script is installed alongside it. With no `migrated.bara.sky` at the root yet, the guard cleanly
+>   no-ops ("nothing is locked yet"); installing `migrated.bara.sky` later *arms* it.
+> - **Still to do** (the ⛔ rows above): install `migrated.bara.sky` + `copy.bara.sky` at the root,
+>   `backsync.yml` + `suggest-flips.yml` under `.github/workflows/`, and the remaining `hack/` scripts,
+>   plus the one-time back-sync bot setup (`SYNC_BOT_TOKEN`, §2.3). These come online in Phase 2.
+
+---
+
+## 7. Crucial do's and don'ts
+
+* **DO** complete Phase 1 restructure entirely before sending the first forward PR.
+* **DO** include unit tests in the same forward PR as the code files.
+* **DO** develop migrated files exclusively in `kubernetes-sigs` once they have been flipped.
+* **DON'T** edit a migrated path directly inside the `gke-labs` repo. The back-sync bot will automatically overwrite/revert your edits.
+* **DON'T** let the back-sync bot sync manifests (`pyproject.toml`, `uv.lock`, `.python-version`, `LICENSE`). These are marked as `NEVER_SYNC` and are managed manually per-repo to prevent version skew and dependency conflicts.

--- a/docs/migration/VALIDATION.md
+++ b/docs/migration/VALIDATION.md
@@ -1,0 +1,307 @@
+# Migration: Validation plan and runbook
+
+### Documentation directory map
+- For high-level steps for gke-labs maintainers, see [README.md](./README.md).
+- For a deep dive into component design and principles, see [component-design.md](./component-design.md).
+- For target directory layouts and glossary, see [directory-structure.md](./directory-structure.md).
+- For the phased pull request deployment sequence, see [pr-plan.md](./pr-plan.md).
+
+This document provides a step-by-step, executable runbook designed to validate the entire migration toolchain, scripts, and CI configurations on an isolated test branch inside `gke-labs/devops-bench` before touching any real files.
+
+---
+
+## 1. Overview of the validation strategy
+
+We validate the migration mechanics in layers, starting with offline static analysis, moving to an isolated local git sandbox, and finally dry-running the GitHub Action workflows:
+
+```
++------------------------------------+
+|  Phase A: Setup Validation Branch  |  <- Copy toolkit scripts to active folders
++------------------------------------+
+                 |
+                 v
++------------------------------------+
+|  Phase B: Local Tooling Dry-Runs   |  <- Check status, mock readonly guard
++------------------------------------+
+                 |
+                 v
++------------------------------------+
+|   Phase C: Git-Remote Sandbox      |  <- Run local file:// remotes to test
+|    (Proves Flow A & Flow B)        |     prep-export.sh & Copybara back-sync
++------------------------------------+
+                 |
+                 v
++------------------------------------+
+|    Phase D: GitHub Actions CI      |  <- Push branch to test guardrails.yml
+|          (Real Dry-Run)            |     and check-migrated-readonly.sh
++------------------------------------+
+```
+
+---
+
+## Phase A: Setup the validation branch
+
+To keep your working tree clean, we create a temporary validation branch in your local clone of `gke-labs/devops-bench`.
+
+1. **Create and Switch to the Test Branch**:
+   ```bash
+   # Save the root path of your local clone for reference in sandbox phases
+   REPO_ROOT="$(pwd)"
+   git checkout -b migration-validation-sandbox
+   ```
+2. **Deploy the Toolkit to Active Locations**:
+   Run the following commands to copy scripts, workflows, and configurations from `docs/migration/` into their active directories:
+   ```bash
+   # Create directories
+   mkdir -p hack .github/workflows
+
+   # Copy configurations and schemas
+   cp docs/migration/migrated.bara.sky .
+   cp docs/migration/copy.bara.sky .
+
+   # Copy scripts and make them executable
+   cp docs/migration/hack/* hack/
+   chmod +x hack/*.sh
+
+   # Copy workflows
+   cp docs/migration/workflows/* .github/workflows/
+   ```
+3. **Commit the Toolkit Draft**:
+   ```bash
+   # Create a dummy file to represent a module we want to migrate
+   mkdir -p devops_bench/core
+   echo "print('registry')" > devops_bench/core/registry.py
+
+   git add migrated.bara.sky copy.bara.sky hack/ .github/workflows/ devops_bench/
+   git commit -m "test: draft migration toolkit and dummy module for sandbox validation"
+   ```
+
+---
+
+## Phase B: Local tooling dry-runs
+
+Verify that local scripts can parse configurations and execute logic with the current state of the repository.
+
+### 1. Test the migration tracker
+Execute the status script to confirm it properly tracks migrated vs. remaining packages:
+```bash
+./hack/migration-status.sh
+```
+*Expected Output*: Since `migrated.bara.sky` is empty, the script should report **100% Tasks Remaining** and display a complete list of legacy packages still needing migration.
+
+### 2. Test the Read-Only Guard (Negative/Fail Test)
+We will simulate a scenario where a developer attempts to modify a migrated path.
+
+1. Add a dummy path to `migrated.bara.sky`:
+   ```python
+   # Edit migrated.bara.sky to simulate a migrated folder
+   MIGRATED = [
+       "devops_bench/tasks/**",
+   ]
+   ```
+2. Create a dummy file under that simulated migrated path, and commit both files to ensure they are part of HEAD:
+   ```bash
+   mkdir -p devops_bench/tasks
+   echo "print('edit')" > devops_bench/tasks/schema.py
+   git add migrated.bara.sky devops_bench/tasks/schema.py
+   git commit -m "test: simulate violation of migrated path"
+   ```
+3. Run the read-only guard script, simulating a pull request targeting `main`:
+   ```bash
+   # Stub BASE_REF as HEAD~1 to compare current branch commits
+   BASE_REF=HEAD~1 ./hack/check-migrated-readonly.sh
+   ```
+   *Expected Output*: The script must print a failure message and exit with code `1`, indicating that edits to `devops_bench/tasks/schema.py` are blocked.
+
+### 3. Test the read-only guard bypass (pass test)
+Verify that the `migrated-override` label or the back-sync bot branch can successfully bypass the guard.
+
+1. Test back-sync branch override:
+   ```bash
+   # Simulate running inside the back-sync bot branch
+   HEAD_REF="backsync/from-upstream" BASE_REF=HEAD~1 ./hack/check-migrated-readonly.sh
+   ```
+   *Expected Output*: The guard should print a bypass notice and exit with code `0` (Success).
+
+2. Test local environment variable override bypass:
+   ```bash
+   MIGRATED_OVERRIDE=1 BASE_REF=HEAD~1 ./hack/check-migrated-readonly.sh
+   ```
+   *Expected Output*: The guard should print a bypass notice and exit with code `0` (Success).
+
+---
+
+## Phase C: Git-remote sandbox (local file://)
+
+This phase simulates the real interaction between `gke-labs` and `kubernetes-sigs` using local git repositories acting as remotes. This completely validates `prep-export.sh` (Flow A) and Copybara (Flow B) without touching GitHub.
+
+> [!IMPORTANT]
+> **Prerequisites:** You must have Docker installed and running locally, as the back-sync validation executes Copybara via a Docker container runner.
+
+```
+       /tmp/sandbox-incubator/ (Local gke-labs clone)
+         /               ^
+  Flow A/             (B) Back-sync
+       v               /
+/tmp/sandbox-canonical/ (Local upstream repo)
+```
+
+1. **Initialize the Mock Repositories**:
+   Run the following block of commands to set up the sandbox directories:
+   ```bash
+   # 1. Create directory structures
+   mkdir -p /tmp/sandbox-canonical.git
+   mkdir -p /tmp/sandbox-incubator-workspace
+
+   # 2. Initialize a bare repository representing the upstream canonical (kubernetes-sigs)
+   git init --bare /tmp/sandbox-canonical.git
+
+   # Initialize the bare repo with a main branch containing an initial commit
+   git clone /tmp/sandbox-canonical.git /tmp/sandbox-canonical-init
+   cd /tmp/sandbox-canonical-init
+   git checkout -b main
+   echo "# Upstream Repository" > README.md
+   git add README.md
+   git commit -m "Initial commit"
+   git push origin main
+   cd -
+   rm -rf /tmp/sandbox-canonical-init
+
+   # 3. Create a workspace that clones gke-labs and points to your sandbox branch
+   cd /tmp/sandbox-incubator-workspace
+   git clone -b migration-validation-sandbox "${REPO_ROOT}" .
+
+   # Configure the mock remote tracking endpoints for sandbox testing
+   git remote add gkelabs "${REPO_ROOT}"
+   git remote add upstream /tmp/sandbox-canonical.git
+    
+   # 4. Point the local configurations to the sandbox path instead of GitHub
+   # Modify copy.bara.sky destinations to target the local directories
+   sed -i.bak 's|https://github.com/kubernetes-sigs/devops-bench.git|file:///tmp/sandbox-canonical.git|g' copy.bara.sky
+   sed -i.bak "s|https://github.com/gke-labs/devops-bench.git|file://${REPO_ROOT}|g" copy.bara.sky
+   rm -f copy.bara.sky.bak
+   git commit -am "test: target local sandbox remotes in copy.bara.sky"
+   ```
+
+2. **Validate Flow A — `prep-export.sh`**:
+   Verify that we can assemble and package a branch containing only specific files to export:
+   ```bash
+   # Fetch from our configured sandbox remotes
+   git fetch --all 2>/dev/null || true
+
+   # Run prep-export to package devops_bench/core files (pointing to our validation branch as the source)
+   ./hack/prep-export.sh \
+     --branch test-export-core \
+     --src-ref migration-validation-sandbox \
+     --paths "devops_bench/core/registry.py"
+   ```
+   *Expected Output*: The script should successfully package `devops_bench/core/registry.py`, create a new branch `test-export-core` starting off `upstream-mock/main`, preserve your author identity, and add a DCO `Signed-off-by` line. Verify the commit history:
+   ```bash
+   git log -n 1 --stat test-export-core
+   ```
+
+3. **Validate Flow B: Copybara back-sync bot**:
+   Ensure Copybara can successfully read from the mock upstream and open a PR back into your local workspace.
+
+   *Prerequisite*: This test requires Docker (or the native Copybara CLI tool) to be installed locally to run `backsync.sh`.
+   ```bash
+    # Prepare the mock upstream with a commit
+    cd /tmp
+    git clone /tmp/sandbox-canonical.git sandbox-canonical-clone
+    cd sandbox-canonical-clone
+    mkdir -p devops_bench/core
+    echo "# Upstream edit" >> devops_bench/core/registry.py
+    git add devops_bench/core/registry.py
+    git commit -m "feat: upstream change to registry" --author="External Contributor <external@example.com>"
+    git push origin HEAD:main
+
+    # Back inside the incubator workspace, add the path to migrated.bara.sky
+    cd /tmp/sandbox-incubator-workspace
+    echo 'MIGRATED = ["devops_bench/core/**"]' > migrated.bara.sky
+    git commit -am "test: uncomment core path in migrated.bara.sky"
+
+    # Execute a local dry-run of Copybara
+    GITHUB_TOKEN=mock-token ./hack/backsync.sh --dry-run
+    ```
+   *Expected Output*: The Copybara output should list the diff importing the upstream commit `feat: upstream change to registry` authored by `External Contributor <external@example.com>`, verifying that **ITERATIVE** mode correctly preserved authorship and history.
+
+4. **Verify authorship and committer identity (CLA-critical)**:
+   The gke-labs CLA gate is author-keyed; commits must preserve the real upstream author, while the committer must be the allowlisted migration bot (see [README.md](./README.md) §4 Step 2.3 for details). Run these assertions from the workspace root:
+   ```bash
+   # (a) Author preserved — the dry-run preview shows the upstream contributor, not the bot.
+   GITHUB_TOKEN=mock-token ./hack/backsync.sh --dry-run 2>&1 \
+     | grep -q "External Contributor <external@example.com>" \
+     && echo "PASS: author preserved" || echo "FAIL: author not preserved"
+
+   # (b) Committer wired to the allowlisted bot. (A --dry-run against a file:// remote does not
+   #     materialize a commit object, so assert the committer configured on the run command.)
+   grep -qE -- '--git-committer-name +"devops-bench-sync-bot"'                hack/backsync.sh \
+     && grep -qE -- '--git-committer-email +"devops-bench-sync-bot@google.com"' hack/backsync.sh \
+     && echo "PASS: committer = devops-bench-sync-bot" || echo "FAIL: committer not the bot"
+
+   # (c) Attribution-safe config: pass_thru (not overwrite) + ITERATIVE (not SQUASH).
+   grep -q "authoring.pass_thru" copy.bara.sky && grep -q 'mode = "ITERATIVE"' copy.bara.sky \
+     && echo "PASS: pass_thru + ITERATIVE" || echo "FAIL: authoring/mode would drop attribution"
+
+   # (d) Workflows act AS the bot (its PAT), not the built-in github-actions[bot].
+   grep -q "secrets.SYNC_BOT_TOKEN" .github/workflows/backsync.yml \
+     && grep -q "secrets.SYNC_BOT_TOKEN" .github/workflows/suggest-flips.yml \
+     && echo "PASS: workflows use the bot PAT" || echo "FAIL: workflows not using SYNC_BOT_TOKEN"
+   ```
+   *Expected Output*: all four checks print `PASS`.
+
+   > [!NOTE]
+   > `git.github_pr_destination` needs the GitHub API, so it cannot open a PR against the `file://`
+   > sandbox — the committer field is only *materialized* in a real run. To prove it end to end,
+   > inspect a real back-sync PR's commit (or run Copybara once into a local bare repo via
+   > `git.destination`) and confirm
+   > `git log -1 --format='author=%an <%ae>%ncommitter=%cn <%ce>'` shows the upstream author with
+   > `devops-bench-sync-bot <devops-bench-sync-bot@google.com>` as the committer.
+
+---
+
+## Phase D: GitHub Actions CI dry-run
+
+Validate that the GitHub Action workflows trigger, pass, and fail exactly when they should in the real GitHub interface.
+
+1. **Push the Validation Branch**:
+   Push your `migration-validation-sandbox` branch to the real `gke-labs` repository:
+   ```bash
+   cd "${REPO_ROOT}"
+   git push origin migration-validation-sandbox
+   ```
+
+2. **Verify Guardrails Auto-Activation**:
+   Navigate to the GitHub Actions tab on your repository.
+   - Verify that `guardrails.yml` triggered.
+   - *Expected Outcome*: Since we have not done a full restructure yet, the `detect` stage should return `ready=false`, causing the rest of the build, test, and lint stages to be skipped as green no-ops.
+
+3. **Verify Read-Only Guard on a Pull Request**:
+   To test the flip guard in the real CI interface:
+   - Create a draft PR on GitHub from `migration-validation-sandbox` into `main`.
+   - Ensure you have a file edit on a path listed in `migrated.bara.sky` (e.g., `devops_bench/tasks/schema.py`).
+   - *Expected Outcome*: The `migrated-readonly` CI status check should fail, blocking the PR.
+   - Now, add the `migrated-override` label to the draft PR.
+   - *Expected Outcome*: Re-triggering the check should cause it to pass successfully.
+
+---
+
+## Phase E: Cleanup
+
+Once validation is complete, run these commands to clean up temporary sandbox directories and restore your working branch:
+
+```bash
+# 1. Clean up mock directories in /tmp
+rm -rf /tmp/sandbox-canonical.git
+rm -rf /tmp/sandbox-canonical-clone
+rm -rf /tmp/sandbox-incubator-workspace
+
+# 2. Return to the main branch
+git checkout main
+
+# 3. Safely delete the local validation sandbox branch
+git branch -D migration-validation-sandbox
+
+# 4. Optional: Delete the remote tracking branch
+git push origin --delete migration-validation-sandbox
+```

--- a/docs/migration/component-design.md
+++ b/docs/migration/component-design.md
@@ -1,0 +1,223 @@
+# Migration: Component design and principles
+
+This document details the architectural decisions, design patterns, and engineering principles behind the restructured `devops-bench` library. 
+
+### Documentation directory map
+- For high-level steps for gke-labs maintainers, see [README.md](./README.md).
+- For target directory layouts and glossary, see [directory-structure.md](./directory-structure.md).
+- For the phased pull request deployment sequence, see [pr-plan.md](./pr-plan.md).
+- For details on proving the plan using a local sandbox, see [VALIDATION.md](./VALIDATION.md).
+
+---
+
+## 1. Core principles
+
+1. **Strict Library Mode**: The entire system is packaged under a single importable, installable namespace: `devops_bench`. No raw Python files are executed directly from directories outside the library path.
+2. **One Unit = One Path = One PR, Tests Included**: Each module or component migrates with its corresponding unit tests (located under `tests/unit/`) in the same pull request. kubernetes-sigs requires PRs to be self-contained and fully tested on landing.
+3. **Interfaces Before Implementations**: Define Abstract Base Classes (ABCs) or Protocols before creating concrete implementations. This decouples the execution engine from the subjects of evaluation and infrastructure dependencies.
+4. **Extensibility via Registry**: Every major extension axis (Agents, Models, Deployers, Chaos Triggers, Chaos Faults, Verifiers, Metrics, Harnesses) is backed by a `Registry[T]` pattern, allowing new components to self-register.
+5. **Transport-based Agent Isolation:** Benchmark subject agents (under evaluation) are organized strictly by their communication transport (`cli/`, `api/`, `chat/`). Support machinery loops (such as the Chaos Agent or LLM-as-judge metrics) are considered part of the harness orchestration and reside in their respective functional modules (`chaos/` or `metrics/`).
+6. **Capability Negotiation**: The harness matches agents with tasks based on declared capabilities and explicit Python Protocols, rejecting unsupported schedules before provisioning infrastructure.
+7. **Isolation of Shared Code**: Shared utilities must sink to a lower dependency layer. Sibling packages (e.g., `chaos/` and `verification/`) must never import each other.
+8. **Dependency-Light Imports**: Eager imports of concrete implementations are banned in all package-level `__init__.py` files to prevent loading heavy third-party dependencies (like cloud SDKs) when they are not in use.
+
+---
+
+## 2. Agent architecture and capability negotiation
+
+To prevent directory bloat and circular dependencies, we split agents across two distinct concerns: **Transport** (how the harness drives the agent) and **Capabilities** (what the agent supports).
+
+### Transport folders
+We place agents in subfolders under `devops_bench/agents/` based on their runtime transport mechanism:
+- `cli/`: Subprocess-based CLI agents.
+- `api/`: LLM-driven API agents, loop agents, and MCP clients.
+- `chat/`: Multi-turn conversational agents.
+
+### Capabilities specs and mixins
+Capabilities represent cross-cutting features that any agent can implement. They reside in the `devops_bench/agents/capabilities/` subpackage. Each capability provides:
+1. A `@runtime_checkable` `Protocol` defining the data attributes and methods the agent must support.
+2. A companion `Mixin` that provides standard default implementations of those methods to avoid code duplication.
+
+```python
+# devops_bench/agents/capabilities/gitops.py
+from typing import Protocol, runtime_checkable
+from pathlib import Path
+
+@runtime_checkable
+class SupportsGitOps(Protocol):
+    workspace_path: Path
+    def open_pr(self, change: Change) -> PRRef: ...
+
+class GitOpsMixin:
+    """Default implementation of git/PR behavior that agents can inherit."""
+    workspace_path: Path
+    
+    def open_pr(self, change: Change) -> PRRef:
+        return git_open_pr(change, cwd=self.workspace_path)
+```
+
+> [!IMPORTANT]
+> Any state a capability mixin reads from the agent MUST be declared as a data-attribute member on the `@runtime_checkable` Protocol (e.g., `workspace_path`). In Python ≥3.12, `isinstance` checks against runtime-checkable Protocols verify the presence of these data members, allowing the scheduler to safely validate agent readiness before running a task.
+
+---
+
+## 3. The evaluation harness (`harness/`)
+
+The evaluation harness is the orchestration engine that drives the lifecycle of each benchmark task. It represents the decomposition of the legacy, monolithic `evaluate.py:main()` script into clean, reusable phases.
+
+### Harness run pipeline
+
+The default engine (`harness/default.py`) executes the following sequence for each task:
+
+```mermaid
+flowchart TD
+    A[1. Provision Infrastructure] --> B[2. Start Scenario]
+    B --> C[3. Run Agent Harness]
+    C --> D[4. Collect Artifacts]
+    D --> E[5. Teardown Infrastructure]
+    E --> F[6. Score Trajectory]
+    F --> G[7. Export Report]
+
+    subgraph "Infrastructure Provisioning (deployers/)"
+        A
+        E
+    end
+    subgraph "Chaos & Checks (harness/scenario.py)"
+        B
+    end
+    subgraph "Agent Run (agents/)"
+        C
+    end
+    subgraph "Metrics Scoring (metrics/)"
+        F
+    end
+```
+
+### Run pipeline steps
+1. **Provision**: Invokes the configured `Deployer` to spin up a local Kind cluster or a GKE environment. It builds a `RunContext` carrying the connection parameters and task metadata.
+2. **Scenario Start**: Handed to the `ScenarioManager` (`harness/scenario.py`). It boots the background thread orchestration for chaos injection and concurrent verification.
+3. **Run Agent**: Fires up the selected `AgentHarness`, running its main loop against the target environment.
+4. **Collect**: Diffs the local workspace and scrapes cluster states, gathering the agent trajectory, tool invocations, tokens used, and generated outputs.
+5. **Teardown**: Destroys the provisioned infrastructure to free cloud and local resources (retained if `BENCH_NO_TEARDOWN=1`).
+6. **Score**: Runs the metrics judge pipeline (`metrics/`) to evaluate outcome validity, grounding, and safety/chaos resilience.
+7. **Report**: Appends results to a central JSON feed for reporting.
+
+---
+
+## 4. Chaos and verification extensibility
+
+The chaos and verification subpackages live behind clean interfaces to ensure that new chaos faults, triggers, and outcome verifiers can be added without altering the core orchestrator.
+
+### Chaos model
+Chaos consists of a **Trigger** (when to inject) and a **Fault** (what to inject), corresponding to `spec.trigger` and `spec.action`.
+
+```python
+# devops_bench/chaos/base.py
+class Trigger(ABC):
+    @abstractmethod
+    def wait(self, ctx: RunContext) -> None: ...  # Blocks until firing condition is met
+
+class Fault(ABC):
+    @abstractmethod
+    def inject(self, ctx: RunContext) -> ChaosResult: ...
+```
+
+- Triggers (`chaos/triggers/`) are self-contained classes (e.g., `delay.py`, `periodic.py`, or `k8s_event.py`).
+- Faults (`chaos/faults/`) are specific actions (e.g., `pod_kill.py`, `node_drain.py`, `cpu_load.py`).
+- To add a new fault or trigger, simply create a file in its respective directory and register it using `@TRIGGERS.register` or `@FAULTS.register`.
+
+### Verification model
+Verification represents check criteria run either at the end of a scenario or continuously in the background during execution.
+
+```python
+# devops_bench/verification/base.py
+class Verifier(ABC):
+    @abstractmethod
+    def verify(self, ctx: RunContext, timeout_sec: int) -> VerificationResult: ...
+```
+
+- Verifiers live under `devops_bench/verification/verifiers/` (e.g., `pod_healthy.py`, `service_responsive.py`).
+- You can compose verifiers hierarchically using lists or dictionaries in the task specification. The runtime automatically parses these into a verifier tree.
+
+---
+
+## 5. Dependency layering and import graph
+
+To prevent circular import dependencies, the repository relies on a strict **layered architecture**. A module at any given layer may only import from its own layer or from layers below it. **Sibling directories at the same layer must never import each other.**
+
+```text
++--------------------------------------------------------+
+|                      5. Entrypoint                     |
+|                      (devops_bench/cli.py)             |
++--------------------------------------------------------+
+                           |
+                           v
++--------------------------------------------------------+
+|                      4. Engine                         |
+|                     (devops_bench/harness/)            |
++--------------------------------------------------------+
+                           |
+                           v
++--------------------------------------------------------+
+|                      3. Components                     |
+|    (tasks/, deployers/, agents/, chaos/,               |
+|     verification/, metrics/)                           |
++--------------------------------------------------------+
+                           |
+                           v
++--------------------------------------------------------+
+|                      2. Shared Providers               |
+|           (devops_bench/k8s/, devops_bench/models/)    |
++--------------------------------------------------------+
+                           |
+                           v
++--------------------------------------------------------+
+|                      1. Foundation                     |
+|                     (devops_bench/core/)               |
++--------------------------------------------------------+
+```
+
+### Avoiding cycles with `RunContext`
+`RunContext` must be accessible to almost every component (including lower layers like `chaos` or `verification`), yet it references high-level structures like `Task`, `Deployer`, or `EventStream`. To prevent circular imports, we enforce two design rules:
+1. We define the `RunContext` type in the foundation layer (`devops_bench/core/context.py`) and build the instance in the top layer (`harness/base.py`).
+2. We type high-level fields in `RunContext` using **Protocols** or `TYPE_CHECKING` guards to prevent the `core` layer from importing upward.
+
+---
+
+## 6. Lazy registry population and heavy backends
+
+To maintain high performance and low startup times, `devops-bench` prevents eager package loads on startup.
+
+### Entry-point plugin discovery
+Instead of using `__init__.py` files that eagerly import all implementation files, registries leverage Python's `importlib.metadata` entry points. We register concrete implementations in `pyproject.toml` and load them on demand:
+
+```toml
+# pyproject.toml
+[project.entry-points."devops_bench.agents"]
+gemini = "devops_bench.agents.cli.gemini:GeminiCli"
+openclaw = "devops_bench.agents.cli.openclaw:OpenClawCli"
+```
+
+The registry resolving logic loads and caches the imported module on the first call to `REGISTRY.get("gemini")`.
+
+### Heavy extras
+To keep the base install light, we declare heavy third-party libraries (such as cloud SDKs or proprietary model clients) as optional dependencies (extras):
+
+```toml
+# pyproject.toml
+[project.optional-dependencies]
+anthropic = ["anthropic>=0.104.1"]
+gcp = ["google-cloud-storage", "google-cloud-aiplatform"]
+```
+
+Users installing only the core framework (`pip install devops-bench`) will not pull down heavy cloud SDKs. If a selected component requires an extra that is missing, the framework raises a clear, helpful error on startup (e.g., `"Please install devops-bench[gcp] to use the GCP deployer"`).
+
+---
+
+## 7. Skills directory architecture
+
+Evaluation skills are markdown checklists and guidelines (such as `skills/outcome-validity-checklist.md` and `skills/tool-invocation-skill.md`) used at runtime by:
+1. LLM-as-judge metrics to evaluate the trajectory.
+2. BYO-skill agents to understand instructions.
+
+Because skills are content data and change independently of library logic, they reside in a top-level `skills/` directory at the repository root. Sibling modules inside the `devops_bench` library read these files directly from disk. The `devops_bench/agents/capabilities/skills.py` package handles loading and mapping these file paths to active agent workspaces.

--- a/docs/migration/copy.bara.sky
+++ b/docs/migration/copy.bara.sky
@@ -1,0 +1,76 @@
+# Back-sync importer: mirrors the migrated paths from kubernetes-sigs/devops-bench back into
+# gke-labs. Run by .github/workflows/backsync.yml or hack/backsync.sh. Re-running on an unchanged
+# frontier is a NO_OP (exit 4). See docs/migration/ for the how and why.
+
+# The frontier is the single source of truth in migrated.bara.sky, also parsed by the flip guard
+# and the tracker. (load() must stay at the top of the file.)
+load("//migrated.bara.sky", "MIGRATED")
+
+CANONICAL = "https://github.com/kubernetes-sigs/devops-bench.git"   # origin (public)
+GKE_LABS  = "https://github.com/gke-labs/devops-bench.git"          # destination (ours)
+
+# Dynamically select origins/destinations to seamlessly support local file:// sandboxing
+origin_obj = git.origin(
+    url = CANONICAL,
+    ref = "main",
+) if (CANONICAL.startswith("file://") or "github.com" not in CANONICAL) else git.github_origin(
+    url = CANONICAL,
+    ref = "main",
+)
+
+dest_obj = git.destination(
+    url = GKE_LABS,
+    push = "main",
+) if (GKE_LABS.startswith("file://") or "github.com" not in GKE_LABS) else git.github_pr_destination(
+    url             = GKE_LABS,
+    destination_ref = "main",
+    pr_branch       = "backsync/from-upstream",
+)
+
+# Dedicated migration bot identity, used as a fallback author.
+# Real upstream authors are preserved (via pass_thru).
+SYNC_BOT = "devops-bench-sync-bot <devops-bench-sync-bot@google.com>"
+
+# Never mirror back: gke-labs-only assets, each repo's own CI, and the human-managed manifests.
+NEVER_SYNC = [
+    "**/__pycache__/**",
+    "**/*.pyc",
+    "**/.terraform/**",
+    "**/*.tfstate*",
+    ".github/**",
+    "site/**",
+    "site_new/**",
+    "copy.bara.sky",
+    "migrated.bara.sky",
+    "pyproject.toml",
+    "uv.lock",
+    ".python-version",
+    "LICENSE",
+    "LICENSES/**",
+]
+
+def frontier_glob():
+    # glob([]) is an error, so use a placeholder while the frontier is empty.
+    paths = MIGRATED if MIGRATED else ["__migration_frontier_placeholder__"]
+    return glob(paths, exclude = NEVER_SYNC)
+
+# No message-rewriting transforms: ITERATIVE mode replays each upstream commit individually,
+# keeping original metadata intact. This is required for author-keyed CLA validation.
+TRANSFORMS = []
+
+core.workflow(
+    name = "backsync",
+    origin = origin_obj,
+    # gke-labs is ours, so push the branch and open a same-repo PR directly. The fixed pr_branch
+    # name lets the read-only flip guard exempt this bot (it writes to migrated paths by design).
+    destination = dest_obj,
+    origin_files      = frontier_glob(),
+    destination_files = frontier_glob(),
+    # pass_thru preserves upstream commit authors (required for CLA validation).
+    # SYNC_BOT is used only as a fallback default.
+    authoring = authoring.pass_thru(SYNC_BOT),
+    # ITERATIVE mode preserves per-commit history and authorship (required for CLA gates).
+    # Do NOT use SQUASH, as it collapses all changes and hides original authorship.
+    mode = "ITERATIVE",
+    transformations = TRANSFORMS,
+)

--- a/docs/migration/directory-structure.md
+++ b/docs/migration/directory-structure.md
@@ -1,0 +1,107 @@
+# Migration: Target directory structure and mapping
+
+This document outlines the target layout for `devops-bench`, maps existing files in `gke-labs/devops-bench` (the *incubator*) to their new homes, and defines the high-level vocabulary used across the codebase.
+
+### Documentation directory map
+- For high-level steps for gke-labs maintainers, see [README.md](./README.md).
+- For a deep dive into architectural designs and principles, see [component-design.md](./component-design.md).
+- For the phased pull request deployment sequence, see [pr-plan.md](./pr-plan.md).
+- For details on proving the plan using a local sandbox, see [VALIDATION.md](./VALIDATION.md).
+
+---
+
+## 1. Glossary: Framework terms
+
+To prevent ambiguity, the codebase adheres to strict definitions for key framework structures:
+
+| Term | What it is | Primary Location |
+|------|------------|------------------|
+| **Task** | A benchmark scenario defining an intent, infrastructure requirements, and success verifications. | `tasks/` (YAML definitions) |
+| **Agent** | The AI system being evaluated. Powered by an **Agent Harness** adapter over a communication transport. | `devops_bench/agents/` |
+| **Evaluation Harness** | The execution pipeline that orchestrates the lifecycle of a task (provisioning, scenario startup, running the agent, teardown, scoring). | `devops_bench/harness/` |
+| **Scenario Manager** | A component within the evaluation harness that concurrently manages background chaos injection and checks. | `devops_bench/harness/scenario.py` |
+| **Chaos** | Fault injection configured as a combination of a **Trigger** (when) and a **Fault** (what). | `devops_bench/chaos/` |
+| **Verification** | Outcome assertions evaluated during or at the end of a scenario. Supports complex nested lists/dicts. | `devops_bench/verification/` |
+| **Metric / Judge** | Rubrics used to grade the agent's run trajectory, usually LLM-as-judge. | `devops_bench/metrics/` |
+| **Model / Provider** | Unified API access for LLM requests (consumed by API agents, chaos, and judges). | `devops_bench/models/` |
+| **Deployer** | Software that provisions/destroys infrastructure by executing Terraform or Kind scripts. | `devops_bench/deployers/` |
+| **Skill** | Runtime instructions, prompts, or checklists loaded by judges or BYO-skill agents. | `skills/` (Markdown documents) |
+
+---
+
+## 2. Target directory tree
+
+We adopt a **flat repository layout** (without a nested `src/` directory) to conform to `kubernetes-sigs` standards. We maintain library integrity using editable installs (`uv sync`) and strict CI checks.
+
+```
+devops-bench/
+├── .github/workflows/                 # CI Configurations
+│   └── guardrails.yml                 # Main test and lint pipeline
+├── devops_bench/                      # Primary package namespace (flat, at root)
+│   ├── __init__.py
+│   ├── core/                          # Primitives (registry, context, results, errors)
+│   ├── tasks/                         # Task schema specifications and loader logic
+│   ├── agents/                        # Target agents under evaluation
+│   │   ├── base.py                    # AgentHarness base class & registry
+│   │   ├── capabilities/              # Capability specs, mixins, and protocols
+│   │   ├── cli/                       # Subprocess CLI transport agents (e.g., gemini)
+│   │   ├── api/                       # API integration transport agents (e.g., mcp)
+│   │   └── chat/                      # Conversation transport agents
+│   ├── models/                        # LLM Provider integrations (Google, Anthropic)
+│   ├── k8s/                           # Subprocess kubectl and watch wrappers
+│   ├── deployers/                     # Terraform and Kind infrastructure engines
+│   ├── harness/                       # Run orchestrator, ScenarioManager, and state
+│   ├── chaos/                         # Fault injection triggers and actions
+│   ├── verification/                  # Outcome check assertions and tree runner
+│   ├── metrics/                       # LLM grading judges and score mapping
+│   ├── reporting/                     # Results JSON aggregator and leaderboard feed
+│   ├── cli.py                         # Command Line entrypoint handler
+│   └── __main__.py
+├── hack/                              # Development scripts (status, prep-export, etc.)
+├── infra/                             # Shared Terraform modules and common stacks
+│   ├── modules/                       # Reusable infrastructure blocks
+│   └── stacks/                        # Reusable stack environments (local, common)
+├── tasks/                             # Task definition data files (YAML + local infra)
+├── skills/                            # Scoring guides and agent instructional prompts
+├── tests/                             # Test suite (mirrors devops_bench/ layout)
+│   ├── unit/                          # Unit tests (migrate with code)
+│   └── integration/                   # Cross-cutting end-to-end integration tests
+└── pyproject.toml                     # Modern package metadata and tool configs
+```
+
+> [!NOTE]
+> **Planned Directories**: The `devops_bench/agents/capabilities/` subpackage is defined in the target architecture but is not part of the initial migration (it is deferred to keep the early PRs small). It will be developed directly upstream in `kubernetes-sigs` as a post-migration phase.
+
+---
+
+## 3. Current-to-target path mapping
+
+This table maps every significant path in the legacy `gke-labs` repository to its restructured location inside the new `devops_bench` library.
+
+| Legacy Path (gke-labs) | Restructured Path (devops_bench) | Notes |
+|-----------------------|---------------------------------|-------|
+| `pkg/evaluator/evaluate.py` (Main loop) | `devops_bench/harness/{base,default,artifacts}.py` | Decomposed into pipeline phases |
+| `pkg/evaluator/evaluate.py` (Metrics) | `devops_bench/metrics/{pipeline,geval,outcome_validity,tool_invocation,grounding,chaos_metrics}.py` | Split into discrete metric modules |
+| `pkg/evaluator/loader.py` | `devops_bench/tasks/loader.py` | |
+| `pkg/manager/manager.py` | `devops_bench/harness/scenario.py` | ScenarioManager is part of the harness |
+| `pkg/agents/chaos/chaos.py` | `devops_bench/chaos/agent.py` + `devops_bench/chaos/faults/generate_load.py` | Split into agent loop + fault action |
+| `pkg/agents/verifier/*` | `devops_bench/verification/*` | Extracted into verifier base and registries |
+| `pkg/agents/runner/gcli.py`, `openclaw.py` | `devops_bench/agents/cli/{gemini,openclaw}.py` | Relocated by transport |
+| `pkg/agents/runner/api/{api,utils}.py`, `mcp_client.py` | `devops_bench/agents/api/{loop,mcp}.py` | |
+| `pkg/agents/runner/api/{llm_client,llm_adapters}.py` | `devops_bench/models/{anthropic,google}.py` | Centralized LLM providers |
+| `pkg/agents/runner/runner.py` | `devops_bench/agents/base.py` | Core AgentHarness class |
+| `deployers/` (Top-level) | `devops_bench/deployers/` | Moved inside the python package namespace |
+| `tf/` | `infra/` | Reorganized into modules and stacks |
+| `tasks/` + `complextasks/` | `tasks/` | Merged into a unified tasks directory |
+| `skills/` (In legacy paths) | `skills/` | Relocated to repo root as content data |
+| `scripts/entrypoint.sh` | `hack/entrypoint.sh` | CLI-wrapping shell helpers |
+
+---
+
+## 4. Out-of-scope files (gke-labs only)
+
+These files represent public web assets and gke-labs-specific CI deployment scripts. They remain exclusively in the `gke-labs` repository and will **not** be exported to `kubernetes-sigs`:
+
+- `site/` (Web dashboard frontend)
+- `site_new/`
+- `.github/workflows/static.yml` (Dashboard deployment pipeline)

--- a/docs/migration/hack/backsync.sh
+++ b/docs/migration/hack/backsync.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# backsync.sh: Run the kubernetes-sigs -> gke-labs back-sync.
+# Maps to .github/workflows/backsync.yml. Dry-run first.
+#
+# Auth: Needs GITHUB_TOKEN with push/PR access to gke-labs/devops-bench.
+# For local dry-run: export GITHUB_TOKEN="$(gh auth token)"
+# For real run:      export GITHUB_TOKEN="$SYNC_BOT_TOKEN"
+# Git committer is always stamped as devops-bench-sync-bot.
+#
+# Usage:
+#   ./hack/backsync.sh --dry-run
+#   ./hack/backsync.sh
+#
+set -euo pipefail
+
+COPYBARA_IMAGE="${COPYBARA_IMAGE:-anipos/copybara:latest}"
+WORKFLOW="${WORKFLOW:-backsync}"
+CONFIG="${CONFIG:-copy.bara.sky}"
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)   EXTRA_ARGS+=("--dry-run"); shift ;;
+    --workflow)  WORKFLOW="$2"; shift 2 ;;
+    --config)    CONFIG="$2"; shift 2 ;;
+    -h|--help)   sed -n '2,12p' "$0"; exit 0 ;;
+    *)           EXTRA_ARGS+=("$1"); shift ;;
+  esac
+done
+
+[[ -f "$CONFIG" ]] || { echo "error: $CONFIG not found (run from repo root)" >&2; exit 1; }
+command -v docker >/dev/null 2>&1 || { echo "error: docker is required but not found on PATH" >&2; exit 1; }
+: "${GITHUB_TOKEN:?set GITHUB_TOKEN (e.g. export GITHUB_TOKEN=\$(gh auth token))}"
+
+echo ">> copybara $WORKFLOW  (image: $COPYBARA_IMAGE)  args: ${EXTRA_ARGS[*]:-none}"
+
+set +e
+# Mount /tmp to support local file:// sandbox testing in Copybara.
+# Overwrite entrypoint to java to bypass buggy wrappers in some copybara images (like anipos/copybara).
+docker run --rm \
+  -v "$PWD":/usr/src/app \
+  -v /tmp:/tmp \
+  -w /usr/src/app \
+  -e GITHUB_TOKEN \
+  -e COPYBARA_CONFIG_ROOT=/usr/src/app \
+  --entrypoint java \
+  "$COPYBARA_IMAGE" \
+  -jar /opt/copybara/copybara_deploy.jar \
+  "$CONFIG" "$WORKFLOW" \
+  --git-committer-name  "devops-bench-sync-bot" \
+  --git-committer-email "devops-bench-sync-bot@google.com" \
+  "${EXTRA_ARGS[@]}"
+rc=$?
+set -e
+
+# exit 4 == nothing to migrate (frontier already in sync).
+if [[ $rc -eq 4 ]]; then
+  echo ">> frontier already in sync."
+  exit 0
+fi
+exit $rc

--- a/docs/migration/hack/check-migrated-readonly.sh
+++ b/docs/migration/hack/check-migrated-readonly.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# check-migrated-readonly.sh: blocks gke-labs PRs from editing paths listed in migrated.bara.sky.
+# Exempts back-sync PRs. Runs in gke-labs CI.
+#
+# Usage (CI):
+#   BASE_REF=origin/main ./hack/check-migrated-readonly.sh
+#
+set -euo pipefail
+
+MANIFEST="${MANIFEST:-migrated.bara.sky}"
+BASE_REF="${BASE_REF:-origin/main}"
+# PR head branch (set by CI). Exempts backsync/* branches used by the sync bot.
+HEAD_REF="${HEAD_REF:-}"
+
+case "$HEAD_REF" in
+  backsync/*) echo "OK: back-sync branch ($HEAD_REF) is exempt from the read-only guard."; exit 0 ;;
+esac
+
+# Bypass check if MIGRATED_OVERRIDE=1 or PR has the 'migrated-override' label.
+# Note: local edits will be overwritten by backsync unless also committed upstream.
+OVERRIDE_LABEL="${OVERRIDE_LABEL:-migrated-override}"
+if [[ "${MIGRATED_OVERRIDE:-}" == "1" ]] || [[ " ${PR_LABELS:-} " == *" $OVERRIDE_LABEL "* ]]; then
+  echo "OK: edits to migrated paths overridden by the '$OVERRIDE_LABEL' label."
+  echo "    Reminder: make the same change in kubernetes-sigs, or the back-sync will revert it here."
+  exit 0
+fi
+
+[[ -f "$MANIFEST" ]] || { echo "OK: no $MANIFEST manifest; nothing is locked yet."; exit 0; }
+
+# Parse active (uncommented) paths from migrated.bara.sky.
+# Uses while-read for compatibility with macOS Bash 3.2.
+PATTERNS=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && PATTERNS+=("$line")
+done < <(sed 's/#.*//' "$MANIFEST" | grep -oE '"[^"]+"' | tr -d '"')
+
+if [[ ${#PATTERNS[@]} -eq 0 ]]; then
+  echo "OK: $MANIFEST is empty; no migrated paths are locked yet (Phase 1 no-op)."
+  exit 0
+fi
+
+# Get changed files in the PR range. Falls back to two-dot diff if three-dot fails.
+if ! diff_out="$(git diff --name-only "$BASE_REF"...HEAD -- 2>/dev/null)"; then
+  diff_out="$(git diff --name-only "$BASE_REF" HEAD --)"
+fi
+
+CHANGED=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && CHANGED+=("$line")
+done <<< "$diff_out"
+
+violations=()
+if [[ ${#CHANGED[@]} -gt 0 ]]; then     # guard: empty-array expansion is unbound under bash 3.2 set -u
+  for f in "${CHANGED[@]}"; do
+    for p in "${PATTERNS[@]}"; do
+      # Match file against globs, or check if it starts with the directory prefix.
+      # shellcheck disable=SC2053  # intentional glob match of $p against $f
+      if [[ "$f" == $p || "$f" == $p/* ]]; then violations+=("$f  (matches '$p')"); break; fi
+    done
+  done
+fi
+
+if [[ ${#violations[@]} -gt 0 ]]; then
+  echo "FAIL: this PR edits paths that have migrated to kubernetes-sigs (now their source of truth):" >&2
+  for v in "${violations[@]}"; do echo "  - $v" >&2; done
+  echo >&2
+  echo "Make these changes in kubernetes-sigs/devops-bench instead; the back-sync bot will mirror" >&2
+  echo "them back here. (If a module was un-migrated on purpose, remove its line from $MANIFEST.)" >&2
+  exit 1
+fi
+
+echo "OK: no edits to migrated (read-only) paths."

--- a/docs/migration/hack/migration-status.sh
+++ b/docs/migration/hack/migration-status.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# migration-status.sh: reports migration progress by comparing migrated.bara.sky and upstream main.
+# --suggest-flips lists/uncomments entries whose paths now exist upstream.
+#
+# Usage:
+#   ./hack/migration-status.sh
+#   ./hack/migration-status.sh --suggest-flips --upstream-files <file>          # report ready-to-flip
+#   ./hack/migration-status.sh --suggest-flips --apply --upstream-files <file>  # uncomment them
+#
+set -euo pipefail
+
+MANIFEST="${MANIFEST:-migrated.bara.sky}"
+SRC="${SRC:-devops_bench}"
+UPSTREAM="${UPSTREAM:-kubernetes-sigs/devops-bench}"
+MODE="status"
+APPLY="false"
+UPSTREAM_FILES=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest)       MANIFEST="$2"; shift 2 ;;
+    --src)            SRC="$2"; shift 2 ;;
+    --upstream)       UPSTREAM="$2"; shift 2 ;;
+    --suggest-flips)  MODE="suggest"; shift ;;
+    --apply)          APPLY="true"; shift ;;
+    --upstream-files) UPSTREAM_FILES="$2"; shift 2 ;;
+    -h|--help)        sed -n '2,18p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -f "$MANIFEST" ]] || { echo "error: manifest '$MANIFEST' not found (run from repo root)" >&2; exit 1; }
+
+# --- suggest-flips: auto-uncomment entries present upstream -----------------
+# A commented path is ready to flip once it exists in upstream main.
+if [[ "$MODE" == "suggest" ]]; then
+  [[ -n "$UPSTREAM_FILES" && -f "$UPSTREAM_FILES" ]] \
+    || { echo "error: --suggest-flips needs --upstream-files <file> (e.g. git ls-tree -r --name-only upstream/main)" >&2; exit 2; }
+
+  to_flip=()
+  while IFS= read -r path; do
+    [[ -n "$path" ]] || continue
+    case "$path" in
+      *'/**') prefix="${path%/**}/"; awk -v p="$prefix" 'index($0,p)==1{f=1} END{exit f?0:1}' "$UPSTREAM_FILES" && to_flip+=("$path") ;;
+      *'/*')  prefix="${path%/*}/";  awk -v p="$prefix" 'index($0,p)==1{f=1} END{exit f?0:1}' "$UPSTREAM_FILES" && to_flip+=("$path") ;;
+      *)      grep -qxF -- "$path" "$UPSTREAM_FILES" && to_flip+=("$path") ;;
+    esac
+  done < <(grep -oE '^[[:space:]]*#[[:space:]]*"[^"]+"' "$MANIFEST" | grep -oE '"[^"]+"' | tr -d '"')
+
+  if [[ ${#to_flip[@]} -eq 0 ]]; then
+    echo "No commented frontier entries are present upstream yet; nothing to flip."
+    exit 0
+  fi
+
+  echo "Ready to flip (present upstream, still commented): ${#to_flip[@]}"
+  for p in "${to_flip[@]}"; do echo "  + $p"; done
+
+  if [[ "$APPLY" == "true" ]]; then
+    for path in "${to_flip[@]}"; do
+      esc="$(printf '%s' "$path" | sed 's/[.*]/\\&/g')"   # escape regex metacharacters in paths
+      sed -i.bak -E "s|^([[:space:]]*)#[[:space:]]*(\"${esc}\",)|\1\2|" "$MANIFEST"
+    done
+    rm -f "$MANIFEST.bak"
+    echo "Uncommented ${#to_flip[@]} entries in $MANIFEST."
+  else
+    echo "(run with --apply to uncomment these in $MANIFEST)"
+  fi
+  exit 0
+fi
+
+# Parse active (uncommented) paths from migrated.bara.sky.
+# Uses while-read for compatibility with macOS Bash 3.2.
+MIGRATED=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && MIGRATED+=("$line")
+done < <(sed 's/#.*//' "$MANIFEST" | grep -oE '"[^"]+"' | tr -d '"')
+
+echo "== Migrated (${#MIGRATED[@]}) — kubernetes-sigs is source of truth, read-only in gke-labs =="
+if [[ ${#MIGRATED[@]} -eq 0 ]]; then
+  echo "  (none yet — still in Phase 1: restructure gke-labs before any forward PR)"
+else
+  for p in "${MIGRATED[@]}"; do echo "  ✓ $p"; done
+fi
+
+echo
+echo "== In-flight upstream PRs ($UPSTREAM) =="
+if command -v gh >/dev/null 2>&1; then
+  gh pr list --repo "$UPSTREAM" --state open \
+     --json number,title,headRefName \
+     --template '{{range .}}  #{{.number}}  {{.title}}  ({{.headRefName}}){{"\n"}}{{end}}' \
+     2>/dev/null || echo "  (could not query gh — check auth / repo exists yet)"
+else
+  echo "  (gh not installed; skipping)"
+fi
+
+echo
+echo "== Coverage of top-level packages under $SRC/ =="
+if [[ -d "$SRC" ]]; then
+  remaining=0; partial=0
+  while IFS= read -r dir; do
+    pkg="$(basename "$dir")"
+    prefix="$SRC/$pkg"
+    state="remaining"
+    if [[ ${#MIGRATED[@]} -gt 0 ]]; then
+      for m in "${MIGRATED[@]}"; do
+        # Check if package is fully or partially migrated
+        if [[ "$m" == "$prefix" || "$m" == "$prefix/" || "$m" == "$prefix/*" || "$m" == "$prefix/**" ]]; then
+          state="full"; break
+        elif [[ "$m" == "$prefix/"* ]]; then
+          [[ "$state" == "full" ]] || state="partial"
+        fi
+      done
+    fi
+    case "$state" in
+      full)      echo "  ✓ $prefix/  (migrated)" ;;
+      partial)   echo "  ◑ $prefix/  (partially migrated)"; partial=$((partial+1)) ;;
+      remaining) echo "  ◻ $prefix/  (not started)"; remaining=$((remaining+1)) ;;
+    esac
+  done < <(find "$SRC" -mindepth 1 -maxdepth 1 -type d -not -name '__pycache__' | sort)
+  echo
+  echo "  $remaining not started, $partial partially migrated."
+else
+  echo "  (source directory not present yet)"
+fi

--- a/docs/migration/hack/prep-export.sh
+++ b/docs/migration/hack/prep-export.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# prep-export.sh: packages files from gke-labs into a signed upstream branch on kubernetes-sigs.
+# Run this from a clone of your fork of kubernetes-sigs/devops-bench.
+#
+# Prereqs:
+#   git remote add gkelabs  https://github.com/gke-labs/devops-bench.git
+#   git remote add upstream https://github.com/kubernetes-sigs/devops-bench.git
+#
+# Usage:
+#   ./hack/prep-export.sh --branch add-gemini-agent \
+#       --paths "devops_bench/agents/cli/gemini.py tests/unit/agents/test_gemini.py"
+#
+#   ./hack/prep-export.sh --branch add-gemini-agent --interactive   # carve a sub-file slice
+#
+set -euo pipefail
+
+BRANCH=""
+PATHS=""
+BASE="upstream/main"
+SRC_REF="gkelabs/main"
+INTERACTIVE="false"
+MSG=""
+
+die() { echo "error: $*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch)      BRANCH="$2"; shift 2 ;;
+    --paths)       PATHS="$2"; shift 2 ;;
+    --base)        BASE="$2"; shift 2 ;;
+    --src-ref)     SRC_REF="$2"; shift 2 ;;
+    --message|-m)  MSG="$2"; shift 2 ;;
+    --interactive) INTERACTIVE="true"; shift ;;
+    -h|--help)     sed -n '2,30p' "$0"; exit 0 ;;
+    *)             die "unknown arg: $1" ;;
+  esac
+done
+
+[[ -n "$BRANCH" ]] || die "--branch is required"
+git remote get-url gkelabs  >/dev/null 2>&1 || die "missing remote 'gkelabs' (see header)"
+git remote get-url upstream >/dev/null 2>&1 || die "missing remote 'upstream' (see header)"
+[[ -z "$(git status --porcelain)" ]] || die "working tree is dirty; commit or stash first"
+
+echo ">> fetching incubator and upstream..."
+git fetch --quiet gkelabs
+git fetch --quiet upstream
+
+echo ">> creating branch '$BRANCH' off $BASE"
+git checkout -q -B "$BRANCH" "$BASE"
+
+if [[ "$INTERACTIVE" == "true" ]]; then
+  # Stage full content, then reset to let the user select changes with `git add -p`
+  echo ">> interactive mode: staging full content from $SRC_REF, then 'git add -p'"
+  git checkout "$SRC_REF" -- . 2>/dev/null || true
+  git reset -q
+  git add -p
+else
+  [[ -n "$PATHS" ]] || die "--paths is required unless --interactive"
+  read -ra path_arr <<< "$PATHS"      # split paths on whitespace into an array
+  echo ">> importing paths from $SRC_REF:"
+  for p in "${path_arr[@]}"; do echo "     $p"; done
+  git checkout "$SRC_REF" -- "${path_arr[@]}"
+  git add -- "${path_arr[@]}"
+fi
+
+if git diff --cached --quiet; then
+  die "nothing staged, aborting (check your --paths / selection)"
+fi
+
+[[ -n "$MSG" ]] || MSG="migrate: ${BRANCH//-/ }"
+echo ">> committing (DCO sign-off, your authorship)"
+git commit -s -m "$MSG"
+
+cat <<EOF
+
+✓ Prepared branch '$BRANCH'. Review it, then:
+
+    git show --stat
+    git push origin "$BRANCH"
+    gh pr create --repo kubernetes-sigs/devops-bench --base main --fill
+
+Respond to the approver with follow-up commits on this branch.
+EOF

--- a/docs/migration/migrated.bara.sky
+++ b/docs/migration/migrated.bara.sky
@@ -1,0 +1,50 @@
+# migrated.bara.sky — the single source of truth for the migrated frontier.
+# Installs at the gke-labs repo root. Loaded by copy.bara.sky (the back-sync scope) and parsed by
+# hack/check-migrated-readonly.sh (flip guard) and hack/migration-status.sh (tracker), so there is
+# exactly one list. Add a path (uncomment a line) when its forward PR merges; remove it to un-migrate.
+#
+# Each module's unit tests travel in the same PR, so add its tests/unit/<area>/ path alongside it.
+# Only tests/integration/** is added at the end (Stage 4); it spans components. The Stage-0 toolchain
+# (pyproject.toml, uv.lock, .python-version, CI) is human-managed in both repos and is NOT listed here.
+#
+# See docs/migration/README.md. Empty until the first module lands.
+
+MIGRATED = [
+    # --- Stage 1: leaves, start here (see pr-plan.md §2) ---
+    # "devops_bench/core/**",
+    # "tests/unit/core/**",
+    # "devops_bench/tasks/**",
+    # "tests/unit/tasks/**",
+    # "devops_bench/deployers/**",
+    # "tests/unit/deployers/**",
+    # "devops_bench/k8s/kubectl.py",
+    # "tests/unit/k8s/**",
+    # "devops_bench/models/**",
+    # "tests/unit/models/**",
+
+    # --- Stage 2: components (each with its tests/unit/<area>/) ---
+    # "devops_bench/agents/base.py",
+    # "devops_bench/agents/cli/**",
+    # "tests/unit/agents/**",
+    # "devops_bench/verification/**",
+    # "tests/unit/verification/**",
+    # "devops_bench/chaos/**",
+    # "tests/unit/chaos/**",
+    # "devops_bench/metrics/**",
+    # "tests/unit/metrics/**",
+    # "skills/**",                      # judge guides travel with the metrics that read them
+    # "devops_bench/agents/api/**",
+
+    # --- Stage 3: orchestrator ---
+    # "devops_bench/harness/**",
+    # "tests/unit/harness/**",
+
+    # --- Stage 4: data + entrypoint, then the cross-cutting tests last ---
+    # "infra/**",
+    # "tasks/**",
+    # "devops_bench/reporting/**",
+    # "devops_bench/cli.py",
+    # "tests/integration/**",
+]
+
+# New-feature interfaces (e.g. devops_bench/agents/capabilities/**) are added later, during migration.

--- a/docs/migration/pr-plan.md
+++ b/docs/migration/pr-plan.md
@@ -1,0 +1,131 @@
+# Migration: PR execution plan
+
+### Documentation directory map
+- For high-level steps for gke-labs maintainers, see [README.md](./README.md).
+- For a deep dive into component design and principles, see [component-design.md](./component-design.md).
+- For target directory layouts and glossary, see [directory-structure.md](./directory-structure.md).
+- For details on proving the plan using a local sandbox, see [VALIDATION.md](./VALIDATION.md).
+
+This document maps out the phased execution strategy to migrate `devops-bench` from `gke-labs/devops-bench` (the *incubator*) to `kubernetes-sigs/devops-bench` (the *canonical* home) as small, reviewable Pull Requests.
+
+---
+
+## 1. Core PR execution principles
+
+To ensure a smooth, error-free upstream review process, every PR must adhere to these structural constraints:
+
+1. **Co-locate Implementation and Unit Tests**: As outlined in the [architectural principles](./component-design.md#1-core-principles), each module or package must migrate together with its corresponding unit tests under `tests/unit/` in a single PR. 
+2. **Prioritize Interfaces and Registries**: Basic classes, registries, and Abstract Base Classes (ABCs) must land before the concrete implementations that import them to ensure clean dependency trees.
+3. **Keep the Frontier Documented**: Immediately after an upstream PR merges, uncomment its paths in `migrated.bara.sky` in a small, reviewed `gke-labs` PR (refer to [README.md](./README.md) §4 Step 2.2 for details). This locks the paths and activates the back-sync bot.
+4. **All PRs are Disposable**: If a forward PR becomes stale, close it and re-assemble a clean one using `prep-export.sh`.
+5. **No Cross-Border Imports**: Banish imports of un-migrated paths in migrated code to maintain a clean boundary.
+
+---
+
+## 2. Phased PR sequence
+
+The migration is divided into 5 chronological stages. Stage 0 is the prerequisite for all subsequent steps. Within Stages 1 and 2, modules can migrate largely in parallel.
+
+```mermaid
+graph TD
+    classDef stage fill:#1e1e2e,stroke:#cba6f7,stroke-width:2px,color:#cdd6f4;
+
+    S0["Stage 0: Toolchain & Core<br/>(pyproject.toml, uv.lock, core/ registry)"]:::stage
+    S1["Stage 1: Leaf Modules (Parallel)<br/>(tasks/, deployers/, k8s/ kubectl, models/)"]:::stage
+    S2["Stage 2: Main Components (Parallel)<br/>(agents/ base & CLI, verification/, chaos/, metrics/)"]:::stage
+    S3["Stage 3: Orchestrator Engine<br/>(harness/ default pipeline)"]:::stage
+    S4["Stage 4: Data & Integration<br/>(infra/ stacks, tasks/ data, integration tests)"]:::stage
+
+    S0 --> S1
+    S1 --> S2
+    S2 --> S3
+    S3 --> S4
+```
+
+---
+
+### Stage 0: Toolchain and foundation
+This is the unblocker. No code can migrate until the toolchain and CI checks are established upstream.
+
+- **0a. Toolchain & CI Setup**:
+  - **Files**: `pyproject.toml`, `uv.lock`, `.python-version`, `devops_bench/__init__.py`, `.github/workflows/guardrails.yml`, `hack/boilerplate.py`.
+  - **Details**: Defines Hatchling as the build system, lists base dependencies, and configures lints (`ruff`). It also installs the GitHub Actions guardrail to check Python code, verify lints, and enforce boilerplate headers.
+- **0b. Foundation (`core/`)**:
+  - **Files**: `devops_bench/core/*` (registry, context, results, logging, subprocess, errors, config), `tests/unit/core/*`.
+  - **Details**: Moves domain-agnostic helpers and types (such as `RunContext` type) so they are available to all higher layers.
+
+---
+
+### Stage 1: Leaf modules
+Leaf modules have zero internal dependencies other than `core/` and basic standard library packages.
+
+- **1a. Task contracts (`tasks/`)**:
+  - **Paths**: `devops_bench/tasks/` (schema, loader, registry), `tests/unit/tasks/`.
+  - **Details**: Formalizes task specifications and parsing logic.
+- **1b. Infrastructure deployers (`deployers/`)**:
+  - **Paths**: `devops_bench/deployers/` (base, factory, tofu, gcp, kind), `tests/unit/deployers/`.
+  - **Details**: Abstract base classes and concrete engines for provisioning Kind or GKE clusters.
+- **1c. Kubernetes wrappers (`k8s/`)**:
+  - **Paths**: `devops_bench/k8s/kubectl.py`, `devops_bench/k8s/conditions.py`, `tests/unit/k8s/`.
+  - **Details**: Basic kubectl utilities and wait/poll configurations. (Note: event watches are deferred).
+- **1d. LLM clients (`models/`)**:
+  - **Paths**: `devops_bench/models/` (base, google, anthropic), `tests/unit/models/`.
+  - **Details**: Provider-agnostic model access layers.
+
+> [!TIP]
+> Send the smallest leaf first (e.g., `tasks/`) to verify your whole toolchain, fork PR mechanics, CNCF EasyCLA, and the first `migrated.bara.sky` flip + back-sync run with minimal risk.
+
+---
+
+### Stage 2: Main components
+These components depend on Stage 1 leaves and form the primary building blocks of benchmark execution.
+
+- **2a. Agents base and CLI (`agents/`)**:
+  - **Paths**: `devops_bench/agents/base.py`, `devops_bench/agents/cli/`, `tests/unit/agents/`.
+  - **Details**: Introduces the `AgentHarness` base class and the CLI agents (`gemini`, `openclaw`). We defer capabilities to keep the initial export small.
+- **2b. Verification engine (`verification/`)**:
+  - **Paths**: `devops_bench/verification/` (base, spec, runner, verifiers/), `tests/unit/verification/`.
+  - **Details**: Implements outcome assertions and the condition verification tree. Depends on `k8s/`.
+- **2c. Chaos injector (`chaos/`)**:
+  - **Paths**: `devops_bench/chaos/` (base, agent, faults/generate_load), `tests/unit/chaos/`.
+  - **Details**: Implements the core chaos scheduler and the network load injection fault. Depends on `models/`.
+- **2d. Metrics judge (`metrics/`)**:
+  - **Paths**: `devops_bench/metrics/`, `tests/unit/metrics/`, and associated `skills/` Markdown guides (e.g., `skills/outcome-validity-checklist.md`).
+  - **Details**: Implements LLM-as-judge scoring pipelines and prompt criteria. You must migrate Markdown guides in the same PR as the metric code that reads them to prevent runtime path resolution failures.
+- **2e. API loop agents (`agents/api/`)**:
+  - **Paths**: `devops_bench/agents/api/` (loop, mcp), `tests/unit/agents/api/`.
+  - **Details**: Advanced agentic integration loops.
+
+---
+
+### Stage 3: Orchestrator engine
+With all leaves and components in place, the core run loop can now migrate.
+
+- **3a. Run orchestration (`harness/`)**:
+  - **Paths**: `devops_bench/harness/` (base, default, scenario, artifacts), `tests/unit/harness/`.
+  - **Details**: Integrates the `ScenarioManager` (controlling chaos and verification) with the `DefaultHarness` (managing task loops, provisioning, execution, and teardown).
+
+---
+
+### Stage 4: Data and entrypoints
+This final stage completes the transition, activating full end-to-end capabilities upstream.
+
+- **4a. Terraform infrastructure stacks (`infra/`)**:
+  - **Paths**: `infra/modules/`, `infra/stacks/`.
+  - **Details**: Reorganizes Terraform modules and the baseline local common stack.
+- **4b. Benchmark tasks (`tasks/` data)**:
+  - **Paths**: `tasks/` definitions (the task YAML files and their co-located task infra directories).
+  - **Details**: Moves all evaluations and benchmark scripts out of the library space.
+- **4c. Command-line interface and integration tests**:
+  - **Paths**: `devops_bench/reporting/`, `devops_bench/cli.py`, `tests/integration/`.
+  - **Details**: Delivers high-level reporting utilities, the CLI entrypoint, and cross-cutting integration tests spanning multiple components.
+
+---
+
+## 3. Post-migration: Developing net-new features
+
+Restructuring only covers existing features. Once the foundational migration is complete, advanced functionality is built directly in the upstream repo:
+
+- `agents/capabilities/` (`Capabilities` spec, `Supports*` protocols, `*Mixin` classes).
+- `k8s/events.py` (The stateful live `kubectl get --watch` stream) and `chaos/triggers/event.py`.
+- Additional chaos faults (`pod_kill.py`, `node_drain.py`) and next-gen agents or judges.

--- a/docs/migration/workflows/backsync.yml
+++ b/docs/migration/workflows/backsync.yml
@@ -1,0 +1,38 @@
+# Installs at: gke-labs/devops-bench/.github/workflows/backsync.yml (gke-labs only).
+# Mirrors the migrated paths from kubernetes-sigs back into gke-labs. See docs/migration/.
+name: backsync
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print the proposed diff without pushing a branch or opening a PR"
+        type: boolean
+        default: false
+
+concurrency:
+  group: backsync
+  cancel-in-progress: false
+
+# Pushes and PRs run as the migration bot via its PAT (secrets.SYNC_BOT_TOKEN).
+# A PAT behaves like a normal user, bypassing default GitHub Actions restrictions.
+# Built-in GITHUB_TOKEN is locked to read-only.
+permissions:
+  contents: read
+
+jobs:
+  backsync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Copybara back-sync
+        # Runs backsync.sh with the bot's PAT to push branches and open PRs.
+        env:
+          GITHUB_TOKEN: ${{ secrets.SYNC_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          DRY=""; [[ "${{ inputs.dry_run }}" == "true" ]] && DRY="--dry-run"
+          ./hack/backsync.sh $DRY

--- a/docs/migration/workflows/guardrails.yml
+++ b/docs/migration/workflows/guardrails.yml
@@ -1,0 +1,102 @@
+# Installs at: .github/workflows/guardrails.yml in BOTH gke-labs and kubernetes-sigs.
+# CI guardrail: uv sync, ruff, license headers, unit tests. The `detect` job keeps it
+# a green no-op until pyproject.toml + devops_bench/ exist, so it is safe to install before the
+# reorg. The migrated-readonly job is gke-labs-only. Label (labeled/unlabeled) events only run the
+# migrated-readonly flip guard — the build/lint/test matrix is skipped, since labels don't change
+# code. See docs/migration/.
+name: guardrails
+
+on:
+  pull_request:
+    branches: [main]
+    # labeled/unlabeled so applying the 'migrated-override' label re-runs the flip guard
+    # immediately. The build/lint/test jobs skip on label events (per-job `if`s below), so
+    # unrelated label churn never reruns the full matrix.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    # Has the reorg landed? Keeps the workflow a no-op until it has.
+    # Skip on label events: labels don't change code, so there's nothing to build/lint/test.
+    # `guardrails` (needs: detect) cascades to skipped as well; only `migrated-readonly` runs on labels.
+    if: github.event.action != 'labeled' && github.event.action != 'unlabeled'
+    runs-on: ubuntu-latest
+    outputs:
+      ready: ${{ steps.check.outputs.ready }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        run: |
+          set -euo pipefail
+          if [[ -f pyproject.toml && -d devops_bench ]]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+            echo "Target layout present (pyproject.toml + devops_bench/): running full guardrails."
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Target layout not present yet (no pyproject.toml and/or devops_bench/);"
+            echo "::notice::guardrails are a green no-op until the foundation reorg PR lands."
+          fi
+
+  guardrails:
+    needs: detect
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Floor is requires-python (>=3.12); 3.14 is the dev default in .python-version.
+        python-version: ["3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        if: needs.detect.outputs.ready == 'true'
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      - name: Sync (build + install, strict library mode)
+        if: needs.detect.outputs.ready == 'true'
+        run: uv sync --frozen
+
+      - name: Lint
+        if: needs.detect.outputs.ready == 'true'
+        # Lint paths come from [tool.ruff] in pyproject.toml; `.` avoids hardcoding devops_bench.
+        run: uv run ruff check .
+
+      - name: License headers
+        if: needs.detect.outputs.ready == 'true'
+        run: uv run python hack/boilerplate.py --dry-run
+
+      - name: Unit tests
+        if: needs.detect.outputs.ready == 'true'
+        run: uv run pytest tests -q
+
+  migrated-readonly:
+    # gke-labs only: block PRs that edit migrated (upstream-owned) paths. No-op while migrated.bara.sky is
+    # empty. Exempt the back-sync bot's PRs (head branch backsync/*) — mirroring into migrated paths
+    # is exactly its job. Runs on code pushes to a PR and, for label events, ONLY when the
+    # 'migrated-override' label itself changes — so unrelated label churn triggers no CI at all.
+    if: >-
+      github.event_name == 'pull_request'
+      && github.repository == 'gke-labs/devops-bench'
+      && !startsWith(github.head_ref, 'backsync/')
+      && ((github.event.action != 'labeled' && github.event.action != 'unlabeled')
+      || github.event.label.name == 'migrated-override')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # need the base branch to diff the PR range
+      - name: Block edits to migrated (read-only) paths
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          # Override hook: the 'migrated-override' label (passed via env, not interpolated).
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+        run: ./hack/check-migrated-readonly.sh

--- a/docs/migration/workflows/guardrails.yml
+++ b/docs/migration/workflows/guardrails.yml
@@ -1,9 +1,9 @@
 # Installs at: .github/workflows/guardrails.yml in BOTH gke-labs and kubernetes-sigs.
-# CI guardrail: uv sync, ruff, license headers, unit tests. The `detect` job keeps it
-# a green no-op until pyproject.toml + devops_bench/ exist, so it is safe to install before the
-# reorg. The migrated-readonly job is gke-labs-only. Label (labeled/unlabeled) events only run the
-# migrated-readonly flip guard — the build/lint/test matrix is skipped, since labels don't change
-# code. See docs/migration/.
+# CI guardrail: uv sync, ruff, unit tests. Lint/test are scoped to the devops_bench
+# component (devops_bench/ + tests/unit/) — the rest of the repo is not yet compliant, so it is
+# deliberately left out of scope. The migrated-readonly job is gke-labs-only. Label
+# (labeled/unlabeled) events only run the migrated-readonly flip guard — the build/lint/test matrix
+# is skipped, since labels don't change code. See docs/migration/.
 name: guardrails
 
 on:
@@ -20,30 +20,10 @@ permissions:
   contents: read
 
 jobs:
-  detect:
-    # Has the reorg landed? Keeps the workflow a no-op until it has.
-    # Skip on label events: labels don't change code, so there's nothing to build/lint/test.
-    # `guardrails` (needs: detect) cascades to skipped as well; only `migrated-readonly` runs on labels.
-    if: github.event.action != 'labeled' && github.event.action != 'unlabeled'
-    runs-on: ubuntu-latest
-    outputs:
-      ready: ${{ steps.check.outputs.ready }}
-    steps:
-      - uses: actions/checkout@v4
-      - id: check
-        run: |
-          set -euo pipefail
-          if [[ -f pyproject.toml && -d devops_bench ]]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-            echo "Target layout present (pyproject.toml + devops_bench/): running full guardrails."
-          else
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Target layout not present yet (no pyproject.toml and/or devops_bench/);"
-            echo "::notice::guardrails are a green no-op until the foundation reorg PR lands."
-          fi
-
   guardrails:
-    needs: detect
+    # Skip on label events: labels don't change code, so there's nothing to build/lint/test.
+    # Only `migrated-readonly` runs on label changes.
+    if: github.event.action != 'labeled' && github.event.action != 'unlabeled'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -54,28 +34,20 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        if: needs.detect.outputs.ready == 'true'
         uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
       - name: Sync (build + install, strict library mode)
-        if: needs.detect.outputs.ready == 'true'
         run: uv sync --frozen
 
       - name: Lint
-        if: needs.detect.outputs.ready == 'true'
-        # Lint paths come from [tool.ruff] in pyproject.toml; `.` avoids hardcoding devops_bench.
-        run: uv run ruff check .
-
-      - name: License headers
-        if: needs.detect.outputs.ready == 'true'
-        run: uv run python hack/boilerplate.py --dry-run
+        # Scoped to the devops_bench component; the rest of the repo is not yet compliant.
+        run: uv run ruff check devops_bench tests/unit
 
       - name: Unit tests
-        if: needs.detect.outputs.ready == 'true'
-        run: uv run pytest tests -q
+        run: uv run pytest tests/unit -q
 
   migrated-readonly:
     # gke-labs only: block PRs that edit migrated (upstream-owned) paths. No-op while migrated.bara.sky is

--- a/docs/migration/workflows/suggest-flips.yml
+++ b/docs/migration/workflows/suggest-flips.yml
@@ -1,0 +1,62 @@
+# Periodically uncomments migrated.bara.sky entries whose paths now exist upstream and opens a PR.
+# Only uncomments pre-written lines; does not auto-merge.
+name: suggest-flips
+
+on:
+  schedule:
+    - cron: "23 6 * * 1"     # weekly (Monday), off-peak and off the :00 mark
+  workflow_dispatch: {}
+
+concurrency:
+  group: suggest-flips
+  cancel-in-progress: false
+
+# Uses the bot's PAT (secrets.SYNC_BOT_TOKEN) to push branches and open PRs.
+permissions:
+  contents: read
+
+jobs:
+  suggest-flips:
+    if: github.repository == 'gke-labs/devops-bench'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Use bot PAT so git operations attribute to the migration bot.
+          token: ${{ secrets.SYNC_BOT_TOKEN }}
+
+      - name: List upstream files (public, anonymous)
+        run: |
+          set -euo pipefail
+          git fetch --quiet --depth=1 https://github.com/kubernetes-sigs/devops-bench.git main
+          git ls-tree -r --name-only FETCH_HEAD > /tmp/upstream-files.txt
+          echo "upstream files: $(wc -l < /tmp/upstream-files.txt)"
+
+      - name: Uncomment entries now present upstream
+        run: ./hack/migration-status.sh --suggest-flips --apply --upstream-files /tmp/upstream-files.txt
+
+      - name: Open / update the flip PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.SYNC_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- migrated.bara.sky; then
+            echo "Nothing new to flip."; exit 0
+          fi
+          BRANCH=flip-suggestions
+          # Configure identity to match the migration bot for CLA validation.
+          git config user.name  "devops-bench-sync-bot"
+          git config user.email "devops-bench-sync-bot@google.com"
+          git checkout -B "$BRANCH"
+          git add migrated.bara.sky
+          git commit -m "chore(migration): flip modules now present upstream"
+          git push --force origin "$BRANCH"
+          # Check if a PR already exists from this branch to prevent swallowing real token/policy failures
+          PR_EXISTS=$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number')
+          if [[ -z "$PR_EXISTS" ]]; then
+            gh pr create --base main --head "$BRANCH" \
+              --title "Migration: flip modules now present upstream" \
+              --body $'Auto-suggested flips. These entries were uncommented in `migrated.bara.sky` because their paths now exist in kubernetes-sigs. Review and merge to complete the flip: ownership moves upstream, the back-sync turns on, and the path becomes read-only here.'
+          else
+            echo "PR #${PR_EXISTS} is already open; force-push has updated it."
+          fi

--- a/hack/check-migrated-readonly.sh
+++ b/hack/check-migrated-readonly.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# check-migrated-readonly.sh: blocks gke-labs PRs from editing paths listed in migrated.bara.sky.
+# Exempts back-sync PRs. Runs in gke-labs CI.
+#
+# Usage (CI):
+#   BASE_REF=origin/main ./hack/check-migrated-readonly.sh
+#
+set -euo pipefail
+
+MANIFEST="${MANIFEST:-migrated.bara.sky}"
+BASE_REF="${BASE_REF:-origin/main}"
+# PR head branch (set by CI). Exempts backsync/* branches used by the sync bot.
+HEAD_REF="${HEAD_REF:-}"
+
+case "$HEAD_REF" in
+  backsync/*) echo "OK: back-sync branch ($HEAD_REF) is exempt from the read-only guard."; exit 0 ;;
+esac
+
+# Bypass check if MIGRATED_OVERRIDE=1 or PR has the 'migrated-override' label.
+# Note: local edits will be overwritten by backsync unless also committed upstream.
+OVERRIDE_LABEL="${OVERRIDE_LABEL:-migrated-override}"
+if [[ "${MIGRATED_OVERRIDE:-}" == "1" ]] || [[ " ${PR_LABELS:-} " == *" $OVERRIDE_LABEL "* ]]; then
+  echo "OK: edits to migrated paths overridden by the '$OVERRIDE_LABEL' label."
+  echo "    Reminder: make the same change in kubernetes-sigs, or the back-sync will revert it here."
+  exit 0
+fi
+
+[[ -f "$MANIFEST" ]] || { echo "OK: no $MANIFEST manifest; nothing is locked yet."; exit 0; }
+
+# Parse active (uncommented) paths from migrated.bara.sky.
+# Uses while-read for compatibility with macOS Bash 3.2.
+PATTERNS=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && PATTERNS+=("$line")
+done < <(sed 's/#.*//' "$MANIFEST" | grep -oE '"[^"]+"' | tr -d '"')
+
+if [[ ${#PATTERNS[@]} -eq 0 ]]; then
+  echo "OK: $MANIFEST is empty; no migrated paths are locked yet (Phase 1 no-op)."
+  exit 0
+fi
+
+# Get changed files in the PR range. Falls back to two-dot diff if three-dot fails.
+if ! diff_out="$(git diff --name-only "$BASE_REF"...HEAD -- 2>/dev/null)"; then
+  diff_out="$(git diff --name-only "$BASE_REF" HEAD --)"
+fi
+
+CHANGED=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && CHANGED+=("$line")
+done <<< "$diff_out"
+
+violations=()
+if [[ ${#CHANGED[@]} -gt 0 ]]; then     # guard: empty-array expansion is unbound under bash 3.2 set -u
+  for f in "${CHANGED[@]}"; do
+    for p in "${PATTERNS[@]}"; do
+      # Match file against globs, or check if it starts with the directory prefix.
+      # shellcheck disable=SC2053  # intentional glob match of $p against $f
+      if [[ "$f" == $p || "$f" == $p/* ]]; then violations+=("$f  (matches '$p')"); break; fi
+    done
+  done
+fi
+
+if [[ ${#violations[@]} -gt 0 ]]; then
+  echo "FAIL: this PR edits paths that have migrated to kubernetes-sigs (now their source of truth):" >&2
+  for v in "${violations[@]}"; do echo "  - $v" >&2; done
+  echo >&2
+  echo "Make these changes in kubernetes-sigs/devops-bench instead; the back-sync bot will mirror" >&2
+  echo "them back here. (If a module was un-migrated on purpose, remove its line from $MANIFEST.)" >&2
+  exit 1
+fi
+
+echo "OK: no edits to migrated (read-only) paths."


### PR DESCRIPTION
This PR adds the comprehensive migration plan documentation and associated toolkit for migrating the repository to kubernetes-sigs.

Part of #79 

### Key Components:
- **Migration Runbooks**: Detailed step-by-step procedures, validation checklists, and sequential PR deployment plans under `docs/migration/`.
- **Validation Toolkit**: Local sandboxing scripts, dynamic Copybara configurations, and automated guardrail workflows.