### PR TITLE
feat(core): bootstrap devops_bench core modules

### DIFF
--- a/devops_bench/core/__init__.py
+++ b/devops_bench/core/__init__.py
@@ -1,0 +1,52 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Curated public API for the core primitives."""
+
+from devops_bench.core.config import first_env, get_bool, get_env, get_int, require_env
+from devops_bench.core.context import ClusterInfo, RunContext
+from devops_bench.core.errors import (
+    AlreadyRegisteredError,
+    ConfigError,
+    DevOpsBenchError,
+    MissingDependencyError,
+    NotRegisteredError,
+    RegistryError,
+    SubprocessError,
+)
+from devops_bench.core.logging import configure_logging, get_logger
+from devops_bench.core.registry import Registry
+from devops_bench.core.results import Result, Status
+
+__all__ = [
+    "ClusterInfo",
+    "RunContext",
+    "Registry",
+    "Result",
+    "Status",
+    "get_logger",
+    "configure_logging",
+    "get_env",
+    "require_env",
+    "first_env",
+    "get_bool",
+    "get_int",
+    "DevOpsBenchError",
+    "ConfigError",
+    "RegistryError",
+    "AlreadyRegisteredError",
+    "NotRegisteredError",
+    "MissingDependencyError",
+    "SubprocessError",
+]

--- a/devops_bench/core/config.py
+++ b/devops_bench/core/config.py
@@ -1,0 +1,164 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for reading configuration from environment variables."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+from devops_bench.core.errors import ConfigError
+
+__all__ = [
+    "get_env",
+    "require_env",
+    "first_env",
+    "get_bool",
+    "get_int",
+]
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "y", "on"})
+_FALSE_VALUES = frozenset({"0", "false", "no", "n", "off", ""})
+
+
+def _source(env: Mapping[str, str] | None) -> Mapping[str, str]:
+    return os.environ if env is None else env
+
+
+def get_env(
+    name: str,
+    default: str | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> str | None:
+    """Read a string variable from the environment.
+
+    Blank or whitespace-only values are treated as unset.
+
+    Args:
+        name: Variable to read.
+        default: Returned when the variable is unset or blank.
+        env: Mapping to read from instead of ``os.environ``.
+
+    Returns:
+        The variable's value, or ``default``.
+    """
+    value = _source(env).get(name)
+    if value is None or not value.strip():
+        return default
+    return value
+
+
+def require_env(name: str, *, env: Mapping[str, str] | None = None) -> str:
+    """Read a required string variable from the environment.
+
+    Args:
+        name: Variable to read.
+        env: Mapping to read from instead of ``os.environ``.
+
+    Returns:
+        The variable's value.
+
+    Raises:
+        ConfigError: If the variable is unset or blank.
+    """
+    value = get_env(name, env=env)
+    if value is None:
+        raise ConfigError(f"required environment variable {name!r} is not set")
+    return value
+
+
+def first_env(
+    *names: str,
+    default: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> str | None:
+    """Return the value of the first variable in ``names`` that is set.
+
+    Args:
+        *names: Variables to try in order.
+        default: Returned when none are set.
+        env: Mapping to read from instead of ``os.environ``.
+
+    Returns:
+        The first set value, or ``default``.
+    """
+    for name in names:
+        value = get_env(name, env=env)
+        if value is not None:
+            return value
+    return default
+
+
+def get_bool(
+    name: str,
+    default: bool = False,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> bool:
+    """Parse a boolean flag from the environment.
+
+    Accepts ``1/true/yes/y/on`` and ``0/false/no/n/off`` (case-insensitive).
+
+    Args:
+        name: Variable to read.
+        default: Returned when the variable is unset or blank.
+        env: Mapping to read from instead of ``os.environ``.
+
+    Returns:
+        The parsed boolean, or ``default``.
+
+    Raises:
+        ConfigError: If the value is set but not a recognized boolean.
+    """
+    raw = _source(env).get(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in _TRUE_VALUES:
+        return True
+    if normalized in _FALSE_VALUES:
+        return default if normalized == "" else False
+    raise ConfigError(f"environment variable {name!r} is not a valid boolean: {raw!r}")
+
+
+def get_int(
+    name: str,
+    default: int | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> int | None:
+    """Parse an integer from the environment.
+
+    Args:
+        name: Variable to read.
+        default: Returned when the variable is unset or blank.
+        env: Mapping to read from instead of ``os.environ``.
+
+    Returns:
+        The parsed integer, or ``default``.
+
+    Raises:
+        ConfigError: If the value is set but not a valid integer.
+    """
+    value = get_env(name, env=env)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ConfigError(
+            f"environment variable {name!r} is not a valid integer: {value!r}"
+        ) from exc

--- a/devops_bench/core/context.py
+++ b/devops_bench/core/context.py
@@ -1,0 +1,104 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run context shared across the evaluation pipeline."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+__all__ = ["ClusterInfo", "RunContext"]
+
+_DEFAULT_KUBECONFIG = "~/.kube/config"
+
+
+def _resolve_kubeconfig(path: str | None = None) -> str:
+    """Resolve a kubeconfig path.
+
+    Args:
+        path: Explicit path, if supplied.
+
+    Returns:
+        ``path`` if given, else ``KUBECONFIG``, else the expanded ``~/.kube/config``.
+    """
+    if path:
+        return path
+    return os.environ.get("KUBECONFIG") or str(Path(_DEFAULT_KUBECONFIG).expanduser())
+
+
+@dataclass(frozen=True)
+class ClusterInfo:
+    """Connection details for a provisioned cluster.
+
+    Attributes:
+        name: Cluster name.
+        location: Cloud region or zone; None for local clusters.
+        project: Cloud project; None for local clusters.
+        kubeconfig_path: Kubeconfig path; resolved from ``KUBECONFIG`` or
+            ``~/.kube/config`` when not supplied.
+    """
+
+    name: str
+    location: str | None = None
+    project: str | None = None
+    kubeconfig_path: str = field(default_factory=_resolve_kubeconfig)
+
+    @classmethod
+    def from_dict(cls, info: dict[str, Any]) -> ClusterInfo:
+        """Build a :class:`ClusterInfo` from a mapping of its fields.
+
+        Args:
+            info: Mapping with a required ``name`` and optional ``location``,
+                ``project``, and ``kubeconfig_path``.
+
+        Returns:
+            The constructed instance, with ``kubeconfig_path`` resolved when absent.
+        """
+        return cls(
+            name=info["name"],
+            location=info.get("location"),
+            project=info.get("project"),
+            kubeconfig_path=_resolve_kubeconfig(info.get("kubeconfig_path")),
+        )
+
+
+@dataclass
+class RunContext:
+    """State threaded through a single benchmark task run.
+
+    Attributes:
+        task_id: Identifier of the task being evaluated.
+        task_name: Human-readable task name.
+        workspace_path: Working directory the agent operates in.
+        cluster: Provisioned cluster details, if any.
+        env: Extra environment variables to apply when running commands.
+    """
+
+    task_id: str
+    task_name: str = ""
+    workspace_path: Path | None = None
+    cluster: ClusterInfo | None = None
+    env: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.workspace_path is not None and not isinstance(self.workspace_path, Path):
+            self.workspace_path = Path(self.workspace_path)
+
+    @property
+    def kubeconfig_path(self) -> str | None:
+        """Cluster kubeconfig path, or None when no cluster is attached."""
+        return self.cluster.kubeconfig_path if self.cluster else None

--- a/devops_bench/core/errors.py
+++ b/devops_bench/core/errors.py
@@ -1,0 +1,96 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exception types raised across devops-bench."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+
+__all__ = [
+    "DevOpsBenchError",
+    "ConfigError",
+    "RegistryError",
+    "AlreadyRegisteredError",
+    "NotRegisteredError",
+    "MissingDependencyError",
+    "SubprocessError",
+]
+
+
+class DevOpsBenchError(Exception):
+    """Base class for all errors raised by devops-bench."""
+
+
+class ConfigError(DevOpsBenchError):
+    """Raised when required configuration is missing or malformed."""
+
+
+class RegistryError(DevOpsBenchError):
+    """Base class for registry registration and lookup failures."""
+
+
+class AlreadyRegisteredError(RegistryError):
+    """Raised when registering a name that is already taken in a registry."""
+
+    def __init__(self, registry_name: str, key: str) -> None:
+        self.registry_name = registry_name
+        self.key = key
+        super().__init__(f"{key!r} is already registered in the {registry_name!r} registry")
+
+
+class NotRegisteredError(RegistryError):
+    """Raised when looking up a name that is not present in a registry."""
+
+    def __init__(self, registry_name: str, key: str, available: Sequence[str] = ()) -> None:
+        self.registry_name = registry_name
+        self.key = key
+        self.available = tuple(available)
+        message = f"{key!r} is not registered in the {registry_name!r} registry"
+        if self.available:
+            message += f"; available: {', '.join(sorted(self.available))}"
+        super().__init__(message)
+
+
+class MissingDependencyError(DevOpsBenchError):
+    """Raised when a feature requires an optional dependency that is not installed."""
+
+    def __init__(self, feature: str, extra: str) -> None:
+        self.feature = feature
+        self.extra = extra
+        super().__init__(
+            f"{feature} requires the optional dependency group {extra!r}. "
+            f"Install it with: pip install devops-bench[{extra}]"
+        )
+
+
+class SubprocessError(DevOpsBenchError):
+    """Raised when a subprocess exits non-zero or times out."""
+
+    def __init__(
+        self,
+        cmd: Sequence[str | os.PathLike[str]],
+        returncode: int,
+        stdout: str | None = None,
+        stderr: str | None = None,
+    ) -> None:
+        self.cmd = [str(part) for part in cmd]
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        message = f"command failed with exit code {returncode}: {' '.join(self.cmd)}"
+        if stderr:
+            message += f"\nstderr: {stderr.strip()}"
+        super().__init__(message)

--- a/devops_bench/core/logging.py
+++ b/devops_bench/core/logging.py
@@ -1,0 +1,102 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Logging helpers for devops-bench."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import IO
+
+__all__ = ["ROOT_LOGGER_NAME", "DEFAULT_FORMAT", "get_logger", "configure_logging"]
+
+ROOT_LOGGER_NAME = "devops_bench"
+DEFAULT_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+DEFAULT_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+_LEVEL_ENV_VAR = "BENCH_LOG_LEVEL"
+
+logging.getLogger(ROOT_LOGGER_NAME).addHandler(logging.NullHandler())
+
+
+def get_logger(name: str | None = None) -> logging.Logger:
+    """Return a logger namespaced under ``devops_bench``.
+
+    Args:
+        name: Dotted name relative to the package root; falsy returns the root.
+
+    Returns:
+        The namespaced logger.
+    """
+    if not name:
+        return logging.getLogger(ROOT_LOGGER_NAME)
+    if name == ROOT_LOGGER_NAME or name.startswith(f"{ROOT_LOGGER_NAME}."):
+        return logging.getLogger(name)
+    return logging.getLogger(f"{ROOT_LOGGER_NAME}.{name}")
+
+
+def _resolve_level(level: int | str | None) -> int:
+    if level is None:
+        level = os.environ.get(_LEVEL_ENV_VAR, "INFO")
+    if isinstance(level, str):
+        resolved = logging.getLevelName(level.upper())
+        if not isinstance(resolved, int):
+            raise ValueError(f"unknown log level: {level!r}")
+        return resolved
+    return level
+
+
+def configure_logging(
+    level: int | str | None = None,
+    *,
+    stream: IO[str] | None = None,
+    fmt: str = DEFAULT_FORMAT,
+    datefmt: str = DEFAULT_DATE_FORMAT,
+    force: bool = False,
+) -> logging.Logger:
+    """Attach a console handler to the ``devops_bench`` logger and set its level.
+
+    Idempotent unless ``force`` replaces existing handlers.
+
+    Args:
+        level: Level as an int or name; defaults to ``BENCH_LOG_LEVEL`` then ``INFO``.
+        stream: Handler destination; defaults to ``stderr``.
+        fmt: Record format string.
+        datefmt: Timestamp format string.
+        force: Replace existing non-null handlers.
+
+    Returns:
+        The package root logger.
+
+    Raises:
+        ValueError: If ``level`` names no known log level.
+    """
+    logger = logging.getLogger(ROOT_LOGGER_NAME)
+    logger.setLevel(_resolve_level(level))
+    logger.propagate = False
+
+    if force:
+        for handler in [h for h in logger.handlers if not isinstance(h, logging.NullHandler)]:
+            logger.removeHandler(handler)
+
+    has_stream_handler = any(
+        isinstance(h, logging.StreamHandler) and not isinstance(h, logging.NullHandler)
+        for h in logger.handlers
+    )
+    if not has_stream_handler:
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter(fmt=fmt, datefmt=datefmt))
+        logger.addHandler(handler)
+
+    return logger

--- a/devops_bench/core/registry.py
+++ b/devops_bench/core/registry.py
@@ -1,0 +1,166 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A generic registry with optional entry-point discovery."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, ItemsView, Iterator, KeysView, ValuesView
+from importlib import metadata
+
+from devops_bench.core.errors import AlreadyRegisteredError, NotRegisteredError
+from devops_bench.core.logging import get_logger
+
+__all__ = ["Registry"]
+
+_log = get_logger("core.registry")
+
+
+class Registry[T]:
+    """Name-to-object registry backing a single extension axis.
+
+    Args:
+        name: Registry name, used in error messages.
+        entry_point_group: Entry-point group scanned lazily for plugins; when
+            None, only explicit registrations are available.
+
+    Example:
+        >>> AGENTS: Registry[type] = Registry("agents")
+        >>> @AGENTS.register("gemini")
+        ... class GeminiCli: ...
+        >>> AGENTS.get("gemini") is GeminiCli
+        True
+    """
+
+    def __init__(self, name: str, *, entry_point_group: str | None = None) -> None:
+        self._name = name
+        self._entry_point_group = entry_point_group
+        self._items: dict[str, T] = {}
+        self._entry_points_loaded = False
+        self._lock = threading.Lock()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def register(self, key: str) -> Callable[[T], T]:
+        """Register an object under ``key``.
+
+        Args:
+            key: Name to register under.
+
+        Returns:
+            A decorator that registers and returns the object it decorates.
+
+        Raises:
+            AlreadyRegisteredError: If ``key`` is already registered.
+        """
+
+        def decorator(obj: T) -> T:
+            if key in self._items:
+                raise AlreadyRegisteredError(self._name, key)
+            self._items[key] = obj
+            _log.debug("registered %r in %r registry", key, self._name)
+            return obj
+
+        return decorator
+
+    def get(self, key: str) -> T:
+        """Look up a registered object by name.
+
+        A miss triggers a one-time entry-point scan when a group was configured.
+
+        Args:
+            key: Name to look up.
+
+        Returns:
+            The registered object.
+
+        Raises:
+            NotRegisteredError: If ``key`` is unknown.
+        """
+        if key not in self._items:
+            self._ensure_entry_points_loaded()
+        try:
+            return self._items[key]
+        except KeyError:
+            raise NotRegisteredError(self._name, key, self.keys()) from None
+
+    def __getitem__(self, key: str) -> T:
+        return self.get(key)
+
+    def __contains__(self, key: object) -> bool:
+        if isinstance(key, str) and key in self._items:
+            return True
+        self._ensure_entry_points_loaded()
+        return key in self._items
+
+    def __iter__(self) -> Iterator[str]:
+        self._ensure_entry_points_loaded()
+        return iter(self._items)
+
+    def __len__(self) -> int:
+        self._ensure_entry_points_loaded()
+        return len(self._items)
+
+    def keys(self) -> KeysView[str]:
+        self._ensure_entry_points_loaded()
+        return self._items.keys()
+
+    def items(self) -> ItemsView[str, T]:
+        self._ensure_entry_points_loaded()
+        return self._items.items()
+
+    def values(self) -> ValuesView[T]:
+        self._ensure_entry_points_loaded()
+        return self._items.values()
+
+    def _ensure_entry_points_loaded(self) -> None:
+        if self._entry_points_loaded or self._entry_point_group is None:
+            return
+        with self._lock:
+            if self._entry_points_loaded:
+                return
+            # Mark loaded only after the scan completes so concurrent readers
+            # never observe a half-populated registry; ``finally`` guards against
+            # a scan that fails to start.
+            try:
+                for entry_point in metadata.entry_points(group=self._entry_point_group):
+                    if entry_point.name in self._items:
+                        continue
+                    try:
+                        loaded = entry_point.load()
+                    except Exception:
+                        _log.exception(
+                            "failed to load entry point %r for %r registry",
+                            entry_point.name,
+                            self._name,
+                        )
+                        continue
+                    self._items[entry_point.name] = loaded
+                    _log.debug(
+                        "loaded entry point %r into %r registry",
+                        entry_point.name,
+                        self._name,
+                    )
+            finally:
+                self._entry_points_loaded = True
+
+    def __repr__(self) -> str:
+        return (
+            f"Registry(name={self._name!r}, "
+            f"entry_point_group={self._entry_point_group!r}, "
+            f"size={len(self._items)})"
+        )

--- a/devops_bench/core/results.py
+++ b/devops_bench/core/results.py
@@ -1,0 +1,87 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Outcome types shared by evaluated steps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+__all__ = ["Status", "Result"]
+
+
+class Status(StrEnum):
+    """Terminal status of an evaluated step."""
+
+    PASSED = "passed"
+    FAILED = "failed"
+    ERROR = "error"
+    SKIPPED = "skipped"
+
+
+@dataclass
+class Result:
+    """Outcome of a single evaluated step.
+
+    Attributes:
+        status: Terminal status; accepts a :class:`Status` or its string value.
+        reason: Explanation of the outcome.
+        elapsed_sec: Duration of the step in seconds.
+        details: JSON-serializable supporting data.
+    """
+
+    status: Status
+    reason: str = ""
+    elapsed_sec: float = 0.0
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, Status):
+            self.status = Status(self.status)
+
+    @property
+    def ok(self) -> bool:
+        """True only when the step passed."""
+        return self.status is Status.PASSED
+
+    @classmethod
+    def passed(cls, reason: str = "", **kwargs: Any) -> Result:
+        return cls(status=Status.PASSED, reason=reason, **kwargs)
+
+    @classmethod
+    def failed(cls, reason: str = "", **kwargs: Any) -> Result:
+        return cls(status=Status.FAILED, reason=reason, **kwargs)
+
+    @classmethod
+    def errored(cls, reason: str = "", **kwargs: Any) -> Result:
+        return cls(status=Status.ERROR, reason=reason, **kwargs)
+
+    @classmethod
+    def skipped(cls, reason: str = "", **kwargs: Any) -> Result:
+        return cls(status=Status.SKIPPED, reason=reason, **kwargs)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serializable mapping.
+
+        Returns:
+            A dict with ``status``, ``reason``, ``elapsed_sec``, and ``details``.
+        """
+        return {
+            "status": self.status.value,
+            "reason": self.reason,
+            "elapsed_sec": self.elapsed_sec,
+            "details": self.details,
+        }

