### PR TITLE
feat(k8s): add kubectl wrappers and wait conditions

### DIFF
--- a/devops_bench/k8s/__init__.py
+++ b/devops_bench/k8s/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reusable Kubernetes primitives: kubectl wrappers and wait/poll conditions."""
+
+from devops_bench.k8s.conditions import poll_until
+from devops_bench.k8s.kubectl import apply, get_json, rollout_status, scale, wait
+
+__all__ = ["apply", "get_json", "poll_until", "rollout_status", "scale", "wait"]

--- a/devops_bench/k8s/__init__.py
+++ b/devops_bench/k8s/__init__.py
@@ -15,6 +15,6 @@
 """Reusable Kubernetes primitives: kubectl wrappers and wait/poll conditions."""
 
 from devops_bench.k8s.conditions import poll_until
-from devops_bench.k8s.kubectl import apply, get_json, rollout_status, scale, wait
+from devops_bench.k8s.kubectl import apply, get_resource, rollout_status, wait
 
-__all__ = ["apply", "get_json", "poll_until", "rollout_status", "scale", "wait"]
+__all__ = ["apply", "get_resource", "poll_until", "rollout_status", "wait"]

--- a/devops_bench/k8s/conditions.py
+++ b/devops_bench/k8s/conditions.py
@@ -1,0 +1,63 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generic wait/poll engine for Kubernetes resources."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+__all__ = [
+    "poll_until",
+]
+
+
+def poll_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout_sec: float,
+    initial_delay: float = 1.0,
+    max_delay: float = 10.0,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> bool:
+    """Poll a predicate with exponential backoff until it holds or time runs out.
+
+    The predicate is checked once per iteration; on failure the loop sleeps for a
+    delay that doubles each round (capped at ``max_delay``) before rechecking. The
+    final sleep is clamped to the time left, so the call never blocks past
+    ``timeout_sec``.
+
+    Args:
+        predicate: Zero-argument callable returning True when the wait is done.
+        timeout_sec: Maximum wall-clock seconds to keep polling.
+        initial_delay: Seconds to sleep after the first failed check.
+        max_delay: Upper bound on the backoff delay.
+        sleep: Sleep function; injectable so tests can avoid real waiting.
+        monotonic: Elapsed-time source; injectable for testing.
+
+    Returns:
+        True if the predicate held within the timeout, otherwise False.
+    """
+    start = monotonic()
+    delay = initial_delay
+    while True:
+        if predicate():
+            return True
+        elapsed = monotonic() - start
+        if elapsed >= timeout_sec:
+            return False
+        sleep(min(delay, timeout_sec - elapsed))
+        delay = min(delay * 2, max_delay)

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -1,0 +1,237 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Thin, shell-free wrappers around the ``kubectl`` command line."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Protocol
+
+from devops_bench.core.subprocess import CompletedProcess, run
+
+__all__ = [
+    "apply",
+    "get_json",
+    "rollout_status",
+    "scale",
+    "wait",
+]
+
+
+class KubeconfigProvider(Protocol):
+    """Structural type for objects that expose a kubeconfig path."""
+
+    kubeconfig_path: str | None
+
+
+# Accepts a raw kubeconfig path or any object exposing ``kubeconfig_path``.
+type KubeconfigSource = str | KubeconfigProvider | None
+
+
+def _resolve_kubeconfig(kubeconfig: KubeconfigSource) -> str | None:
+    """Return a kubeconfig path from a string or a provider object.
+
+    Args:
+        kubeconfig: Explicit path, a ``KubeconfigProvider``, or None.
+
+    Returns:
+        The kubeconfig path, or None when none is available.
+    """
+    if kubeconfig is None or isinstance(kubeconfig, str):
+        return kubeconfig
+    return kubeconfig.kubeconfig_path
+
+
+def _namespace_args(namespace: str | None) -> list[str]:
+    return ["-n", namespace] if namespace else []
+
+
+def _selector_args(selector: str | None) -> list[str]:
+    return ["-l", selector] if selector else []
+
+
+def _run_kubectl(argv: list[str], kubeconfig: KubeconfigSource, **kwargs: Any) -> CompletedProcess:
+    """Run ``kubectl`` with the resolved kubeconfig overlaid on the environment.
+
+    Args:
+        argv: Full kubectl command and arguments, never a shell string.
+        kubeconfig: Explicit path, a ``KubeconfigProvider``, or None.
+        **kwargs: Extra keyword arguments forwarded to ``core.subprocess.run``
+            (e.g. ``timeout``).
+
+    Returns:
+        The completed process.
+
+    Raises:
+        SubprocessError: If kubectl exits non-zero or times out.
+    """
+    path = _resolve_kubeconfig(kubeconfig)
+    extra_env = {"KUBECONFIG": path} if path else None
+    return run(argv, extra_env=extra_env, **kwargs)
+
+
+def wait(
+    resource_type: str,
+    *,
+    selector: str | None = None,
+    for_condition: str = "condition=Ready",
+    timeout_sec: float,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+) -> CompletedProcess:
+    """Block until a resource satisfies a condition via ``kubectl wait``.
+
+    Args:
+        resource_type: Resource kind to wait on, e.g. ``"pod"``.
+        selector: Optional label selector (``-l``).
+        for_condition: Condition expression for ``--for``.
+        timeout_sec: Maximum seconds to wait (``--timeout=<n>s``).
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+
+    Returns:
+        The completed process.
+
+    Raises:
+        SubprocessError: If the condition is not met before the timeout.
+    """
+    argv = [
+        "kubectl",
+        "wait",
+        f"--for={for_condition}",
+        resource_type,
+        *_selector_args(selector),
+        f"--timeout={timeout_sec}s",
+        *_namespace_args(namespace),
+    ]
+    return _run_kubectl(argv, kubeconfig)
+
+
+def get_json(
+    resource_type: str,
+    name: str | None = None,
+    *,
+    selector: str | None = None,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+) -> dict[str, Any]:
+    """Fetch a resource (or list) as parsed JSON via ``kubectl get -o json``.
+
+    Args:
+        resource_type: Resource kind to fetch, e.g. ``"pods"``.
+        name: Optional specific resource name.
+        selector: Optional label selector (``-l``).
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+
+    Returns:
+        The parsed JSON document.
+
+    Raises:
+        SubprocessError: If kubectl exits non-zero or times out.
+        json.JSONDecodeError: If the output is not valid JSON.
+    """
+    argv = [
+        "kubectl",
+        "get",
+        resource_type,
+        *([name] if name else []),
+        *_selector_args(selector),
+        "-o",
+        "json",
+        *_namespace_args(namespace),
+    ]
+    completed = _run_kubectl(argv, kubeconfig)
+    return json.loads(completed.stdout)
+
+
+def apply(
+    path: str,
+    *,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+) -> CompletedProcess:
+    """Apply a manifest file or directory via ``kubectl apply -f``.
+
+    Args:
+        path: Manifest file, directory, or URL passed to ``-f``.
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+
+    Returns:
+        The completed process.
+
+    Raises:
+        SubprocessError: If kubectl exits non-zero or times out.
+    """
+    argv = ["kubectl", "apply", "-f", path, *_namespace_args(namespace)]
+    return _run_kubectl(argv, kubeconfig)
+
+
+def scale(
+    resource: str,
+    replicas: int,
+    *,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+) -> CompletedProcess:
+    """Set the replica count of a resource via ``kubectl scale``.
+
+    Args:
+        resource: Resource reference, e.g. ``"deployment/web"``.
+        replicas: Desired replica count.
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+
+    Returns:
+        The completed process.
+
+    Raises:
+        SubprocessError: If kubectl exits non-zero or times out.
+    """
+    argv = ["kubectl", "scale", f"--replicas={replicas}", resource, *_namespace_args(namespace)]
+    return _run_kubectl(argv, kubeconfig)
+
+
+def rollout_status(
+    resource: str,
+    *,
+    timeout_sec: float | None = None,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+) -> CompletedProcess:
+    """Wait for a rollout to finish via ``kubectl rollout status``.
+
+    Args:
+        resource: Resource reference, e.g. ``"deployment/web"``.
+        timeout_sec: Optional maximum seconds to wait (``--timeout=<n>s``).
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+
+    Returns:
+        The completed process.
+
+    Raises:
+        SubprocessError: If the rollout does not complete before the timeout.
+    """
+    argv = [
+        "kubectl",
+        "rollout",
+        "status",
+        resource,
+        *([f"--timeout={timeout_sec}s"] if timeout_sec is not None else []),
+        *_namespace_args(namespace),
+    ]
+    return _run_kubectl(argv, kubeconfig)

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -23,9 +23,8 @@ from devops_bench.core.subprocess import CompletedProcess, run
 
 __all__ = [
     "apply",
-    "get_json",
+    "get_resource",
     "rollout_status",
-    "scale",
     "wait",
 ]
 
@@ -119,7 +118,7 @@ def wait(
     return _run_kubectl(argv, kubeconfig)
 
 
-def get_json(
+def get_resource(
     resource_type: str,
     name: str | None = None,
     *,
@@ -177,31 +176,6 @@ def apply(
         SubprocessError: If kubectl exits non-zero or times out.
     """
     argv = ["kubectl", "apply", "-f", path, *_namespace_args(namespace)]
