### PR TITLE
feat: add GKE DevOps benchmark tasks for M1 Milestone (CUJ 1, 2 and 3)

### DIFF
--- a/tasks/gcp/deploy-postgres-web-app/task.yaml
+++ b/tasks/gcp/deploy-postgres-web-app/task.yaml
@@ -1,0 +1,130 @@
+task_id: 13
+name: "deploy-postgres-web-app"
+infrastructure:
+  deployer: "tofu"
+  stack: "prebuilt/minimum"
+  teardown: true
+  variables:
+    node_count: 3
+    machine_type: "e2-standard-2"
+prompt: "Deploy a Postgres-backed Python web app to namespace {{NAMESPACE}} in the cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}. The web app should have 2 replicas. Ensure that the deployment complies with GKE security baselines (e.g., non-root user, no privilege escalation) and passes admission controllers. Use `postgres:15` for the database and a standard python image (e.g., `python:3.9-slim`) for the web app, configured to connect to the database."
+expected_output: |
+  critical requirements:
+
+  - Expected Tool Call: generate_manifest
+  - Deploy a Postgres database using `postgres:15` image in namespace `{{NAMESPACE}}`.
+  - Create a Service for the Postgres database to allow the web app to connect.
+  - Deploy a Python web app with 2 replicas using a standard image (e.g., `python:3.9-slim`) in namespace `{{NAMESPACE}}`.
+  - Configure the web app to connect to the Postgres database using environment variables.
+  - Create a Service to expose the web app (ClusterIP is sufficient).
+  - Configure Pod Security Standards: set `securityContext` with `runAsNonRoot: true` and `allowPrivilegeEscalation: false` for both deployments.
+  - Set resource requests and limits for both deployments.
+
+  Expected Manifest Generated:
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: postgres-db
+    namespace: {{NAMESPACE}}
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: postgres
+    template:
+      metadata:
+        labels:
+          app: postgres
+      spec:
+        containers:
+        - name: postgres
+          image: postgres:15
+          env:
+          - name: POSTGRES_PASSWORD
+            value: "password" # Placeholder
+          ports:
+          - containerPort: 5432
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999 # Postgres default non-root
+            allowPrivilegeEscalation: false
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: postgres-service
+    namespace: {{NAMESPACE}}
+  spec:
+    ports:
+    - port: 5432
+    selector:
+      app: postgres
+  ---
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: web-app
+    namespace: {{NAMESPACE}}
+  spec:
+    replicas: 2
+    selector:
+      matchLabels:
+        app: web-app
+    template:
+      metadata:
+        labels:
+          app: web-app
+      spec:
+        containers:
+        - name: web-app
+          image: python:3.9-slim
+          command: ["python", "-c", "import time; print('App started'); time.sleep(3600)"] # Placeholder
+          env:
+          - name: DB_HOST
+            value: "postgres-service"
+          ports:
+          - containerPort: 8080
+          resources:
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: web-app-service
+    namespace: {{NAMESPACE}}
+  spec:
+    ports:
+    - port: 8080
+    selector:
+      app: web-app
+    type: ClusterIP
+
+documentation:
+  - doc_name: "GKE Hardening Guide"
+    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster"
+    constraints:
+      - text: "runAsNonRoot: true"
+        critical: true
+      - text: "allowPrivilegeEscalation: false"
+        critical: true
+  - doc_name: "Pod Security Standards"
+    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/pod-security-standards"
+    constraints:
+      - text: "restricted profile"
+        critical: false

--- a/tasks/gcp/deploy-postgres-web-app/task.yaml
+++ b/tasks/gcp/deploy-postgres-web-app/task.yaml
@@ -7,11 +7,10 @@ infrastructure:
   variables:
     node_count: 3
     machine_type: "e2-standard-2"
-prompt: "Deploy a Postgres-backed Python web app to namespace {{NAMESPACE}} in the cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}. The web app should have 2 replicas. Ensure that the deployment complies with GKE security baselines (e.g., non-root user, no privilege escalation) and passes admission controllers. Use `postgres:15` for the database and a standard python image (e.g., `python:3.9-slim`) for the web app, configured to connect to the database."
+prompt: "Deploy a Postgres-backed Python web app to namespace {{NAMESPACE}} in the cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}. The web app should have 2 replicas. Use `postgres:15` for the database and a standard python image (e.g., `python:3.9-slim`) for the web app, configured to connect to the database."
 expected_output: |
   critical requirements:
 
