### PR TITLE
feat(tasks): add task contracts (schema + loader)

### DIFF
--- a/devops_bench/tasks/__init__.py
+++ b/devops_bench/tasks/__init__.py
@@ -14,7 +14,7 @@
 
 """Task contracts: the typed schema and loaders for benchmark tasks."""
 
-from devops_bench.tasks.loader import FileSystemTaskLoader, TaskLoader, load_tasks
+from devops_bench.tasks.loader import FileSystemTaskLoader, TaskLoader
 from devops_bench.tasks.schema import Constraint, DocumentationEntry, Task
 
 __all__ = [
@@ -23,5 +23,4 @@ __all__ = [
     "DocumentationEntry",
     "TaskLoader",
     "FileSystemTaskLoader",
-    "load_tasks",
 ]

--- a/devops_bench/tasks/__init__.py
+++ b/devops_bench/tasks/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Task contracts: the typed schema and loaders for benchmark tasks."""
+
+from devops_bench.tasks.loader import FileSystemTaskLoader, TaskLoader, load_tasks
+from devops_bench.tasks.schema import Constraint, DocumentationEntry, Task
+
+__all__ = [
+    "Task",
+    "Constraint",
+    "DocumentationEntry",
+    "TaskLoader",
+    "FileSystemTaskLoader",
+    "load_tasks",
+]

--- a/devops_bench/tasks/loader.py
+++ b/devops_bench/tasks/loader.py
@@ -1,0 +1,225 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loading task contracts from a tasks directory or a single spec file."""
+
+from __future__ import annotations
+
+import json
+import os
+from abc import ABC, abstractmethod
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from devops_bench.core import ConfigError, get_logger
+from devops_bench.tasks.schema import Task
+
+__all__ = [
+    "TaskLoader",
+    "FileSystemTaskLoader",
+    "load_from_tasks_dir",
+    "load_tasks",
+]
+
+_log = get_logger("tasks.loader")
+
+_TASK_FILE = "task.yaml"
+
+# YAML 1.2 semantics: only ``true``/``false`` are booleans, so ``yes``/``no``/
+# ``on``/``off`` parse as plain strings rather than being coerced to booleans.
+_yaml = YAML(typ="safe")
+
+
+def safe_parse_yaml(content: str) -> Any:
+    """Parse YAML text into a Python value, treating empty documents as ``{}``.
+
+    Args:
+        content: Raw YAML text.
+
+    Returns:
+        The parsed value (typically a mapping, but possibly a list or scalar),
+        or an empty dict for empty/null documents.
+    """
+    return _yaml.load(content) or {}
+
+
+def _sort_key(task: Task) -> tuple[int, int | str]:
+    """Order numeric ids by value and fall back to lexical order otherwise."""
+    text = str(task.id)
+    return (0, int(text)) if text.isdigit() else (1, text)
+
+
+def _load_yaml_task(path: str, name_default: str) -> Task | None:
+    """Read one YAML spec file into a Task, or None if it is not a mapping.
+
+    Args:
+        path: Path to the YAML spec file.
+        name_default: Fallback name used when the spec omits one.
+
+    Returns:
+        The parsed task, or ``None`` when the document is not a mapping.
+    """
+    with open(path) as stream:
+        content = safe_parse_yaml(stream.read())
+    if not isinstance(content, dict):
+        return None
+    return Task.from_dict(content, name_default=name_default)
+
+
+def load_from_tasks_dir(dir_path: str) -> list[Task]:
+    """Recursively load every ``task.yaml`` under a tasks directory.
+
+    Directories are walked in sorted order for deterministic discovery, and the
+    returned tasks are sorted by id (numeric ids by value). A spec that fails to
+    parse is logged and skipped rather than aborting the load. A duplicate
+    explicit task id is logged as a warning but still loaded, keeping directory
+    loading resilient.
+
+    Args:
+        dir_path: Root directory to scan.
+
+    Returns:
+        The discovered tasks, sorted by id.
+
+    Raises:
+        ConfigError: If ``dir_path`` does not exist.
+    """
+    if not os.path.exists(dir_path):
+        raise ConfigError(f"tasks directory not found at {dir_path}")
+
+    tasks: list[Task] = []
+    seen_ids: set[str] = set()
+    for root, dirs, files in os.walk(dir_path):
+        # Sort dirs in place to ensure deterministic ordering during walk.
+        dirs.sort()
+        if _TASK_FILE not in files:
+            continue
+
+        yaml_path = os.path.join(root, _TASK_FILE)
+        try:
+            task = _load_yaml_task(yaml_path, name_default=os.path.basename(root))
+            if task is not None:
+                if task.id and task.id in seen_ids:
+                    _log.warning("duplicate task id %r at %s", task.id, yaml_path)
+                elif task.id:
+                    seen_ids.add(task.id)
+                tasks.append(task)
+        except Exception as exc:
+            _log.warning("Failed to read task spec in %s: %s", yaml_path, exc)
+
+    tasks.sort(key=_sort_key)
+    return tasks
+
+
+def _load_single_file(path: str) -> list[Task]:
+    """Load tasks from a single ``.yaml``/``.yml``/``.json`` spec file.
+
+    YAML files yield a single task; JSON files may hold a single object or a
+    list of objects. A YAML document or JSON payload that is neither a mapping
+    nor (for JSON) a list yields no tasks.
+
+    Args:
+        path: Path to the spec file.
+
+    Returns:
+        The loaded tasks.
+
+    Raises:
+        ConfigError: If the file cannot be parsed or holds a malformed payload.
+            Unlike directory loads (which log and skip), single-file loads
+            always surface a clean ``ConfigError``.
+    """
+    name_default = os.path.splitext(os.path.basename(path))[0]
+
+    try:
+        if path.endswith((".yaml", ".yml")):
+            task = _load_yaml_task(path, name_default=name_default)
+            return [task] if task is not None else []
+
+        with open(path) as f:
+            raw = json.load(f)
+
+        if isinstance(raw, dict):
+            return [Task.from_dict(raw, name_default=name_default)]
+        if isinstance(raw, list):
+            tasks: list[Task] = []
+            for idx, item in enumerate(raw):
+                if not isinstance(item, dict):
+                    raise ConfigError(f"task spec {path}: JSON list element {idx} is not an object")
+                tasks.append(Task.from_dict(item, name_default=name_default))
+            return tasks
+        return []
+    except ConfigError:
+        raise
+    except Exception as exc:
+        raise ConfigError(f"failed to load task spec {path}: {exc}") from exc
+
+
+class TaskLoader(ABC):
+    """Loads task contracts from a source such as a directory or file."""
+
+    @abstractmethod
+    def load_tasks(self, source: str) -> list[Task]:
+        """Load and parse tasks from the given source.
+
+        Args:
+            source: Location to load from (e.g. a directory or spec file path).
+
+        Returns:
+            The loaded tasks.
+        """
+
+
+class FileSystemTaskLoader(TaskLoader):
+    """Loads tasks from a directory tree or a single YAML/JSON spec file."""
+
+    def load_tasks(self, source: str) -> list[Task]:
+        """Load tasks from a directory or a single spec file.
+
+        A directory is scanned recursively; a file is parsed as YAML
+        (``.yaml``/``.yml``) or JSON, where JSON may hold a single object or a
+        list of objects.
+
+        Args:
+            source: A tasks directory or a single spec file.
+
+        Returns:
+            The loaded tasks; directory sources are sorted by id.
+
+        Raises:
+            ConfigError: If ``source`` does not exist.
+        """
+        if os.path.isdir(source):
+            return load_from_tasks_dir(source)
+        if not os.path.exists(source):
+            raise ConfigError(f"task spec not found at {source}")
+        return _load_single_file(source)
+
+
+def load_tasks(source: str) -> list[Task]:
+    """Load task contracts from a directory or a single spec file.
+
+    Convenience wrapper over :class:`FileSystemTaskLoader`.
+
+    Args:
+        source: A tasks directory or a single spec file.
+
+    Returns:
+        The loaded tasks.
+
+    Raises:
+        ConfigError: If ``source`` does not exist.
+    """
+    return FileSystemTaskLoader().load_tasks(source)

--- a/devops_bench/tasks/loader.py
+++ b/devops_bench/tasks/loader.py
@@ -17,8 +17,8 @@
 from __future__ import annotations
 
 import json
-import os
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any
 
 from ruamel.yaml import YAML
@@ -61,7 +61,7 @@ def _sort_key(task: Task) -> tuple[int, int | str]:
     return (0, int(text)) if text.isdigit() else (1, text)
 
 
-def _load_yaml_task(path: str, name_default: str) -> Task | None:
+def _load_yaml_task(path: Path, name_default: str) -> Task | None:
     """Read one YAML spec file into a Task, or None if it is not a mapping.
 
     Args:
@@ -71,8 +71,7 @@ def _load_yaml_task(path: str, name_default: str) -> Task | None:
     Returns:
         The parsed task, or ``None`` when the document is not a mapping.
     """
-    with open(path) as stream:
-        content = safe_parse_yaml(stream.read())
+    content = safe_parse_yaml(path.read_text())
     if not isinstance(content, dict):
         return None
     return Task.from_dict(content, name_default=name_default)
@@ -96,20 +95,21 @@ def load_from_tasks_dir(dir_path: str) -> list[Task]:
     Raises:
         ConfigError: If ``dir_path`` does not exist.
     """
-    if not os.path.exists(dir_path):
+    root_dir = Path(dir_path)
+    if not root_dir.exists():
         raise ConfigError(f"tasks directory not found at {dir_path}")
 
     tasks: list[Task] = []
     seen_ids: set[str] = set()
-    for root, dirs, files in os.walk(dir_path):
+    for current, dirs, files in root_dir.walk():
         # Sort dirs in place to ensure deterministic ordering during walk.
         dirs.sort()
         if _TASK_FILE not in files:
             continue
 
-        yaml_path = os.path.join(root, _TASK_FILE)
+        yaml_path = current / _TASK_FILE
         try:
-            task = _load_yaml_task(yaml_path, name_default=os.path.basename(root))
+            task = _load_yaml_task(yaml_path, name_default=current.name)
             if task is not None:
                 if task.id and task.id in seen_ids:
                     _log.warning("duplicate task id %r at %s", task.id, yaml_path)
@@ -141,15 +141,15 @@ def _load_single_file(path: str) -> list[Task]:
             Unlike directory loads (which log and skip), single-file loads
             always surface a clean ``ConfigError``.
     """
-    name_default = os.path.splitext(os.path.basename(path))[0]
+    spec = Path(path)
+    name_default = spec.stem
 
     try:
-        if path.endswith((".yaml", ".yml")):
-            task = _load_yaml_task(path, name_default=name_default)
+        if spec.suffix in (".yaml", ".yml"):
+            task = _load_yaml_task(spec, name_default=name_default)
             return [task] if task is not None else []
 
-        with open(path) as f:
-            raw = json.load(f)
+        raw = json.loads(spec.read_text())
 
         if isinstance(raw, dict):
             return [Task.from_dict(raw, name_default=name_default)]
@@ -201,9 +201,10 @@ class FileSystemTaskLoader(TaskLoader):
         Raises:
             ConfigError: If ``source`` does not exist.
         """
-        if os.path.isdir(source):
+        spec = Path(source)
+        if spec.is_dir():
             return load_from_tasks_dir(source)
-        if not os.path.exists(source):
+        if not spec.exists():
             raise ConfigError(f"task spec not found at {source}")
         return _load_single_file(source)
 

--- a/devops_bench/tasks/loader.py
+++ b/devops_bench/tasks/loader.py
@@ -30,7 +30,6 @@ __all__ = [
     "TaskLoader",
     "FileSystemTaskLoader",
     "load_from_tasks_dir",
-    "load_tasks",
 ]
 
 _log = get_logger("tasks.loader")
@@ -207,20 +206,3 @@ class FileSystemTaskLoader(TaskLoader):
         if not spec.exists():
             raise ConfigError(f"task spec not found at {source}")
         return _load_single_file(source)
-
-
-def load_tasks(source: str) -> list[Task]:
-    """Load task contracts from a directory or a single spec file.
-
-    Convenience wrapper over :class:`FileSystemTaskLoader`.
-
-    Args:
-        source: A tasks directory or a single spec file.
-
-    Returns:
-        The loaded tasks.
-
-    Raises:
-        ConfigError: If ``source`` does not exist.
-    """
-    return FileSystemTaskLoader().load_tasks(source)

--- a/devops_bench/tasks/schema.py
+++ b/devops_bench/tasks/schema.py
@@ -1,0 +1,194 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed schema for benchmark task contracts."""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+__all__ = ["Task", "DocumentationEntry", "Constraint"]
+
+# Strict validation: reject implicit type coercion (e.g. the string ``"yes"``
+# is not a bool), and ignore unknown keys in source specs.
+_STRICT = ConfigDict(strict=True, extra="ignore")
+
+
+def _text(value: Any) -> Any:
+    """Coalesce an empty (``None``) text value to ``""`` and strip strings.
+
+    A non-string, non-None value is returned unchanged so strict validation can
+    reject it.
+
+    Args:
+        value: The raw text value from a parsed spec.
+
+    Returns:
+        ``""`` for ``None``, the stripped string for a string, else ``value``.
+    """
+    if value is None:
+        return ""
+    return value.strip() if isinstance(value, str) else value
+
+
+class Constraint(BaseModel):
+    """A single documented requirement the agent's solution must satisfy.
+
+    Attributes:
+        text: The requirement description.
+        critical: Whether failing this requirement fails the task outright.
+    """
+
+    model_config = _STRICT
+
+    text: str
+    critical: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coalesce_empty(cls, data: Any) -> Any:
+        """Coalesce empty (``None``) nested YAML keys to field defaults.
+
+        Only ``None`` values are coalesced; other values pass through so strict
+        validation still rejects genuinely wrong types (e.g. ``critical: "yes"``).
+        """
+        if not isinstance(data, dict):
+            return data
+        coalesced = dict(data)
+        if "text" in coalesced and coalesced["text"] is None:
+            coalesced["text"] = ""
+        if "critical" in coalesced and coalesced["critical"] is None:
+            coalesced["critical"] = False
+        return coalesced
+
+
+class DocumentationEntry(BaseModel):
+    """A reference document and the constraints derived from it.
+
+    Attributes:
+        doc_name: Human-readable document name.
+        url: Source URL for the document.
+        constraints: Requirements drawn from the document.
+    """
+
+    model_config = _STRICT
+
+    doc_name: str = ""
+    url: str = ""
+    constraints: list[Constraint] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coalesce_empty(cls, data: Any) -> Any:
+        """Coalesce empty (``None``) nested YAML keys to field defaults.
+
+        Only ``None`` values are coalesced; other values pass through so strict
+        validation still rejects genuinely wrong types.
+        """
+        if not isinstance(data, dict):
+            return data
+        coalesced = dict(data)
+        if "doc_name" in coalesced and coalesced["doc_name"] is None:
+            coalesced["doc_name"] = ""
+        if "url" in coalesced and coalesced["url"] is None:
+            coalesced["url"] = ""
+        if "constraints" in coalesced and coalesced["constraints"] is None:
+            coalesced["constraints"] = []
+        return coalesced
+
+
+class Task(BaseModel):
+    """Standardized representation of an evaluation task.
+
+    Attributes:
+        id: Task identifier.
+        name: Human-readable task name.
+        prompt: Instruction text driving the agent.
+        expected_output: Reference output the result is judged against.
+        retrieval_context: Supporting passages for retrieval-based scoring.
+        chaos_spec: Opaque chaos-injection specification parsed by the chaos
+            subsystem; may be a mapping, list, or raw JSON string.
+        verification_spec: Opaque verification specification parsed by the
+            verification subsystem; may be a mapping, list, or raw JSON string.
+        infrastructure: Deployer and stack settings for the task environment.
+        documentation: Documentation entries, each with per-constraint criticality.
+    """
+
+    model_config = _STRICT
+
+    id: str = ""
+    name: str = ""
+    prompt: str = ""
+    expected_output: str = ""
+    retrieval_context: list[str] = Field(default_factory=list)
+    chaos_spec: Any = None
+    verification_spec: Any = None
+    infrastructure: dict[str, Any] = Field(default_factory=dict)
+    documentation: list[DocumentationEntry] = Field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any], *, name_default: str = "") -> "Task":
+        """Build a task from a parsed spec mapping, validating types strictly.
+
+        Adapts the source naming before validation: ``task_id`` is accepted as an
+        alias for ``id`` (and coerced to a string), and ``goal``/``input`` are
+        accepted as aliases for ``prompt``. Text fields are stripped. Malformed
+        values (e.g. a non-boolean ``critical``) raise ``pydantic.ValidationError``.
+
+        Args:
+            raw: Parsed mapping for a single task.
+            name_default: Name used when the mapping omits ``name``.
+
+        Returns:
+            The validated task.
+
+        Raises:
+            ValidationError: If a field has the wrong type.
+        """
+        raw_id = raw.get("id")
+        if raw_id is None:
+            raw_id = raw.get("task_id")
+        name = raw.get("name")
+        prompt = raw.get("prompt")
+        if prompt is None:
+            prompt = raw.get("goal")
+        if prompt is None:
+            prompt = raw.get("input")
+        retrieval = raw.get("retrieval_context", [])
+        infrastructure = raw.get("infrastructure", {})
+        documentation = raw.get("documentation", [])
+
+        return cls.model_validate(
+            {
+                "id": "" if raw_id is None else str(raw_id),
+                "name": name_default if name is None else name,
+                "prompt": _text(prompt),
+                "expected_output": _text(raw.get("expected_output", "")),
+                # An empty YAML block (``key:`` with no value) parses to None;
+                # treat it as the field's empty default rather than rejecting it.
+                "retrieval_context": [] if retrieval is None else retrieval,
+                "chaos_spec": raw.get("chaos_spec"),
+                "verification_spec": raw.get("verification_spec"),
+                "infrastructure": {} if infrastructure is None else infrastructure,
+                "documentation": [] if documentation is None else documentation,
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the task as a plain serializable mapping.
+
+        Returns:
+            A mapping of every field name to its value.
+        """
+        return self.model_dump()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,9 @@ dependencies = [
     "google-genai>=2.6.0",
     "mcp>=1.27.1",
     "anthropic>=0.104.1",
+    "pydantic>=2.0",
     "pyyaml>=6.0.3",
+    "ruamel.yaml>=0.18.0",
 ]
 
 [tool.hatch.version]

--- a/tests/unit/tasks/test_tasks_loader.py
+++ b/tests/unit/tasks/test_tasks_loader.py
@@ -1,0 +1,294 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.tasks.loader using real temp directories."""
+
+import json
+import logging
+import os
+
+import pytest
+
+from devops_bench.core.errors import ConfigError
+from devops_bench.tasks.loader import (
+    FileSystemTaskLoader,
+    TaskLoader,
+    load_from_tasks_dir,
+    load_tasks,
+)
+
+
+def _write(path: str, content: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def test_load_from_tasks_dir_recursive_and_ordered(tmp_path):
+    # id 2 lives under a directory that sorts before id 1, so a correct
+    # loader must sort by id rather than discovery order.
+    _write(
+        os.path.join(str(tmp_path), "aaa", "task-two", "task.yaml"),
+        'task_id: 2\nname: "task-two"\nprompt: "Two"\nexpected_output: "E2"\n',
+    )
+    _write(
+        os.path.join(str(tmp_path), "zzz", "task-one", "task.yaml"),
+        'task_id: 1\nname: "task-one"\nprompt: "One"\nexpected_output: "E1"\n',
+    )
+
+    tasks = load_tasks(str(tmp_path))
+    assert len(tasks) == 2
+    assert tasks[0].id == "1"
+    assert tasks[0].name == "task-one"
+    assert tasks[1].id == "2"
+    assert tasks[1].name == "task-two"
+
+
+def test_numeric_ids_sort_by_value_not_lexically(tmp_path):
+    _write(os.path.join(str(tmp_path), "a", "task.yaml"), 'task_id: 10\nname: "ten"\n')
+    _write(os.path.join(str(tmp_path), "b", "task.yaml"), 'task_id: 2\nname: "two"\n')
+
+    tasks = load_from_tasks_dir(str(tmp_path))
+    assert [t.name for t in tasks] == ["two", "ten"]
+
+
+def test_load_from_tasks_dir_subdir_scope(tmp_path):
+    _write(
+        os.path.join(str(tmp_path), "gcp", "task-gcp", "task.yaml"),
+        'task_id: 1\nname: "task-gcp"\nprompt: "GCP"\nexpected_output: "G"\n',
+    )
+    _write(
+        os.path.join(str(tmp_path), "generic", "task-generic", "task.yaml"),
+        'task_id: 2\nname: "task-generic"\nprompt: "Generic"\nexpected_output: "X"\n',
+    )
+
+    scoped = load_from_tasks_dir(os.path.join(str(tmp_path), "generic"))
+    assert len(scoped) == 1
+    assert scoped[0].name == "task-generic"
+
+
+def test_field_defaults_missing_id_and_name(tmp_path):
+    # No task_id and no name -> empty id and the directory basename.
+    _write(
+        os.path.join(str(tmp_path), "the-dir-name", "task.yaml"),
+        'prompt: "  padded prompt  "\nexpected_output: "  padded  "\n',
+    )
+
+    tasks = load_from_tasks_dir(str(tmp_path))
+    assert len(tasks) == 1
+    assert tasks[0].id == ""
+    assert tasks[0].name == "the-dir-name"
+    assert tasks[0].prompt == "padded prompt"
+    assert tasks[0].expected_output == "padded"
+
+
+def test_goal_alias_in_dir_load(tmp_path):
+    _write(
+        os.path.join(str(tmp_path), "alias", "task.yaml"),
+        'task_id: 5\ngoal: "  goal driven  "\n',
+    )
+    tasks = load_from_tasks_dir(str(tmp_path))
+    assert tasks[0].prompt == "goal driven"
+
+
+_DOC_YAML = """\
+task_id: 1
+name: "doc-task"
+prompt: "p"
+expected_output: "e"
+documentation:
+  - doc_name: "Guide A"
+    url: "https://example.com/a"
+    constraints:
+      - text: "Must use TLS"
+        critical: true
+      - text: "Prefer caching"
+        critical: false
+  - doc_name: "Guide B"
+    url: "https://example.com/b"
+    constraints:
+      - text: "Optional thing"
+"""
+
+
+def test_documentation_parsed_on_load(tmp_path):
+    _write(os.path.join(str(tmp_path), "doc", "task.yaml"), _DOC_YAML)
+    docs = load_from_tasks_dir(str(tmp_path))[0].documentation
+    assert len(docs) == 2
+
+    assert docs[0].doc_name == "Guide A"
+    assert docs[0].url == "https://example.com/a"
+    assert [(c.text, c.critical) for c in docs[0].constraints] == [
+        ("Must use TLS", True),
+        ("Prefer caching", False),
+    ]
+
+    assert docs[1].doc_name == "Guide B"
+    assert docs[1].url == "https://example.com/b"
+    # A constraint without an explicit critical flag defaults to False.
+    assert [(c.text, c.critical) for c in docs[1].constraints] == [("Optional thing", False)]
+
+
+def test_invalid_task_is_skipped_with_warning(tmp_path, caplog):
+    # Under YAML 1.2 ``critical: yes`` is the string "yes"; the strict schema
+    # rejects it, so the task is skipped with a warning rather than loaded.
+    yaml_text = (
+        "task_id: 1\n"
+        'name: "n"\n'
+        "documentation:\n"
+        '  - doc_name: "A"\n'
+        "    constraints:\n"
+        '      - text: "x"\n'
+        "        critical: yes\n"
+    )
+    _write(os.path.join(str(tmp_path), "d", "task.yaml"), yaml_text)
+    with caplog.at_level(logging.WARNING, logger="devops_bench.tasks.loader"):
+        tasks = load_from_tasks_dir(str(tmp_path))
+    assert tasks == []
+    assert any("Failed to read task spec" in rec.message for rec in caplog.records)
+
+
+def test_yaml_1_2_booleans_stay_strings(tmp_path):
+    # ``yes``/``no``/``off`` are plain strings under YAML 1.2; only
+    # ``true``/``false`` are booleans.
+    _write(
+        os.path.join(str(tmp_path), "t", "task.yaml"),
+        'task_id: 1\ninfrastructure:\n  a: yes\n  b: "no"\n  c: true\n',
+    )
+    infra = load_from_tasks_dir(str(tmp_path))[0].infrastructure
+    assert infra["a"] == "yes"
+    assert infra["b"] == "no"
+    assert infra["c"] is True
+
+
+def test_load_single_yaml_file(tmp_path):
+    path = os.path.join(str(tmp_path), "case.yaml")
+    _write(path, 'task_id: 11\nname: "single"\nprompt: "  hi  "\nexpected_output: "out"\n')
+    tasks = load_tasks(path)
+    assert len(tasks) == 1
+    assert tasks[0].id == "11"
+    assert tasks[0].name == "single"
+    assert tasks[0].prompt == "hi"
+
+
+def test_load_single_json_file_object_with_goal_alias(tmp_path):
+    path = os.path.join(str(tmp_path), "case.json")
+    _write(
+        path,
+        json.dumps({"task_id": 4, "name": "json-case", "goal": "json goal"}),
+    )
+    tasks = load_tasks(path)
+    assert len(tasks) == 1
+    assert tasks[0].id == "4"
+    assert tasks[0].name == "json-case"
+    assert tasks[0].prompt == "json goal"
+
+
+def test_load_single_json_file_list(tmp_path):
+    path = os.path.join(str(tmp_path), "cases.json")
+    _write(
+        path,
+        json.dumps(
+            [
+                {"task_id": 1, "name": "a", "input": "ia"},
+                {"task_id": 2, "name": "b", "goal": "gb"},
+            ]
+        ),
+    )
+    tasks = load_tasks(path)
+    assert [t.name for t in tasks] == ["a", "b"]
+    assert tasks[0].prompt == "ia"
+    assert tasks[1].prompt == "gb"
+
+
+def test_single_file_malformed_yaml_raises_config_error(tmp_path):
+    # A single malformed YAML spec surfaces a clean ConfigError rather than
+    # leaking the underlying parser error.
+    path = os.path.join(str(tmp_path), "broken.yaml")
+    _write(path, "[unterminated")
+    with pytest.raises(ConfigError):
+        load_tasks(path)
+
+
+def test_single_file_json_list_non_dict_element_raises_config_error(tmp_path):
+    # A JSON list whose elements are not all objects is rejected with a clean
+    # ConfigError instead of crashing inside Task.from_dict.
+    path = os.path.join(str(tmp_path), "cases.json")
+    _write(path, json.dumps([{"task_id": 1}, 5]))
+    with pytest.raises(ConfigError):
+        load_tasks(path)
+
+
+def test_missing_directory_raises_config_error(tmp_path):
+    missing = os.path.join(str(tmp_path), "definitely-does-not-exist-xyz-123")
+    with pytest.raises(ConfigError):
+        load_from_tasks_dir(missing)
+
+
+def test_missing_directory_via_load_tasks_raises_config_error(tmp_path):
+    missing = os.path.join(str(tmp_path), "definitely-does-not-exist-xyz-456")
+    with pytest.raises(ConfigError):
+        load_tasks(missing)
+
+
+def test_parse_error_is_logged_and_skipped(tmp_path, caplog):
+    # A valid task plus one with malformed YAML; the bad one is skipped.
+    _write(
+        os.path.join(str(tmp_path), "good", "task.yaml"),
+        'task_id: 1\nname: "good"\nprompt: "p"\nexpected_output: "e"\n',
+    )
+    _write(
+        os.path.join(str(tmp_path), "bad", "task.yaml"),
+        "task_id: 2\nname: [unterminated\n",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="devops_bench.tasks.loader"):
+        tasks = load_from_tasks_dir(str(tmp_path))
+
+    assert [t.name for t in tasks] == ["good"]
+    assert any("Failed to read task spec" in rec.message for rec in caplog.records)
+
+
+def test_duplicate_task_id_logs_warning(tmp_path, caplog):
+    # Two task.yaml with the same explicit task_id: the duplicate is logged as
+    # a warning but both are still loaded (directory loading stays resilient).
+    _write(
+        os.path.join(str(tmp_path), "first", "task.yaml"),
+        'task_id: 7\nname: "first"\nprompt: "p"\n',
+    )
+    _write(
+        os.path.join(str(tmp_path), "second", "task.yaml"),
+        'task_id: 7\nname: "second"\nprompt: "q"\n',
+    )
+
+    with caplog.at_level(logging.WARNING, logger="devops_bench.tasks.loader"):
+        tasks = load_from_tasks_dir(str(tmp_path))
+
+    assert len(tasks) == 2
+    assert any("duplicate task id" in rec.message for rec in caplog.records)
+
+
+def test_filesystem_task_loader_is_a_task_loader():
+    assert isinstance(FileSystemTaskLoader(), TaskLoader)
+
+
+def test_task_loader_cannot_be_instantiated():
+    with pytest.raises(TypeError):
+        TaskLoader()
+
+
+def test_filesystem_task_loader_loads_directory(tmp_path):
+    _write(os.path.join(str(tmp_path), "t", "task.yaml"), 'task_id: 1\nname: "t"\nprompt: "p"\n')
+    tasks = FileSystemTaskLoader().load_tasks(str(tmp_path))
+    assert [t.name for t in tasks] == ["t"]

--- a/tests/unit/tasks/test_tasks_loader.py
+++ b/tests/unit/tasks/test_tasks_loader.py
@@ -16,7 +16,7 @@
 
 import json
 import logging
-import os
+from pathlib import Path
 
 import pytest
 
@@ -29,21 +29,20 @@ from devops_bench.tasks.loader import (
 )
 
 
-def _write(path: str, content: str) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
-        f.write(content)
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
 
 
 def test_load_from_tasks_dir_recursive_and_ordered(tmp_path):
     # id 2 lives under a directory that sorts before id 1, so a correct
     # loader must sort by id rather than discovery order.
     _write(
-        os.path.join(str(tmp_path), "aaa", "task-two", "task.yaml"),
+        tmp_path / "aaa" / "task-two" / "task.yaml",
         'task_id: 2\nname: "task-two"\nprompt: "Two"\nexpected_output: "E2"\n',
     )
     _write(
-        os.path.join(str(tmp_path), "zzz", "task-one", "task.yaml"),
+        tmp_path / "zzz" / "task-one" / "task.yaml",
         'task_id: 1\nname: "task-one"\nprompt: "One"\nexpected_output: "E1"\n',
     )
 
@@ -56,8 +55,8 @@ def test_load_from_tasks_dir_recursive_and_ordered(tmp_path):
 
 
 def test_numeric_ids_sort_by_value_not_lexically(tmp_path):
-    _write(os.path.join(str(tmp_path), "a", "task.yaml"), 'task_id: 10\nname: "ten"\n')
-    _write(os.path.join(str(tmp_path), "b", "task.yaml"), 'task_id: 2\nname: "two"\n')
+    _write(tmp_path / "a" / "task.yaml", 'task_id: 10\nname: "ten"\n')
+    _write(tmp_path / "b" / "task.yaml", 'task_id: 2\nname: "two"\n')
 
     tasks = load_from_tasks_dir(str(tmp_path))
     assert [t.name for t in tasks] == ["two", "ten"]
@@ -65,15 +64,15 @@ def test_numeric_ids_sort_by_value_not_lexically(tmp_path):
 
 def test_load_from_tasks_dir_subdir_scope(tmp_path):
     _write(
-        os.path.join(str(tmp_path), "gcp", "task-gcp", "task.yaml"),
+        tmp_path / "gcp" / "task-gcp" / "task.yaml",
         'task_id: 1\nname: "task-gcp"\nprompt: "GCP"\nexpected_output: "G"\n',
     )
     _write(
-        os.path.join(str(tmp_path), "generic", "task-generic", "task.yaml"),
+        tmp_path / "generic" / "task-generic" / "task.yaml",
         'task_id: 2\nname: "task-generic"\nprompt: "Generic"\nexpected_output: "X"\n',
     )
 
-    scoped = load_from_tasks_dir(os.path.join(str(tmp_path), "generic"))
+    scoped = load_from_tasks_dir(str(tmp_path / "generic"))
     assert len(scoped) == 1
     assert scoped[0].name == "task-generic"
 
@@ -81,7 +80,7 @@ def test_load_from_tasks_dir_subdir_scope(tmp_path):
 def test_field_defaults_missing_id_and_name(tmp_path):
     # No task_id and no name -> empty id and the directory basename.
     _write(
-        os.path.join(str(tmp_path), "the-dir-name", "task.yaml"),
+        tmp_path / "the-dir-name" / "task.yaml",
         'prompt: "  padded prompt  "\nexpected_output: "  padded  "\n',
     )
 
@@ -95,7 +94,7 @@ def test_field_defaults_missing_id_and_name(tmp_path):
 
 def test_goal_alias_in_dir_load(tmp_path):
     _write(
-        os.path.join(str(tmp_path), "alias", "task.yaml"),
+        tmp_path / "alias" / "task.yaml",
         'task_id: 5\ngoal: "  goal driven  "\n',
     )
     tasks = load_from_tasks_dir(str(tmp_path))
@@ -123,7 +122,7 @@ documentation:
 
 
 def test_documentation_parsed_on_load(tmp_path):
-    _write(os.path.join(str(tmp_path), "doc", "task.yaml"), _DOC_YAML)
+    _write(tmp_path / "doc" / "task.yaml", _DOC_YAML)
     docs = load_from_tasks_dir(str(tmp_path))[0].documentation
     assert len(docs) == 2
 
@@ -152,7 +151,7 @@ def test_invalid_task_is_skipped_with_warning(tmp_path, caplog):
         '      - text: "x"\n'
         "        critical: yes\n"
     )
-    _write(os.path.join(str(tmp_path), "d", "task.yaml"), yaml_text)
+    _write(tmp_path / "d" / "task.yaml", yaml_text)
     with caplog.at_level(logging.WARNING, logger="devops_bench.tasks.loader"):
         tasks = load_from_tasks_dir(str(tmp_path))
     assert tasks == []
@@ -163,7 +162,7 @@ def test_yaml_1_2_booleans_stay_strings(tmp_path):
     # ``yes``/``no``/``off`` are plain strings under YAML 1.2; only
     # ``true``/``false`` are booleans.
     _write(
-        os.path.join(str(tmp_path), "t", "task.yaml"),
+        tmp_path / "t" / "task.yaml",
         'task_id: 1\ninfrastructure:\n  a: yes\n  b: "no"\n  c: true\n',
     )
     infra = load_from_tasks_dir(str(tmp_path))[0].infrastructure
@@ -173,9 +172,9 @@ def test_yaml_1_2_booleans_stay_strings(tmp_path):
 
 
 def test_load_single_yaml_file(tmp_path):
-    path = os.path.join(str(tmp_path), "case.yaml")
+    path = tmp_path / "case.yaml"
     _write(path, 'task_id: 11\nname: "single"\nprompt: "  hi  "\nexpected_output: "out"\n')
-    tasks = load_tasks(path)
+    tasks = load_tasks(str(path))
     assert len(tasks) == 1
     assert tasks[0].id == "11"
     assert tasks[0].name == "single"
@@ -183,12 +182,12 @@ def test_load_single_yaml_file(tmp_path):
 
 
 def test_load_single_json_file_object_with_goal_alias(tmp_path):
-    path = os.path.join(str(tmp_path), "case.json")
+    path = tmp_path / "case.json"
     _write(
         path,
         json.dumps({"task_id": 4, "name": "json-case", "goal": "json goal"}),
     )
-    tasks = load_tasks(path)
+    tasks = load_tasks(str(path))
     assert len(tasks) == 1
     assert tasks[0].id == "4"
     assert tasks[0].name == "json-case"
@@ -196,7 +195,7 @@ def test_load_single_json_file_object_with_goal_alias(tmp_path):
 
 
 def test_load_single_json_file_list(tmp_path):
-    path = os.path.join(str(tmp_path), "cases.json")
+    path = tmp_path / "cases.json"
     _write(
         path,
         json.dumps(
@@ -206,7 +205,7 @@ def test_load_single_json_file_list(tmp_path):
             ]
         ),
     )
-    tasks = load_tasks(path)
+    tasks = load_tasks(str(path))
     assert [t.name for t in tasks] == ["a", "b"]
     assert tasks[0].prompt == "ia"
     assert tasks[1].prompt == "gb"
@@ -215,41 +214,41 @@ def test_load_single_json_file_list(tmp_path):
 def test_single_file_malformed_yaml_raises_config_error(tmp_path):
     # A single malformed YAML spec surfaces a clean ConfigError rather than
     # leaking the underlying parser error.
-    path = os.path.join(str(tmp_path), "broken.yaml")
+    path = tmp_path / "broken.yaml"
     _write(path, "[unterminated")
     with pytest.raises(ConfigError):
-        load_tasks(path)
+        load_tasks(str(path))
 
 
 def test_single_file_json_list_non_dict_element_raises_config_error(tmp_path):
     # A JSON list whose elements are not all objects is rejected with a clean
     # ConfigError instead of crashing inside Task.from_dict.
-    path = os.path.join(str(tmp_path), "cases.json")
+    path = tmp_path / "cases.json"
     _write(path, json.dumps([{"task_id": 1}, 5]))
     with pytest.raises(ConfigError):
-        load_tasks(path)
+        load_tasks(str(path))
 
 
 def test_missing_directory_raises_config_error(tmp_path):
-    missing = os.path.join(str(tmp_path), "definitely-does-not-exist-xyz-123")
+    missing = tmp_path / "definitely-does-not-exist-xyz-123"
     with pytest.raises(ConfigError):
-        load_from_tasks_dir(missing)
+        load_from_tasks_dir(str(missing))
 
 
 def test_missing_directory_via_load_tasks_raises_config_error(tmp_path):
-    missing = os.path.join(str(tmp_path), "definitely-does-not-exist-xyz-456")
+    missing = tmp_path / "definitely-does-not-exist-xyz-456"
     with pytest.raises(ConfigError):
-        load_tasks(missing)
+        load_tasks(str(missing))
 
 
 def test_parse_error_is_logged_and_skipped(tmp_path, caplog):
     # A valid task plus one with malformed YAML; the bad one is skipped.
     _write(
-        os.path.join(str(tmp_path), "good", "task.yaml"),
+        tmp_path / "good" / "task.yaml",
         'task_id: 1\nname: "good"\nprompt: "p"\nexpected_output: "e"\n',
     )
     _write(
-        os.path.join(str(tmp_path), "bad", "task.yaml"),
+        tmp_path / "bad" / "task.yaml",
         "task_id: 2\nname: [unterminated\n",
     )
 
@@ -264,11 +263,11 @@ def test_duplicate_task_id_logs_warning(tmp_path, caplog):
     # Two task.yaml with the same explicit task_id: the duplicate is logged as
     # a warning but both are still loaded (directory loading stays resilient).
     _write(
-        os.path.join(str(tmp_path), "first", "task.yaml"),
+        tmp_path / "first" / "task.yaml",
         'task_id: 7\nname: "first"\nprompt: "p"\n',
     )
     _write(
-        os.path.join(str(tmp_path), "second", "task.yaml"),
+        tmp_path / "second" / "task.yaml",
         'task_id: 7\nname: "second"\nprompt: "q"\n',
     )
 
@@ -289,6 +288,6 @@ def test_task_loader_cannot_be_instantiated():
 
 
 def test_filesystem_task_loader_loads_directory(tmp_path):
-    _write(os.path.join(str(tmp_path), "t", "task.yaml"), 'task_id: 1\nname: "t"\nprompt: "p"\n')
+    _write(tmp_path / "t" / "task.yaml", 'task_id: 1\nname: "t"\nprompt: "p"\n')
     tasks = FileSystemTaskLoader().load_tasks(str(tmp_path))
     assert [t.name for t in tasks] == ["t"]

--- a/tests/unit/tasks/test_tasks_loader.py
+++ b/tests/unit/tasks/test_tasks_loader.py
@@ -25,7 +25,6 @@ from devops_bench.tasks.loader import (
     FileSystemTaskLoader,
     TaskLoader,
     load_from_tasks_dir,
-    load_tasks,
 )
 
 
@@ -46,7 +45,7 @@ def test_load_from_tasks_dir_recursive_and_ordered(tmp_path):
         'task_id: 1\nname: "task-one"\nprompt: "One"\nexpected_output: "E1"\n',
     )
 