-    return _run_kubectl(argv, kubeconfig)
-
-
-def scale(
-    resource: str,
-    replicas: int,
-    *,
-    namespace: str | None = None,
-    kubeconfig: KubeconfigSource = None,
-) -> CompletedProcess:
-    """Set the replica count of a resource via ``kubectl scale``.
-
-    Args:
-        resource: Resource reference, e.g. ``"deployment/web"``.
-        replicas: Desired replica count.
-        namespace: Optional namespace (``-n``).
-        kubeconfig: Kubeconfig path or context-like object.
-
-    Returns:
-        The completed process.
-
-    Raises:
-        SubprocessError: If kubectl exits non-zero or times out.
-    """
-    argv = ["kubectl", "scale", f"--replicas={replicas}", resource, *_namespace_args(namespace)]
     return _run_kubectl(argv, kubeconfig)
 
 

--- a/tests/unit/k8s/test_k8s_conditions.py
+++ b/tests/unit/k8s/test_k8s_conditions.py
@@ -1,0 +1,141 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.k8s.conditions.
+
+A fake clock and fake sleep drive ``poll_until`` so the backoff schedule is
+verified without any real waiting.
+"""
+
+from devops_bench.k8s import conditions
+
+
+class FakeClock:
+    """Monotonic clock stub whose ``sleep`` advances the recorded time."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+def test_poll_until_returns_true_immediately_without_sleeping():
+    clock = FakeClock()
+
+    result = conditions.poll_until(
+        lambda: True,
+        timeout_sec=100,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    assert result is True
+    assert clock.sleeps == []
+
+
+def test_poll_until_succeeds_after_a_few_attempts():
+    clock = FakeClock()
+    calls = {"n": 0}
+
+    def predicate() -> bool:
+        calls["n"] += 1
+        return calls["n"] == 3
+
+    result = conditions.poll_until(
+        predicate,
+        timeout_sec=100,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    assert result is True
+    # Two failures before success -> two backoff sleeps.
+    assert clock.sleeps == [1.0, 2.0]
+
+
+def test_poll_until_backoff_sequence_is_capped():
+    clock = FakeClock()
+
+    # Always false; deadline large enough to exercise the cap, but the fake
+    # clock advances via sleep so the loop terminates deterministically.
+    result = conditions.poll_until(
+        lambda: False,
+        timeout_sec=40,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    assert result is False
+    # Doubling is capped at max_delay (10), and the final sleep is clamped to the
+    # remaining time so the loop lands exactly on the 40s deadline rather than
+    # overshooting it (0,1,3,7,15,25,35,40).
+    assert clock.sleeps == [1.0, 2.0, 4.0, 8.0, 10.0, 10.0, 5.0]
+
+
+def test_poll_until_respects_custom_delays():
+    clock = FakeClock()
+
+    result = conditions.poll_until(
+        lambda: False,
+        timeout_sec=20,
+        initial_delay=2.0,
+        max_delay=5.0,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    assert result is False
+    # 0 -> 2 -> 6 -> 11 -> 16 -> 20: the final sleep is clamped from 5 to the
+    # remaining 4 seconds so the loop lands exactly on the deadline.
+    assert clock.sleeps == [2.0, 4.0, 5.0, 5.0, 4.0]
+
+
+def test_poll_until_timeout_returns_false():
+    clock = FakeClock()
+
+    result = conditions.poll_until(
+        lambda: False,
+        timeout_sec=0,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    # Deadline already passed: one predicate check, no sleep.
+    assert result is False
+    assert clock.sleeps == []
+
+
+def test_poll_until_catches_success_on_next_check_after_sleep():
+    clock = FakeClock()
+    calls = {"n": 0}
+
+    def predicate() -> bool:
+        calls["n"] += 1
+        # False on the first check, True on the recheck after the backoff sleep.
+        return calls["n"] == 2
+
+    result = conditions.poll_until(
+        predicate,
+        timeout_sec=1,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    assert result is True

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -1,0 +1,208 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for devops_bench.k8s.kubectl.
+
+These patch the module-local ``run`` so no real ``kubectl`` is invoked, and
+assert the exact argv lists and KUBECONFIG threading.
+"""
+
+import json
+import subprocess
+
+import pytest
+
+from devops_bench.core.context import ClusterInfo, RunContext
+from devops_bench.core.errors import SubprocessError
+from devops_bench.k8s import kubectl
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    """Build a real CompletedProcess for the patched ``run``."""
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout)
+
+
+def test_wait_builds_argv_and_threads_kubeconfig(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.wait(
+        "pod",
+        selector="app=my-app",
+        timeout_sec=60,
+        namespace="prod",
+        kubeconfig="/tmp/kc",
+    )
+
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "wait",
+        "--for=condition=Ready",
+        "pod",
+        "-l",
+        "app=my-app",
+        "--timeout=60s",
+        "-n",
+        "prod",
+    ]
+    assert mock_run.call_args.kwargs["extra_env"] == {"KUBECONFIG": "/tmp/kc"}
+
+
+def test_wait_custom_condition_without_optionals(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.wait("deployment", for_condition="condition=Available", timeout_sec=30)
+
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "wait",
+        "--for=condition=Available",
+        "deployment",
+        "--timeout=30s",
+    ]
+    # No kubeconfig supplied -> run is called without overlaying KUBECONFIG.
+    assert mock_run.call_args.kwargs["extra_env"] is None
+
+
+def test_get_json_parses_output_and_builds_argv(mocker):
+    payload = {"items": [{"status": {"phase": "Running"}}]}
+    mock_run = mocker.patch(
+        "devops_bench.k8s.kubectl.run",
+        return_value=_completed(stdout=json.dumps(payload)),
+    )
+
+    result = kubectl.get_json("pods", selector="app=web", namespace="default")
+
+    assert result == payload
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "get",
+        "pods",
+        "-l",
+        "app=web",
+        "-o",
+        "json",
+        "-n",
+        "default",
+    ]
+
+
+def test_get_json_with_name(mocker):
+    payload = {"status": {"readyReplicas": 3}}
+    mock_run = mocker.patch(
+        "devops_bench.k8s.kubectl.run",
+        return_value=_completed(stdout=json.dumps(payload)),
+    )
+
+    result = kubectl.get_json("deployment", "my-dep")
+
+    assert result == payload
+    argv = mock_run.call_args.args[0]
+    assert argv == ["kubectl", "get", "deployment", "my-dep", "-o", "json"]
+
+
+def test_apply_builds_argv(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.apply("/manifests/app.yaml", namespace="staging")
+
+    argv = mock_run.call_args.args[0]
+    assert argv == ["kubectl", "apply", "-f", "/manifests/app.yaml", "-n", "staging"]
+
+
+def test_scale_builds_argv(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.scale("deployment/web", 5)
+
+    argv = mock_run.call_args.args[0]
+    assert argv == ["kubectl", "scale", "--replicas=5", "deployment/web"]
+
+
+def test_rollout_status_with_timeout(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.rollout_status("deployment/web", timeout_sec=120, namespace="prod")
+
+    argv = mock_run.call_args.args[0]
+    assert argv == [
+        "kubectl",
+        "rollout",
+        "status",
+        "deployment/web",
+        "--timeout=120s",
+        "-n",
+        "prod",
+    ]
+
+
+def test_rollout_status_without_timeout(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.rollout_status("deployment/web")
+
+    argv = mock_run.call_args.args[0]
+    assert argv == ["kubectl", "rollout", "status", "deployment/web"]
+
+
+def test_kubeconfig_from_run_context(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+    ctx = RunContext(
+        task_id="t1",
+        cluster=ClusterInfo(name="c1", kubeconfig_path="/ctx/kc"),
+    )
+
+    kubectl.wait("pod", timeout_sec=10, kubeconfig=ctx)
+
+    assert mock_run.call_args.kwargs["extra_env"] == {"KUBECONFIG": "/ctx/kc"}
+
+
+def test_kubeconfig_from_cluster_info(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+    cluster = ClusterInfo(name="c1", kubeconfig_path="/cluster/kc")
+
+    kubectl.scale("deployment/web", 2, kubeconfig=cluster)
+
+    assert mock_run.call_args.kwargs["extra_env"] == {"KUBECONFIG": "/cluster/kc"}
+
+
+def test_run_context_without_cluster_omits_kubeconfig(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+    ctx = RunContext(task_id="t1")
+
+    kubectl.wait("pod", timeout_sec=10, kubeconfig=ctx)
+
+    assert mock_run.call_args.kwargs["extra_env"] is None
+
+
+def test_get_json_propagates_invalid_json(mocker):
+    mocker.patch(
+        "devops_bench.k8s.kubectl.run",
+        return_value=_completed(stdout="not json"),
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        kubectl.get_json("pods")
+
+
+def test_wait_propagates_subprocess_error(mocker):
+    mocker.patch(
+        "devops_bench.k8s.kubectl.run",
+        side_effect=SubprocessError(["kubectl", "wait"], returncode=1),
+    )
+
+    with pytest.raises(SubprocessError):
+        kubectl.wait("pod", timeout_sec=10)

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -76,14 +76,14 @@ def test_wait_custom_condition_without_optionals(mocker):
     assert mock_run.call_args.kwargs["extra_env"] is None
 
 
-def test_get_json_parses_output_and_builds_argv(mocker):
+def test_get_resource_parses_output_and_builds_argv(mocker):
     payload = {"items": [{"status": {"phase": "Running"}}]}
     mock_run = mocker.patch(
         "devops_bench.k8s.kubectl.run",
         return_value=_completed(stdout=json.dumps(payload)),
     )
 
-    result = kubectl.get_json("pods", selector="app=web", namespace="default")
+    result = kubectl.get_resource("pods", selector="app=web", namespace="default")
 
     assert result == payload
     argv = mock_run.call_args.args[0]
@@ -100,14 +100,14 @@ def test_get_json_parses_output_and_builds_argv(mocker):
     ]
 
 
-def test_get_json_with_name(mocker):
+def test_get_resource_with_name(mocker):
     payload = {"status": {"readyReplicas": 3}}
     mock_run = mocker.patch(
         "devops_bench.k8s.kubectl.run",
         return_value=_completed(stdout=json.dumps(payload)),
     )
 
-    result = kubectl.get_json("deployment", "my-dep")
+    result = kubectl.get_resource("deployment", "my-dep")
 
     assert result == payload
     argv = mock_run.call_args.args[0]
@@ -121,15 +121,6 @@ def test_apply_builds_argv(mocker):
 
     argv = mock_run.call_args.args[0]
     assert argv == ["kubectl", "apply", "-f", "/manifests/app.yaml", "-n", "staging"]
-
-
-def test_scale_builds_argv(mocker):
-    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
-
-    kubectl.scale("deployment/web", 5)
-
-    argv = mock_run.call_args.args[0]
-    assert argv == ["kubectl", "scale", "--replicas=5", "deployment/web"]
 
 
 def test_rollout_status_with_timeout(mocker):
@@ -174,7 +165,7 @@ def test_kubeconfig_from_cluster_info(mocker):
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
     cluster = ClusterInfo(name="c1", kubeconfig_path="/cluster/kc")
 
-    kubectl.scale("deployment/web", 2, kubeconfig=cluster)
+    kubectl.wait("pod", timeout_sec=10, kubeconfig=cluster)
 
     assert mock_run.call_args.kwargs["extra_env"] == {"KUBECONFIG": "/cluster/kc"}
 
@@ -188,14 +179,14 @@ def test_run_context_without_cluster_omits_kubeconfig(mocker):
     assert mock_run.call_args.kwargs["extra_env"] is None
 
 
-def test_get_json_propagates_invalid_json(mocker):
+def test_get_resource_propagates_invalid_json(mocker):
     mocker.patch(
         "devops_bench.k8s.kubectl.run",
         return_value=_completed(stdout="not json"),
     )
 
     with pytest.raises(json.JSONDecodeError):
-        kubectl.get_json("pods")
+        kubectl.get_resource("pods")
 
 
 def test_wait_propagates_subprocess_error(mocker):


### PR DESCRIPTION
Stage 1 leaf module **k8s** (depends on #84 core). kubectl usage used to be scattered across the verifier/chaos/manager code (`pkg/agents/verifier/pod_healthy.py`, `scaling_complete.py`, `pkg/agents/chaos/chaos.py`, `pkg/manager/manager.py`); this replaces it with shell-free `kubectl` wrappers (`wait`/`get_json`/`apply`/`scale`/`rollout_status`) on `core.subprocess.run`, plus a generic `poll_until` backoff engine in `conditions.py`. Adds the package and tests only — callers are rewired later, and verifier-specific readiness predicates are deferred to Stage 2.

**Behavior changes**
- All kubectl calls now use argv lists through `core.subprocess.run`; `chaos.py` used to run `subprocess.run(..., shell=True)` on LLM-generated command strings.
- KUBECONFIG is now threaded from a `RunContext`/`ClusterInfo` instead of relying on the ambient kubeconfig.
- `poll_until` is a single parameterized, injectable backoff engine replacing the hard-coded inline loop that used to live in `scaling_complete.py`; it uses a monotonic clock and clamps the final sleep to the deadline.
- Non-zero exits and timeouts now surface as a single `SubprocessError`.

**Bugs fixed**
- The scaling poll used to be able to sleep past its timeout by up to `max_delay` (~10s); `poll_until` clamps the last sleep to the time remaining.
- Polling used to measure elapsed time with `time.time()` (sensitive to wall-clock adjustments); it now uses `time.monotonic()`.