-  - Expected Tool Call: generate_manifest
   - Deploy a Postgres database using `postgres:15` image in namespace `{{NAMESPACE}}`.
   - Create a Service for the Postgres database to allow the web app to connect.
   - Deploy a Python web app with 2 replicas using a standard image (e.g., `python:3.9-slim`) in namespace `{{NAMESPACE}}`.

--- a/tasks/gcp/deploy-postgres-web-app/task.yaml
+++ b/tasks/gcp/deploy-postgres-web-app/task.yaml
@@ -7,11 +7,11 @@ infrastructure:
   variables:
     node_count: 3
     machine_type: "e2-standard-2"
-prompt: "Deploy a Postgres-backed Python web app to namespace {{NAMESPACE}} in the cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}. The web app should have 2 replicas. Use `postgres:15` for the database and a standard python image (e.g., `python:3.9-slim`) for the web app, configured to connect to the database."
+prompt: "Deploy a Postgres-backed Python web app to namespace {{NAMESPACE}} in the cluster {{GKE_CLUSTER_NAME}} in project {{GCP_PROJECT_ID}}. The web app should have 2 replicas. Use standard public images for both the web app and the database."
 expected_output: |
   critical requirements:
 
-  - Deploy a Postgres database using `postgres:15` image in namespace `{{NAMESPACE}}`.
+  - Deploy a Postgres database using a standard postgres image in namespace `{{NAMESPACE}}`.
   - Create a Service for the Postgres database to allow the web app to connect.
   - Deploy a Python web app with 2 replicas using a standard image (e.g., `python:3.9-slim`) in namespace `{{NAMESPACE}}`.
   - Configure the web app to connect to the Postgres database using environment variables.

--- a/tasks/gcp/gitops-auto-revert/task.yaml
+++ b/tasks/gcp/gitops-auto-revert/task.yaml
@@ -1,0 +1,46 @@
+task_id: 15
+name: "gitops-auto-revert"
+infrastructure:
+  deployer: "tofu"
+  stack: "prebuilt/gitops-revert"
+  teardown: true
+  variables:
+    node_count: 3
+    machine_type: "e2-standard-2"
+prompt: "The deployment `hello-app` in namespace {{NAMESPACE}} is failing. It is managed via GitOps from the repository at `/app/results/gitops-repo`. Fix the issue in the repository."
+expected_output: |
+  critical requirements:
+
+  - Confirm the 'hello-app' deployment in namespace '{{NAMESPACE}}' is in a failed state (e.g. ImagePullBackOff).
+  - Inspect git history at `/app/results/gitops-repo` to identify the last working version of the image (tag `1.0`).
+  - Create a new branch (e.g., `fix-hello-app`) in `/app/results/gitops-repo`.
+  - Modify `deployment.yaml` in the repository to revert the image tag to `1.0`.
+  - Commit the change to the new branch.
+
+  Expected Manifest Generated:
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: hello-app
+    namespace: {{NAMESPACE}}
+  spec:
+    replicas: 2
+    selector:
+      matchLabels:
+        app: hello-app
+    template:
+      metadata:
+        labels:
+          app: hello-app
+      spec:
+        containers:
+        - name: hello-app
+          image: us-docker.pkg.dev/google-samples/containers/gke/hello-app:1.0
+          ports:
+          - containerPort: 8080
+documentation:
+  - doc_name: "GitOps Application Delivery"
+    url: "https://cloud.google.com/kubernetes-engine/docs/concepts/add-on/gitops"
+    constraints:
+      - text: "revert configuration in git"
+        critical: true

--- a/tasks/gcp/troubleshoot-unhealthy-pod/task.yaml
+++ b/tasks/gcp/troubleshoot-unhealthy-pod/task.yaml
@@ -7,7 +7,7 @@ infrastructure:
   variables:
     node_count: 3
     machine_type: "e2-standard-2"
-prompt: "The `frontend` deployment in namespace {{NAMESPACE}} in cluster {{GKE_CLUSTER_NAME}} is failing. Diagnose the issue, identify the root cause by inspecting logs and events, and suggest a mitigation plan."
+prompt: "The `frontend` deployment in namespace {{NAMESPACE}} in cluster {{GKE_CLUSTER_NAME}} is failing. Diagnose the issue and suggest a mitigation."
 expected_output: |
   critical requirements:
 