-    tasks = load_tasks(str(tmp_path))
+    tasks = FileSystemTaskLoader().load_tasks(str(tmp_path))
     assert len(tasks) == 2
     assert tasks[0].id == "1"
     assert tasks[0].name == "task-one"
@@ -174,7 +173,7 @@ def test_yaml_1_2_booleans_stay_strings(tmp_path):
 def test_load_single_yaml_file(tmp_path):
     path = tmp_path / "case.yaml"
     _write(path, 'task_id: 11\nname: "single"\nprompt: "  hi  "\nexpected_output: "out"\n')
-    tasks = load_tasks(str(path))
+    tasks = FileSystemTaskLoader().load_tasks(str(path))
     assert len(tasks) == 1
     assert tasks[0].id == "11"
     assert tasks[0].name == "single"
@@ -187,7 +186,7 @@ def test_load_single_json_file_object_with_goal_alias(tmp_path):
         path,
         json.dumps({"task_id": 4, "name": "json-case", "goal": "json goal"}),
     )
-    tasks = load_tasks(str(path))
+    tasks = FileSystemTaskLoader().load_tasks(str(path))
     assert len(tasks) == 1
     assert tasks[0].id == "4"
     assert tasks[0].name == "json-case"
@@ -205,7 +204,7 @@ def test_load_single_json_file_list(tmp_path):
             ]
         ),
     )