--- a/devops_bench/core/subprocess.py
+++ b/devops_bench/core/subprocess.py
@@ -1,0 +1,114 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single entry point for running external commands."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Mapping, Sequence
+
+from devops_bench.core.errors import SubprocessError
+from devops_bench.core.logging import get_logger
+
+__all__ = ["run", "CompletedProcess"]
+
+type CompletedProcess = subprocess.CompletedProcess[str]
+
+_log = get_logger("core.subprocess")
+
+
+def _build_env(
+    env: Mapping[str, str] | None,
+    extra_env: Mapping[str, str] | None,
+) -> dict[str, str] | None:
+    if env is None and extra_env is None:
+        return None
+    base = dict(os.environ if env is None else env)
+    if extra_env:
+        base.update(extra_env)
+    return base
+
+
+def run(
+    cmd: Sequence[str | os.PathLike[str]],
+    *,
+    cwd: str | os.PathLike[str] | None = None,
+    env: Mapping[str, str] | None = None,
+    extra_env: Mapping[str, str] | None = None,
+    check: bool = True,
+    capture: bool = True,
+    text: bool = True,
+    timeout: float | None = None,
+    input: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command and return the completed process.
+
+    Args:
+        cmd: Command and arguments as a sequence, never a shell string.
+        cwd: Working directory.
+        env: Full child environment; defaults to the parent's.
+        extra_env: Variables overlaid on ``env`` (or the parent environment).
+        check: Raise on a non-zero exit code.
+        capture: Capture stdout and stderr.
+        text: Decode output as text.
+        timeout: Seconds before terminating the command.
+        input: Data written to stdin.
+
+    Returns:
+        The completed process.
+
+    Raises:
+        SubprocessError: If the command exits non-zero (when ``check``) or times out.
+    """
+    rendered = " ".join(str(arg) for arg in cmd)
+    _log.debug("running command: %s (cwd=%s)", rendered, cwd or os.getcwd())
+
+    try:
+        completed = subprocess.run(
+            list(cmd),
+            cwd=cwd,
+            env=_build_env(env, extra_env),
+            capture_output=capture,
+            text=text,
+            timeout=timeout,
+            input=input,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        _log.error("command timed out after %ss: %s", timeout, rendered)
+        raise SubprocessError(
+            cmd,
+            returncode=-1,
+            stdout=_as_text(exc.stdout),
+            stderr=_as_text(exc.stderr),
+        ) from exc
+
+    if check and completed.returncode != 0:
+        _log.error("command exited with %s: %s", completed.returncode, rendered)
+        raise SubprocessError(
+            cmd,
+            returncode=completed.returncode,
+            stdout=_as_text(completed.stdout),
+            stderr=_as_text(completed.stderr),
+        )
+
+    return completed
+
+
+def _as_text(value: str | bytes | None) -> str | None:
+    if value is None or isinstance(value, str):
+        return value
+    return value.decode("utf-8", errors="replace")

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -1,0 +1,100 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.core.config."""
+
+import pytest
+
+from devops_bench.core import config
+from devops_bench.core.errors import ConfigError
+
+
+def test_get_env_returns_value():
+    assert config.get_env("FOO", env={"FOO": "bar"}) == "bar"
+
+
+def test_get_env_missing_returns_default():
+    assert config.get_env("FOO", "fallback", env={}) == "fallback"
+
+
+def test_get_env_blank_treated_as_unset():
+    assert config.get_env("FOO", "fallback", env={"FOO": "   "}) == "fallback"
+
+
+def test_get_env_reads_os_environ_by_default(monkeypatch):
+    monkeypatch.setenv("BENCH_TEST_VAR", "live")
+    assert config.get_env("BENCH_TEST_VAR") == "live"
+
+
+def test_require_env_returns_value():
+    assert config.require_env("FOO", env={"FOO": "bar"}) == "bar"
+
+
+def test_require_env_raises_when_missing():
+    with pytest.raises(ConfigError, match="FOO"):
+        config.require_env("FOO", env={})
+
+
+def test_first_env_returns_first_set():
+    env = {"GCP_PROJECT_ID": "secondary"}
+    assert config.first_env("PROJECT_ID", "GCP_PROJECT_ID", env=env) == "secondary"
+
+
+def test_first_env_prefers_earlier_name():
+    env = {"PROJECT_ID": "primary", "GCP_PROJECT_ID": "secondary"}
+    assert config.first_env("PROJECT_ID", "GCP_PROJECT_ID", env=env) == "primary"
+
+
+def test_first_env_default_when_none_set():
+    assert config.first_env("A", "B", default="d", env={}) == "d"
+
+
+@pytest.mark.parametrize("raw", ["1", "true", "TRUE", "Yes", "on", "  y "])
+def test_get_bool_truthy(raw):
+    assert config.get_bool("FLAG", env={"FLAG": raw}) is True
+
+
+@pytest.mark.parametrize("raw", ["0", "false", "No", "off", "n"])
+def test_get_bool_falsy(raw):
+    assert config.get_bool("FLAG", default=True, env={"FLAG": raw}) is False
+
+
+def test_get_bool_unset_returns_default():
+    assert config.get_bool("FLAG", default=True, env={}) is True
+
+
+def test_get_bool_blank_returns_default():
+    assert config.get_bool("FLAG", default=True, env={"FLAG": ""}) is True
+
+
+def test_get_bool_invalid_raises():
+    with pytest.raises(ConfigError, match="boolean"):
+        config.get_bool("FLAG", env={"FLAG": "maybe"})
+
+
+def test_get_int_parses():
+    assert config.get_int("N", env={"N": "42"}) == 42
+
+
+def test_get_int_default_when_missing():
+    assert config.get_int("N", default=7, env={}) == 7
+
+
+def test_get_int_blank_returns_default():
+    assert config.get_int("N", default=7, env={"N": "   "}) == 7
+
+
+def test_get_int_invalid_raises():
+    with pytest.raises(ConfigError, match="integer"):
+        config.get_int("N", env={"N": "not-a-number"})

--- a/tests/unit/core/test_context.py
+++ b/tests/unit/core/test_context.py
@@ -1,0 +1,97 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.core.context."""
+
+from pathlib import Path
+
+from devops_bench.core.context import ClusterInfo, RunContext
+
+
+def test_cluster_info_from_dict_full():
+    info = ClusterInfo.from_dict(
+        {
+            "name": "c1",
+            "location": "us-central1-a",
+            "project": "proj",
+            "kubeconfig_path": "/tmp/kubeconfig",
+        }
+    )
+    assert info == ClusterInfo("c1", "us-central1-a", "proj", "/tmp/kubeconfig")
+
+
+def test_cluster_info_from_dict_minimal():
+    info = ClusterInfo.from_dict({"name": "c1"})
+    assert info.name == "c1"
+    assert info.location is None
+    assert info.project is None
+
+
+def test_kubeconfig_uses_env_when_not_provided(monkeypatch):
+    monkeypatch.setenv("KUBECONFIG", "/custom/kubeconfig")
+    assert ClusterInfo("c1").kubeconfig_path == "/custom/kubeconfig"
+    assert ClusterInfo.from_dict({"name": "c1"}).kubeconfig_path == "/custom/kubeconfig"
+
+
+def test_kubeconfig_falls_back_to_default(monkeypatch):
+    monkeypatch.delenv("KUBECONFIG", raising=False)
+    expected = str(Path("~/.kube/config").expanduser())
+    assert ClusterInfo("c1").kubeconfig_path == expected
+
+
+def test_kubeconfig_explicit_path_wins(monkeypatch):
+    monkeypatch.setenv("KUBECONFIG", "/custom/kubeconfig")
+    assert ClusterInfo("c1", kubeconfig_path="/explicit").kubeconfig_path == "/explicit"
+
+
+def test_cluster_info_is_frozen():
+    info = ClusterInfo("c1")
+    import dataclasses
+
+    try:
+        info.name = "c2"  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        pass
+    else:  # pragma: no cover - guards against a regression in frozen=True
+        raise AssertionError("ClusterInfo should be immutable")
+
+
+def test_run_context_defaults():
+    ctx = RunContext(task_id="t1")
+    assert ctx.task_id == "t1"
+    assert ctx.task_name == ""
+    assert ctx.cluster is None
+    assert ctx.env == {}
+
+
+def test_run_context_coerces_workspace_to_path():
+    ctx = RunContext(task_id="t1", workspace_path="/work/space")
+    assert isinstance(ctx.workspace_path, Path)
+    assert ctx.workspace_path == Path("/work/space")
+
+
+def test_run_context_kubeconfig_accessor():
+    ctx = RunContext(task_id="t1", cluster=ClusterInfo("c1", kubeconfig_path="/tmp/kc"))
+    assert ctx.kubeconfig_path == "/tmp/kc"
+
+
+def test_run_context_kubeconfig_accessor_without_cluster():
+    assert RunContext(task_id="t1").kubeconfig_path is None
+
+
+def test_run_context_env_is_independent_per_instance():
+    a = RunContext(task_id="a")
+    b = RunContext(task_id="b")
+    a.env["KEY"] = "value"
+    assert b.env == {}

--- a/tests/unit/core/test_errors.py
+++ b/tests/unit/core/test_errors.py
@@ -1,0 +1,87 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.core.errors."""
+
+import pytest
+
+from devops_bench.core.errors import (
+    AlreadyRegisteredError,
+    ConfigError,
+    DevOpsBenchError,
+    MissingDependencyError,
+    NotRegisteredError,
+    RegistryError,
+    SubprocessError,
+)
+
+
+@pytest.mark.parametrize(
+    "error_cls",
+    [
+        ConfigError,
+        RegistryError,
+        AlreadyRegisteredError,
+        NotRegisteredError,
+        MissingDependencyError,
+        SubprocessError,
+    ],
+)
+def test_all_errors_derive_from_base(error_cls):
+    assert issubclass(error_cls, DevOpsBenchError)
+
+
+def test_registry_errors_share_registry_base():
+    assert issubclass(AlreadyRegisteredError, RegistryError)
+    assert issubclass(NotRegisteredError, RegistryError)
+
+
+def test_already_registered_error_message_and_fields():
+    err = AlreadyRegisteredError("agents", "gemini")
+    assert err.registry_name == "agents"
+    assert err.key == "gemini"
+    assert "gemini" in str(err)
+    assert "agents" in str(err)
+
+
+def test_not_registered_error_lists_available_sorted():
+    err = NotRegisteredError("agents", "missing", available=["beta", "alpha"])
+    assert err.available == ("beta", "alpha")
+    message = str(err)
+    assert "missing" in message
+    assert message.index("alpha") < message.index("beta")
+
+
+def test_not_registered_error_without_available():
+    err = NotRegisteredError("agents", "missing")
+    assert "available" not in str(err)
+
+
+def test_missing_dependency_error_hints_install_command():
+    err = MissingDependencyError("The GCP deployer", "gcp")
+    assert err.feature == "The GCP deployer"
+    assert err.extra == "gcp"
+    assert "pip install devops-bench[gcp]" in str(err)
+
+
+def test_subprocess_error_captures_streams():
+    err = SubprocessError(["kubectl", "get", "pods"], returncode=1, stdout="out", stderr="boom")
+    assert err.cmd == ["kubectl", "get", "pods"]
+    assert err.returncode == 1
+    assert err.stdout == "out"
+    assert err.stderr == "boom"
+    rendered = str(err)
+    assert "kubectl get pods" in rendered
+    assert "exit code 1" in rendered
+    assert "boom" in rendered

--- a/tests/unit/core/test_logging.py
+++ b/tests/unit/core/test_logging.py
@@ -1,0 +1,93 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.core.logging."""
+
+import io
+import logging
+
+import pytest
+
+from devops_bench.core import logging as bench_logging
+from devops_bench.core.logging import ROOT_LOGGER_NAME, configure_logging, get_logger
+
+
+@pytest.fixture
+def clean_root_logger():
+    """Snapshot and restore the package root logger around each test."""
+    logger = logging.getLogger(ROOT_LOGGER_NAME)
+    saved_handlers = logger.handlers[:]
+    saved_level = logger.level
+    saved_propagate = logger.propagate
+    yield logger
+    logger.handlers[:] = saved_handlers
+    logger.level = saved_level
+    logger.propagate = saved_propagate
+
+
+def test_get_logger_namespaces_children():
+    assert get_logger("deployers.gcp").name == "devops_bench.deployers.gcp"
+
+
+def test_get_logger_no_name_returns_root():
+    assert get_logger().name == ROOT_LOGGER_NAME
+
+
+def test_get_logger_does_not_double_prefix():
+    assert get_logger("devops_bench.core").name == "devops_bench.core"
+
+
+def test_root_logger_has_null_handler_on_import():
+    handlers = logging.getLogger(ROOT_LOGGER_NAME).handlers
+    assert any(isinstance(h, logging.NullHandler) for h in handlers)
+
+
+def test_configure_logging_attaches_stream_handler(clean_root_logger):
+    stream = io.StringIO()
+    configure_logging("DEBUG", stream=stream, force=True)
+    get_logger("core.test").info("hello world")
+    assert "hello world" in stream.getvalue()
+
+
+def test_configure_logging_sets_level(clean_root_logger):
+    configure_logging("WARNING", force=True)
+    assert clean_root_logger.level == logging.WARNING
+
+
+def test_configure_logging_is_idempotent(clean_root_logger):
+    configure_logging("INFO", force=True)
+    before = [h for h in clean_root_logger.handlers if not isinstance(h, logging.NullHandler)]
+    configure_logging("INFO")
+    after = [h for h in clean_root_logger.handlers if not isinstance(h, logging.NullHandler)]
+    assert len(before) == len(after) == 1
+
+
+def test_configure_logging_reads_env_level(clean_root_logger, monkeypatch):
+    monkeypatch.setenv("BENCH_LOG_LEVEL", "ERROR")
+    configure_logging(force=True)
+    assert clean_root_logger.level == logging.ERROR
+
+
+def test_configure_logging_invalid_level_raises(clean_root_logger):
+    with pytest.raises(ValueError, match="unknown log level"):
+        configure_logging("NOPE")
+
+
+def test_configure_logging_disables_propagation(clean_root_logger):
+    configure_logging("INFO", force=True)
+    assert clean_root_logger.propagate is False
+
+
+def test_module_exposes_default_format():
+    assert "%(message)s" in bench_logging.DEFAULT_FORMAT

--- a/tests/unit/core/test_public_api.py
+++ b/tests/unit/core/test_public_api.py
@@ -1,0 +1,34 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the devops_bench.core curated public API."""
+
+import devops_bench.core as core
+
+
+def test_all_names_are_importable():
+    for name in core.__all__:
+        assert hasattr(core, name), f"{name} listed in __all__ but not exported"
+
+
+def test_curated_symbols_resolve_to_submodule_definitions():
+    from devops_bench.core.context import RunContext
+    from devops_bench.core.registry import Registry
+
+    assert core.Registry is Registry
+    assert core.RunContext is RunContext
+
+
+def test_subprocess_runner_is_not_re_exported():
+    assert not hasattr(core, "run")

--- a/tests/unit/core/test_registry.py
+++ b/tests/unit/core/test_registry.py
@@ -1,0 +1,163 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.core.registry."""
+
+import threading
+import time
+
+import pytest
+
+from devops_bench.core.errors import AlreadyRegisteredError, NotRegisteredError
+from devops_bench.core.registry import Registry
+
+
+class _FakeEntryPoint:
+    """Minimal stand-in for importlib.metadata.EntryPoint."""
+
+    def __init__(self, name, value, *, error=None):
+        self.name = name
+        self._value = value
+        self._error = error
+        self.loaded = False
+
+    def load(self):
+        self.loaded = True
+        if self._error is not None:
+            raise self._error
+        return self._value
+
+
+def test_register_value():
+    reg: Registry[int] = Registry("nums")
+    reg.register("one")(1)
+    assert reg.get("one") == 1
+
+
+def test_register_decorator_returns_object():
+    reg: Registry[type] = Registry("agents")
+
+    @reg.register("gemini")
+    class Gemini:
+        pass
+
+    assert reg.get("gemini") is Gemini
+
+
+def test_register_duplicate_raises():
+    reg: Registry[int] = Registry("nums")
+    reg.register("dup")(1)
+    with pytest.raises(AlreadyRegisteredError):
+        reg.register("dup")(2)
+
+
+def test_get_missing_raises_with_available():
+    reg: Registry[int] = Registry("nums")
+    reg.register("a")(1)
+    with pytest.raises(NotRegisteredError) as exc_info:
+        reg.get("missing")
+    assert "a" in str(exc_info.value)
+
+
+def test_container_and_iteration_helpers():
+    reg: Registry[int] = Registry("nums")
+    reg.register("a")(1)
+    reg.register("b")(2)
+    assert "a" in reg
+    assert len(reg) == 2
+    assert set(reg) == {"a", "b"}
+    assert set(reg.keys()) == {"a", "b"}
+    assert set(reg.values()) == {1, 2}
+    assert dict(reg.items()) == {"a": 1, "b": 2}
+    assert reg["a"] == 1
+
+
+def test_entry_points_loaded_lazily_on_miss(mocker):
+    ep = _FakeEntryPoint("plugin", "loaded-value")
+    mock_eps = mocker.patch("devops_bench.core.registry.metadata.entry_points", return_value=[ep])
+    reg: Registry[str] = Registry("plugins", entry_point_group="devops_bench.plugins")
+
+    assert ep.loaded is False
+    mock_eps.assert_not_called()
+
+    assert reg.get("plugin") == "loaded-value"
+    assert ep.loaded is True
+    mock_eps.assert_called_once_with(group="devops_bench.plugins")
+
+
+def test_entry_points_loaded_only_once(mocker):
+    ep = _FakeEntryPoint("plugin", "value")
+    mock_eps = mocker.patch("devops_bench.core.registry.metadata.entry_points", return_value=[ep])
+    reg: Registry[str] = Registry("plugins", entry_point_group="devops_bench.plugins")
+
+    reg.get("plugin")
+    with pytest.raises(NotRegisteredError):
+        reg.get("still-missing")
+    mock_eps.assert_called_once()
+
+
+def test_explicit_registration_wins_over_entry_point(mocker):
+    ep = _FakeEntryPoint("plugin", "from-entry-point")
+    mocker.patch("devops_bench.core.registry.metadata.entry_points", return_value=[ep])
+    reg: Registry[str] = Registry("plugins", entry_point_group="devops_bench.plugins")
+    reg.register("plugin")("explicit")
+
+    assert reg.get("plugin") == "explicit"
+    assert ep.loaded is False
+
+
+def test_failing_entry_point_is_skipped(mocker):
+    good = _FakeEntryPoint("good", "ok")
+    bad = _FakeEntryPoint("bad", None, error=RuntimeError("boom"))
+    mocker.patch("devops_bench.core.registry.metadata.entry_points", return_value=[bad, good])
+    reg: Registry[str] = Registry("plugins", entry_point_group="devops_bench.plugins")
+
+    assert reg.get("good") == "ok"
+    with pytest.raises(NotRegisteredError):
+        reg.get("bad")
+
+
+def test_entry_points_loaded_once_under_concurrency(mocker):
+    load_count = {"n": 0}
+
+    class _SlowEntryPoint:
+        name = "plugin"
+
+        def load(self):
+            load_count["n"] += 1
+            time.sleep(0.02)
+            return "value"
+
+    mock_eps = mocker.patch(
+        "devops_bench.core.registry.metadata.entry_points",
+        return_value=[_SlowEntryPoint()],
+    )
+    reg: Registry[str] = Registry("plugins", entry_point_group="devops_bench.plugins")
+
+    results: list[str] = []
+    barrier = threading.Barrier(8)
+
+    def worker() -> None:
+        barrier.wait()
+        results.append(reg.get("plugin"))
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert results == ["value"] * 8
+    assert load_count["n"] == 1
+    mock_eps.assert_called_once()

--- a/tests/unit/core/test_results.py
+++ b/tests/unit/core/test_results.py
@@ -1,0 +1,67 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.core.results."""
+
+import json
+
+from devops_bench.core.results import Result, Status
+
+
+def test_status_is_str_comparable():
+    assert Status.PASSED == "passed"
+    assert str(Status.FAILED) == "failed"
+
+
+def test_result_ok_only_when_passed():
+    assert Result.passed().ok is True
+    assert Result.failed().ok is False
+    assert Result.errored().ok is False
+    assert Result.skipped().ok is False
+
+
+def test_factory_helpers_set_status_and_reason():
+    result = Result.failed("pod never became ready")
+    assert result.status is Status.FAILED
+    assert result.reason == "pod never became ready"
+
+
+def test_factory_helpers_accept_extra_fields():
+    result = Result.passed("done", elapsed_sec=1.5, details={"count": 3})
+    assert result.elapsed_sec == 1.5
+    assert result.details == {"count": 3}
+
+
+def test_string_status_is_normalized_to_enum():
+    result = Result(status="error")
+    assert result.status is Status.ERROR
+
+
+def test_to_dict_is_json_serializable():
+    result = Result.passed("ok", elapsed_sec=2.0, details={"nested": {"a": 1}})
+    payload = result.to_dict()
+    assert payload == {
+        "status": "passed",
+        "reason": "ok",
+        "elapsed_sec": 2.0,
+        "details": {"nested": {"a": 1}},
+    }
+    assert json.loads(json.dumps(payload))["status"] == "passed"
+
+
+def test_details_default_is_independent_per_instance():
+    a = Result.passed()
+    b = Result.passed()
+    a.details["x"] = 1
+    assert b.details == {}

--- a/tests/unit/core/test_subprocess.py
+++ b/tests/unit/core/test_subprocess.py
@@ -1,0 +1,117 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.core.subprocess.
+
+These exercise the wrapper against real, portable shell-free commands
+(``python -c ...``) so behavior is verified end to end without mocking out
+the standard library.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from devops_bench.core import subprocess as bench_subprocess
+from devops_bench.core.errors import SubprocessError
+
+
+def _py(code: str) -> list[str]:
+    return [sys.executable, "-c", code]
+
+
+def test_run_captures_stdout():
+    result = bench_subprocess.run(_py("print('hello')"))
+    assert result.returncode == 0
+    assert result.stdout.strip() == "hello"
+
+
+def test_run_raises_on_nonzero_exit():
+    with pytest.raises(SubprocessError) as exc_info:
+        bench_subprocess.run(_py("import sys; sys.exit(3)"))
+    assert exc_info.value.returncode == 3
+
+
+def test_run_check_false_returns_completed_process():
+    result = bench_subprocess.run(_py("import sys; sys.exit(5)"), check=False)
+    assert result.returncode == 5
+
+
+def test_run_captures_stderr_in_error():
+    code = "import sys; sys.stderr.write('kaboom'); sys.exit(1)"
+    with pytest.raises(SubprocessError) as exc_info:
+        bench_subprocess.run(_py(code))
+    assert "kaboom" in exc_info.value.stderr
+    assert "kaboom" in str(exc_info.value)
+
+
+def test_run_extra_env_overlays_parent(monkeypatch):
+    monkeypatch.setenv("BASE_VAR", "from-parent")
+    result = bench_subprocess.run(
+        _py("import os; print(os.environ.get('EXTRA'), os.environ.get('BASE_VAR'))"),
+        extra_env={"EXTRA": "from-extra"},
+    )
+    assert result.stdout.strip() == "from-extra from-parent"
+
+
+def test_run_env_replaces_parent():
+    result = bench_subprocess.run(
+        _py("import os; print(os.environ.get('ONLY'))"),
+        env={"ONLY": "isolated"},
+    )
+    assert result.stdout.strip() == "isolated"
+
+
+def test_run_cwd(tmp_path):
+    result = bench_subprocess.run(_py("import os; print(os.getcwd())"), cwd=tmp_path)
+    # Resolve to defeat macOS /var -> /private/var symlinks.
+    assert result.stdout.strip().endswith(tmp_path.name)
+
+
+def test_run_input_is_forwarded():
+    result = bench_subprocess.run(
+        _py("import sys; sys.stdout.write(sys.stdin.read().upper())"),
+        input="abc",
+    )
+    assert result.stdout == "ABC"
+
+
+def test_run_timeout_raises_subprocess_error():
+    with pytest.raises(SubprocessError):
+        bench_subprocess.run(_py("import time; time.sleep(5)"), timeout=0.2)
+
+
+def test_run_accepts_path_objects_in_cmd():
+    result = bench_subprocess.run([Path(sys.executable), "-c", "print('hi')"])
+    assert result.stdout.strip() == "hi"
+
+
+def test_run_error_renders_path_command():
+    with pytest.raises(SubprocessError) as exc_info:
+        bench_subprocess.run([Path(sys.executable), "-c", "import sys; sys.exit(1)"])
+    assert sys.executable in str(exc_info.value)
+
+
+def test_run_decodes_non_utf8_output_on_failure():
+    code = r"import sys; sys.stderr.buffer.write(b'\xff\xfe'); sys.exit(1)"
+    with pytest.raises(SubprocessError) as exc_info:
+        bench_subprocess.run(_py(code), text=False)
+    assert isinstance(exc_info.value.stderr, str)
+
+
+def test_as_text_handles_bytes_and_none():
+    assert bench_subprocess._as_text(None) is None
+    assert bench_subprocess._as_text("text") == "text"
+    assert isinstance(bench_subprocess._as_text(b"\xff\xfe"), str)


### PR DESCRIPTION
[Refactoring] Stage 0b: Add core package with domain-agnostic primitives (errors, logging, config, subprocess, results, registry, context), that act as stdlib for the `devops_bench` repo.