--- a/tasks/gcp/troubleshoot-unhealthy-pod/task.yaml
+++ b/tasks/gcp/troubleshoot-unhealthy-pod/task.yaml
@@ -1,0 +1,27 @@
+task_id: 14
+name: "troubleshoot-unhealthy-pod"
+infrastructure:
+  deployer: "tofu"
+  stack: "prebuilt/unhealthy-pod"
+  teardown: true
+  variables:
+    node_count: 3
+    machine_type: "e2-standard-2"
+prompt: "The `frontend` deployment in namespace {{NAMESPACE}} in cluster {{GKE_CLUSTER_NAME}} is failing. Diagnose the issue, identify the root cause by inspecting logs and events, and suggest a mitigation plan."
+expected_output: |
+  critical requirements:
+
+  - Confirm the 'frontend' deployment in namespace '{{NAMESPACE}}' is in a failed state (e.g. CrashLoopBackOff).
+  - Inspect the logs of the failing 'frontend' pod and identify the error message: "FATAL: Database connection failed. Host db-service unreachable."
+  - Identify that the root cause is that the application cannot connect to 'db-service' because the service does not exist in the namespace '{{NAMESPACE}}'.
+  - Suggest a mitigation plan to resolve the issue (e.g., deploying the missing 'db-service' or updating the application configuration to point to a valid database).
+
+  Expected Manifest Generated: N/A, not a manifest generation request.
+documentation:
+  - doc_name: "Troubleshooting Applications"
+    url: "https://kubernetes.io/docs/tasks/debug/debug-application/"
+    constraints:
+      - text: "Inspect pod logs"
+        critical: true
+      - text: "Check pod events"
+        critical: false

--- a/tasks/gcp/troubleshoot-unhealthy-pod/task.yaml
+++ b/tasks/gcp/troubleshoot-unhealthy-pod/task.yaml
@@ -16,7 +16,14 @@ expected_output: |
   - Identify that the logs are unavailable or empty because the container failed to start due to the missing configuration.
   - Suggest the exact mitigation: Create the missing ConfigMap named `frontend-config` in namespace `{{NAMESPACE}}` with the key `api-url`.
 
-  Expected Manifest Generated: N/A, not a manifest generation request.
+  Expected Manifest Generated:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: frontend-config
+    namespace: {{NAMESPACE}}
+  data:
+    api-url: "http://mock-api"
 documentation:
   - doc_name: "Troubleshooting Applications"
     url: "https://kubernetes.io/docs/tasks/debug/debug-application/"

--- a/tasks/gcp/troubleshoot-unhealthy-pod/task.yaml
+++ b/tasks/gcp/troubleshoot-unhealthy-pod/task.yaml
@@ -11,17 +11,17 @@ prompt: "The `frontend` deployment in namespace {{NAMESPACE}} in cluster {{GKE_C
 expected_output: |
   critical requirements:
 
-  - Confirm the 'frontend' deployment in namespace '{{NAMESPACE}}' is in a failed state (e.g. CrashLoopBackOff).
-  - Inspect the logs of the failing 'frontend' pod and identify the error message: "FATAL: Database connection failed. Host db-service unreachable."
-  - Identify that the root cause is that the application cannot connect to 'db-service' because the service does not exist in the namespace '{{NAMESPACE}}'.
-  - Suggest a mitigation plan to resolve the issue (e.g., deploying the missing 'db-service' or updating the application configuration to point to a valid database).
+  - Confirm the 'frontend' deployment in namespace '{{NAMESPACE}}' is in a failed state (e.g., `CreateContainerConfigError` or `CreateContainerError`).
+  - Identify the root cause by inspecting pod events (e.g., `warning` events indicating `configmap "frontend-config" not found`).
+  - Identify that the logs are unavailable or empty because the container failed to start due to the missing configuration.
+  - Suggest the exact mitigation: Create the missing ConfigMap named `frontend-config` in namespace `{{NAMESPACE}}` with the key `api-url`.
 
   Expected Manifest Generated: N/A, not a manifest generation request.
 documentation:
   - doc_name: "Troubleshooting Applications"
     url: "https://kubernetes.io/docs/tasks/debug/debug-application/"
     constraints:
-      - text: "Inspect pod logs"
-        critical: true
       - text: "Check pod events"
-        critical: false
+        critical: true
+      - text: "Inspect pod status"
+        critical: true