-    tasks = load_tasks(str(path))
+    tasks = FileSystemTaskLoader().load_tasks(str(path))
     assert [t.name for t in tasks] == ["a", "b"]
     assert tasks[0].prompt == "ia"
     assert tasks[1].prompt == "gb"
@@ -217,7 +216,7 @@ def test_single_file_malformed_yaml_raises_config_error(tmp_path):
     path = tmp_path / "broken.yaml"
     _write(path, "[unterminated")
     with pytest.raises(ConfigError):
-        load_tasks(str(path))
+        FileSystemTaskLoader().load_tasks(str(path))
 
 
 def test_single_file_json_list_non_dict_element_raises_config_error(tmp_path):
@@ -226,7 +225,7 @@ def test_single_file_json_list_non_dict_element_raises_config_error(tmp_path):
     path = tmp_path / "cases.json"
     _write(path, json.dumps([{"task_id": 1}, 5]))
     with pytest.raises(ConfigError):
-        load_tasks(str(path))
+        FileSystemTaskLoader().load_tasks(str(path))
 
 
 def test_missing_directory_raises_config_error(tmp_path):
@@ -235,10 +234,10 @@ def test_missing_directory_raises_config_error(tmp_path):
         load_from_tasks_dir(str(missing))
 
 
-def test_missing_directory_via_load_tasks_raises_config_error(tmp_path):
+def test_missing_directory_via_loader_raises_config_error(tmp_path):
     missing = tmp_path / "definitely-does-not-exist-xyz-456"
     with pytest.raises(ConfigError):