--- a/tf/prebuilt/gitops-revert/main.tf
+++ b/tf/prebuilt/gitops-revert/main.tf
@@ -1,0 +1,162 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  zone    = var.location
+}
+
+module "gke" {
+  source       = "../../modules/gke"
+  project_id   = var.project_id
+  cluster_name = var.cluster_name
+  location     = var.location
+  node_count   = var.node_count
+  machine_type = var.machine_type
+}
+
+data "google_client_config" "default" {}
+
+provider "kubernetes" {
+  host                   = "https://${module.gke.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(module.gke.cluster_ca_certificate)
+}
+
+resource "kubernetes_namespace" "gitops" {
+  count = var.namespace == "default" ? 0 : 1
+  metadata {
+    name = var.namespace
+  }
+}
+
+resource "kubernetes_deployment" "hello_app" {
+  metadata {
+    name      = "hello-app"
+    namespace = var.namespace
+    labels = {
+      app = "hello-app"
+    }
+  }
+
+  spec {
+    replicas = 2
+
+    selector {
+      match_labels = {
+        app = "hello-app"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "hello-app"
+        }
+      }
+
+      spec {
+        container {
+          image = "us-docker.pkg.dev/google-samples/containers/gke/hello-app:2.0-broken"
+          name  = "hello-app"
+          port {
+            container_port = 8080
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [module.gke, kubernetes_namespace.gitops]
+}
+
+resource "null_resource" "gitops_repo_setup" {
+  provisioner "local-exec" {
+    command = <<EOT
+      mkdir -p /app/results/gitops-repo
+      cd /app/results/gitops-repo
+      git init
+      git config user.email "gitops-bot@example.com"
+      git config user.name "GitOps Bot"
+      
+      # Write working deployment
+      cat <<EOF > deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-app
+  namespace: ${var.namespace}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-app
+  template:
+    metadata:
+      labels:
+        app: hello-app
+    spec:
+      containers:
+      - name: hello-app
+        image: us-docker.pkg.dev/google-samples/containers/gke/hello-app:1.0
+        ports:
+        - containerPort: 8080
+EOF
+      git add deployment.yaml
+      git commit -m "Deploy hello-app v1.0"
+      
+      # Write broken deployment
+      cat <<EOF > deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-app
+  namespace: ${var.namespace}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-app
+  template:
+    metadata:
+      labels:
+        app: hello-app
+    spec:
+      containers:
+      - name: hello-app
+        image: us-docker.pkg.dev/google-samples/containers/gke/hello-app:2.0-broken
+        ports:
+        - containerPort: 8080
+EOF
+      git add deployment.yaml
+      git commit -m "Upgrade hello-app to v2.0-broken"
+    EOT
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "rm -rf /app/results/gitops-repo"
+  }
+}
+
+output "cluster_name" {
+  value = module.gke.cluster_name
+}
+
+output "cluster_location" {
+  value = module.gke.cluster_location
+}

--- a/tf/prebuilt/gitops-revert/variables.tf
+++ b/tf/prebuilt/gitops-revert/variables.tf
@@ -1,0 +1,16 @@
+variable "project_id" {}
+variable "cluster_name" {}
+
+variable "location" { default = "us-central1-a" }
+variable "node_count" {
+  type    = number
+  default = 3
+}
+variable "machine_type" {
+  type    = string
+  default = "e2-standard-2"
+}
+variable "namespace" {
+  type    = string
+  default = "default"
+}

--- a/tf/prebuilt/unhealthy-pod/main.tf
+++ b/tf/prebuilt/unhealthy-pod/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  zone    = var.location
+}
+
+module "gke" {
+  source       = "../../modules/gke"
+  project_id   = var.project_id
+  cluster_name = var.cluster_name
+  location     = var.location
+  node_count   = var.node_count
+  machine_type = var.machine_type
+}
+
+data "google_client_config" "default" {}
+
+provider "kubernetes" {
+  host                   = "https://${module.gke.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(module.gke.cluster_ca_certificate)
+}
+
+resource "kubernetes_deployment" "frontend" {
+  metadata {
+    name      = "frontend"
+    namespace = var.namespace
+    labels = {
+      app = "frontend"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "frontend"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "frontend"
+        }
+      }
+
+      spec {
+        container {
+          image   = "busybox"
+          name    = "frontend"
+          command = ["sh", "-c", "echo 'Connecting to DB...'; sleep 2; ping -c 1 db-service; if [ $? -ne 0 ]; then echo 'FATAL: Database connection failed. Host db-service unreachable.'; exit 1; fi; echo 'Connected!'; sleep 3600"]
+        }
+      }
+    }
+  }
+}
+
+output "cluster_name" {
+  value = module.gke.cluster_name
+}
+
+output "cluster_location" {
+  value = module.gke.cluster_location
+}

--- a/tf/prebuilt/unhealthy-pod/main.tf
+++ b/tf/prebuilt/unhealthy-pod/main.tf
@@ -62,7 +62,17 @@ resource "kubernetes_deployment" "frontend" {
         container {
           image   = "busybox"
           name    = "frontend"
-          command = ["sh", "-c", "echo 'Connecting to DB...'; sleep 2; ping -c 1 db-service; if [ $? -ne 0 ]; then echo 'FATAL: Database connection failed. Host db-service unreachable.'; exit 1; fi; echo 'Connected!'; sleep 3600"]
+          command = ["sh", "-c", "echo 'Frontend running...'; sleep 3600"]
+          
+          env {
+            name = "API_URL"
+            value_from {
+              config_map_key_ref {
+                name = "frontend-config"
+                key  = "api-url"
+              }
+            }
+          }
         }
       }
     }