-        load_tasks(str(missing))
+        FileSystemTaskLoader().load_tasks(str(missing))
 
 
 def test_parse_error_is_logged_and_skipped(tmp_path, caplog):

--- a/tests/unit/tasks/test_tasks_schema.py
+++ b/tests/unit/tasks/test_tasks_schema.py
@@ -1,0 +1,215 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.tasks.schema."""
+
+import pytest
+from pydantic import ValidationError
+
+from devops_bench.tasks.schema import Task
+
+
+def test_from_dict_full():
+    raw = {
+        "task_id": 7,
+        "name": "explicit-name",
+        "prompt": "  do the thing  ",
+        "expected_output": "  done  ",
+        "retrieval_context": ["ctx"],
+        "chaos_spec": {"kind": "kill"},
+        "verification_spec": {"check": "ok"},
+        "infrastructure": {"deployer": "tofu"},
+    }
+    task = Task.from_dict(raw, name_default="dir-name")
+
+    assert task.id == "7"
+    assert task.name == "explicit-name"
+    assert task.prompt == "do the thing"
+    assert task.expected_output == "done"
+    assert task.retrieval_context == ["ctx"]
+    assert task.chaos_spec == {"kind": "kill"}
+    assert task.verification_spec == {"check": "ok"}
+    assert task.infrastructure == {"deployer": "tofu"}
+
+
+def test_id_coerced_to_string():
+    assert Task.from_dict({"task_id": 7}, name_default="d").id == "7"
+    assert Task.from_dict({"id": "abc"}, name_default="d").id == "abc"
+
+
+def test_id_zero_is_preserved():
+    assert Task.from_dict({"id": 0}, name_default="d").id == "0"
+
+
+def test_null_id_falls_back_to_task_id():
+    assert Task.from_dict({"id": None, "task_id": 5}, name_default="d").id == "5"
+
+
+def test_missing_id_defaults_to_empty():
+    task = Task.from_dict({"prompt": "x"}, name_default="d")
+    assert task.id == ""
+
+
+def test_explicit_null_id_defaults_to_empty():
+    task = Task.from_dict({"task_id": None, "prompt": "x"}, name_default="d")
+    assert task.id == ""
+
+
+def test_missing_name_uses_default():
+    task = Task.from_dict({"prompt": "x"}, name_default="from-dir")
+    assert task.name == "from-dir"
+
+
+def test_prompt_is_stripped():
+    task = Task.from_dict({"prompt": "  hello  "}, name_default="d")
+    assert task.prompt == "hello"
+
+
+def test_goal_alias_maps_to_prompt():
+    task = Task.from_dict({"goal": "  goal text  "}, name_default="d")
+    assert task.prompt == "goal text"
+
+
+def test_prompt_takes_precedence_over_goal():
+    task = Task.from_dict({"prompt": "p", "goal": "g"}, name_default="d")
+    assert task.prompt == "p"
+
+
+def test_defaults_for_empty_mapping():
+    task = Task.from_dict({}, name_default="d")
+    assert task.id == ""
+    assert task.name == "d"
+    assert task.prompt == ""
+    assert task.expected_output == ""
+    assert task.retrieval_context == []
+    assert task.chaos_spec is None
+    assert task.verification_spec is None
+    assert task.infrastructure == {}
+    assert task.documentation == []
+
+
+def test_non_string_prompt_raises():
+    with pytest.raises(ValidationError):
+        Task.from_dict({"prompt": 123}, name_default="d")
+
+
+def test_non_list_retrieval_context_raises():
+    with pytest.raises(ValidationError):
+        Task.from_dict({"retrieval_context": "nope"}, name_default="d")
+
+
+def test_documentation_defaults_url_and_critical():
+    raw = {
+        "documentation": [
+            {
+                "doc_name": "A",
+                "constraints": [
+                    {"text": "needs url default"},
+                    {"text": "explicit critical", "critical": True},
+                ],
+            }
+        ]
+    }
+    doc = Task.from_dict(raw, name_default="d").documentation[0]
+    assert doc.url == ""
+    assert [(c.text, c.critical) for c in doc.constraints] == [
+        ("needs url default", False),
+        ("explicit critical", True),
+    ]
+
+
+def test_documentation_non_bool_critical_raises():
+    # Strict validation: ``critical: "yes"`` (the string a YAML 1.2 parser
+    # yields) is not a boolean and must raise rather than be coerced.
+    raw = {"documentation": [{"doc_name": "A", "constraints": [{"text": "x", "critical": "yes"}]}]}
+    with pytest.raises(ValidationError):
+        Task.from_dict(raw, name_default="d")
+
+
+def test_documentation_missing_constraint_text_raises():
+    raw = {"documentation": [{"doc_name": "A", "constraints": [{"critical": True}]}]}
+    with pytest.raises(ValidationError):
+        Task.from_dict(raw, name_default="d")
+
+
+def test_non_list_documentation_raises():
+    with pytest.raises(ValidationError):
+        Task.from_dict({"documentation": "nope"}, name_default="d")
+
+
+def test_empty_yaml_blocks_become_defaults():
+    # An empty block (``key:`` with no value) parses to None and must fall back
+    # to the field default rather than failing strict validation.
+    raw = {
+        "infrastructure": None,
+        "retrieval_context": None,
+        "documentation": None,
+        "prompt": None,
+        "expected_output": None,
+    }
+    task = Task.from_dict(raw, name_default="d")
+    assert task.infrastructure == {}
+    assert task.retrieval_context == []
+    assert task.documentation == []
+    assert task.prompt == ""
+    assert task.expected_output == ""
+
+
+def test_documentation_entry_empty_nested_keys_coalesce():
+    # Empty nested YAML keys parse to None; the strict schema must coalesce them
+    # to defaults rather than rejecting them.
+    raw = {"documentation": [{"doc_name": None, "url": None, "constraints": None}]}
+    doc = Task.from_dict(raw, name_default="d").documentation[0]
+    assert doc.doc_name == ""
+    assert doc.url == ""
+    assert doc.constraints == []
+
+
+def test_constraint_empty_text_coalesces():
+    raw = {"documentation": [{"doc_name": "A", "constraints": [{"text": None}]}]}
+    constraint = Task.from_dict(raw, name_default="d").documentation[0].constraints[0]
+    assert constraint.text == ""
+    assert constraint.critical is False
+
+
+def test_chaos_and_verification_specs_are_opaque():
+    # These specs are parsed downstream, so the schema accepts any shape
+    # (e.g. a raw JSON string from a YAML literal block, a list, or a mapping).
+    raw = {"chaos_spec": '[{"name": "spike"}]', "verification_spec": [{"name": "v"}]}
+    task = Task.from_dict(raw, name_default="d")
+    assert task.chaos_spec == '[{"name": "spike"}]'
+    assert task.verification_spec == [{"name": "v"}]
+
+
+def test_to_dict_roundtrip_fields():
+    task = Task.from_dict(
+        {"task_id": 3, "name": "n", "prompt": "p", "expected_output": "e"},
+        name_default="d",
+    )
+    d = task.to_dict()
+    assert d["id"] == "3"
+    assert d["name"] == "n"
+    assert d["prompt"] == "p"
+    assert d["expected_output"] == "e"
+    assert set(d) == {
+        "id",
+        "name",
+        "prompt",
+        "expected_output",
+        "retrieval_context",
+        "chaos_spec",
+        "verification_spec",
+        "infrastructure",
+        "documentation",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -458,7 +458,9 @@ dependencies = [
     { name = "deepeval" },
     { name = "google-genai" },
     { name = "mcp" },
+    { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "ruamel-yaml" },
 ]
 
 [package.dev-dependencies]
@@ -475,7 +477,9 @@ requires-dist = [
     { name = "deepeval", specifier = ">=4.0.3" },
     { name = "google-genai", specifier = ">=2.6.0" },
     { name = "mcp", specifier = ">=1.27.1" },
+    { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "ruamel-yaml", specifier = ">=0.18.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1823,6 +1827,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
     { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
     { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stage 1 leaf module **tasks** (depends on #84 core). Task loading used to be split across `pkg/evaluator/loader.py` (a directory loader plus a hand-rolled documentation text scanner) and `pkg/evaluator/evaluate.py::load_evaluation_data` (single-file); this consolidates both into `devops_bench/tasks/`, behind a typed pydantic schema. Adds `pydantic` and `ruamel.yaml`.

**Behavior changes**
- YAML parsing moves from PyYAML (YAML 1.1) to ruamel safe-load (YAML 1.2): `yes`/`no`/`on`/`off` now stay strings instead of coercing to booleans.
- `documentation` is parsed from the structured YAML/JSON via the schema rather than scanned line-by-line, and is now preserved for all load paths (dir, YAML, JSON, dict).
- Strict validation replaces the old silent coercion: malformed tasks raise `ConfigError` (single-file) or are logged and skipped (directory).
- `prompt` → `goal` → `input` aliasing is now unified across every load path.
- `Task.id` is a string — it used to be a numeric id with `999`/`1` sentinels; missing id now defaults to `""` and sorting handles non-numeric ids.
- A missing tasks dir/file now raises `ConfigError`; it used to call `sys.exit(1)` / leak `FileNotFoundError`.

**Bugs fixed**
- `documentation` was silently dropped on dict/JSON single-file loads.
- Duplicate `task_id`s used to be masked by a shared `999` sentinel; they're now kept distinct with explicit duplicate detection.
- Mixed int/str ids used to crash the numeric sort.
- The hand-rolled documentation scanner mis-parsed nested/quoted/flow-style YAML.