--- a/tf/prebuilt/unhealthy-pod/variables.tf
+++ b/tf/prebuilt/unhealthy-pod/variables.tf
@@ -1,0 +1,17 @@
+variable "project_id" {}
+variable "cluster_name" {}
+
+variable "location" { default = "us-central1-a" }
+variable "node_count" {
+  type    = number
+  default = 3
+}
+variable "machine_type" {
+  type    = string
+  default = "e2-standard-2"
+}
+variable "namespace" {
+  type    = string
+  default = "default"
+}
+


### PR DESCRIPTION
### Description
This PR adds three new benchmark tasks to evaluate GKE-focused operations agents against the **M1 Milestone** requirements. It also introduces two new prebuilt infrastructure stacks to support troubleshooting and GitOps scenario setups.

---

### **New Tasks Added**

#### **1. Deploy Postgres-Backed Web App (CUJ 1: Deploy via NL)**
*   **Path**: `tasks/gcp/deploy-postgres-web-app/task.yaml`
*   **Goal**: Evaluates if the agent can deploy a secure, compliant two-tier application (Python + Postgres) in a dynamic namespace.
*   **Key Checks**:
    *   Generates and applies manifests for both web-app and database using standard public images.
    *   Configures environment-based database connection.
    *   Enforces GKE security hardening guidelines (e.g., `runAsNonRoot: true`, `allowPrivilegeEscalation: false`).
    *   Sets appropriate resource requests/limits.

#### **2. Troubleshoot Unhealthy Pod (CUJ 2: Pod RCA)**
*   **Path**: `tasks/gcp/troubleshoot-unhealthy-pod/task.yaml`
*   **Goal**: Evaluates the agent's ability to perform Root Cause Analysis (RCA) on a failing deployment with a deterministic mitigation path.
*   **Key Checks**:
    *   Identifies the failing state (`CreateContainerConfigError`) of the frontend service in the target namespace.
    *   Inspects pod events to identify the missing ConfigMap (`frontend-config`) and missing key (`api-url`).
    *   Suggests the exact mitigation: Create the missing ConfigMap `frontend-config` with the `api-url` key.

#### **3. GitOps Auto-Revert (CUJ 3: Manage Cluster Config)**
*   **Path**: `tasks/gcp/gitops-auto-revert/task.yaml`
*   **Goal**: Evaluates the agent's ability to detect a deployment failure caused by a bad config change, inspect git history, and propose a fix in the Git repository.
*   **Key Checks**:
    *   Identifies that the deployment `hello-app` is failing due to `ImagePullBackOff` (invalid image tag).
    *   Inspects the git log at `/app/results/gitops-repo` to find the last working image tag (`1.0`).
    *   Creates a new branch (e.g., `fix-hello-app`) and modifies the manifest to revert the image tag back to `1.0`.
    *   Commits the fix to the repository.

---

### **Infrastructure Changes (tf/)**
*   **Added `tf/prebuilt/unhealthy-pod` stack**:
    *   Provisions GKE cluster + deploys a `frontend` pod referencing a missing ConfigMap to trigger `CreateContainerConfigError`.
*   **Added `tf/prebuilt/gitops-revert` stack**:
    *   Provisions GKE cluster + deploys a `hello-app` pod with an invalid image tag.
    *   Uses a `null_resource` to initialize a local Git repository at `/app/results/gitops-repo` with the mock commit history (v1.0 working -> v2.0-broken).

Both stacks support dynamic namespaces via OpenTofu variables.

---

### **Testing Locally**
You can run these tasks locally using the `devops-bench` runner by pointing to the task configs:
```bash
# Run Task 1 (CUJ 1)
export BENCH_TASK_FILE="tasks/gcp/deploy-postgres-web-app/task.yaml"

# Run Task 2 (CUJ 2)
export BENCH_TASK_FILE="tasks/gcp/troubleshoot-unhealthy-pod/task.yaml"

# Run Task 3 (CUJ 3)
export BENCH_TASK_FILE="tasks/gcp/gitops-auto-revert/task.yaml"

# Run the evaluator
./scripts/entrypoint.sh
```