### PR TITLE
feat(agents): API agent (MCP + skills) on capabilities + models/loop

### DIFF
--- a/devops_bench/agents/api/__init__.py
+++ b/devops_bench/agents/api/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""API/MCP agent harness driving the shared :func:`run_tool_loop` primitive.
+
+The concrete harness lives in :mod:`devops_bench.agents.api.agent` and
+self-registers under ``"api"`` via ``@AGENTS.register``. That module and its
+siblings (:mod:`devops_bench.agents.api.mcp`,
+:mod:`devops_bench.agents.api.skills`) pull in heavy optional dependencies (the
+``mcp`` SDK, ``deepeval``) only at call time — importing this package never
+forces those imports.
+"""
+
+from __future__ import annotations

--- a/devops_bench/agents/api/agent.py
+++ b/devops_bench/agents/api/agent.py
@@ -36,7 +36,7 @@ from devops_bench.agents.config import AgentConfig
 from devops_bench.agents.result import AgentResult, ToolCall
 from devops_bench.core import get_logger
 from devops_bench.models import LLMClient, get_model
-from devops_bench.models.loop import LoopResult, run_tool_loop
+from devops_bench.models.utils.loop import LoopResult, run_tool_loop
 
 __all__ = ["ApiAgent", "fold_trajectory", "extract_tokens"]
 
@@ -232,7 +232,7 @@ def _build_dispatch(
 
     Returns:
         An async ``(name, args, call_id) -> str`` callable matching
-        :data:`devops_bench.models.loop.ToolDispatcher`.
+        :data:`devops_bench.models.utils.loop.ToolDispatcher`.
     """
 
     async def dispatch(name: str, args: Any, call_id: str | None) -> str:

--- a/devops_bench/agents/api/agent.py
+++ b/devops_bench/agents/api/agent.py
@@ -1,0 +1,446 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""API/MCP agent harness driving the shared :func:`run_tool_loop` primitive.
+
+:class:`ApiAgent` drives a model-agnostic MCP/skills tool-use loop and folds the
+resulting conversation history into canonical :class:`ToolCall` trajectory
+entries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+from typing import Any
+
+from devops_bench.agents.api.mcp import MCPClient, extract_tool_text
+from devops_bench.agents.api.skills import (
+    SkillToolInfo,
+    discover_skill_tools,
+    read_skill_file,
+)
+from devops_bench.agents.base import AGENTS, AgentHarness
+from devops_bench.agents.config import AgentConfig
+from devops_bench.agents.result import AgentResult, ToolCall
+from devops_bench.core import get_logger
+from devops_bench.models import LLMClient, get_model
+from devops_bench.models.loop import LoopResult, run_tool_loop
+
+__all__ = ["ApiAgent", "fold_trajectory", "extract_tokens"]
+
+_log = get_logger("agents.api.agent")
+
+# Safety cap on agent turns; overridable via ``AgentConfig.max_turns``. Set high
+# because API agents legitimately take many tool-use turns — it only guards
+# against a model that never stops requesting tools.
+_DEFAULT_MAX_TURNS = 50
+
+
+def fold_trajectory(contents: list[dict]) -> list[dict]:
+    """Fold a :class:`LoopResult.contents` history into canonical trajectory entries.
+
+    Each assistant tool call is paired by ``tool_call_id`` with its tool result
+    and emitted as one :class:`ToolCall`.
+
+    Args:
+        contents: The conversation history produced by :func:`run_tool_loop`.
+
+    Returns:
+        A list of ``ToolCall.to_dict()`` mappings, one per tool call the model
+        issued, in the order issued.
+
+    Note:
+        Tool results matching no assistant-issued call are dropped from the
+        trajectory rather than synthesized into free-floating entries.
+    """
+    folded, _orphans = _fold_with_extraction_errors(contents)
+    return folded
+
+
+def _fold_with_extraction_errors(
+    contents: list[dict],
+) -> tuple[list[dict], list[str]]:
+    """Same as :func:`fold_trajectory` but also returns orphan-result diagnostics.
+
+    Args:
+        contents: As :func:`fold_trajectory`.
+
+    Returns:
+        A ``(trajectory, orphan_errors)`` tuple. ``orphan_errors`` lists one
+        message per unpaired ``role: tool`` entry; empty on a clean fold.
+    """
+    # Index assistant call ids first so we can detect orphans on the result pass.
+    assistant_call_ids: set[str] = set()
+    for msg in contents:
+        if msg.get("role") != "assistant":
+            continue
+        for call in msg.get("tool_calls") or []:
+            cid = call.get("id")
+            if cid is not None:
+                assistant_call_ids.add(str(cid))
+
+    # Pre-build call-id → (text, is_error) map so an out-of-order or absent
+    # result still leaves the call as ``status="called"``/``result=None`` rather
+    # than crashing on a lookup.
+    results_by_id: dict[str, tuple[str, bool]] = {}
+    orphan_errors: list[str] = []
+    for msg in contents:
+        if msg.get("role") != "tool":
+            continue
+        call_id = msg.get("tool_call_id")
+        text = msg.get("content")
+        text_str = text if isinstance(text, str) else "" if text is None else str(text)
+        is_error = isinstance(text, str) and text.startswith("Error: ")
+        if call_id is None or str(call_id) not in assistant_call_ids:
+            # Drop the orphan from the trajectory but surface it for diagnostics.
+            preview = text_str[:80].replace("\n", " ")
+            msg_text = (
+                "fold_trajectory dropped tool result with no matching call "
+                f"(id={call_id!r}, content={preview!r})"
+            )
+            _log.debug(msg_text)
+            orphan_errors.append(msg_text)
+            continue
+        results_by_id[str(call_id)] = (text_str, is_error)
+
+    trajectory: list[ToolCall] = []
+    for msg in contents:
+        if msg.get("role") != "assistant":
+            continue
+        tool_calls = msg.get("tool_calls") or []
+        for call in tool_calls:
+            name = call.get("name", "")
+            args = call.get("args")
+            call_id = call.get("id")
+            entry = ToolCall(
+                name=name,
+                args=args if isinstance(args, dict) else {},
+                status="called",
+            )
+            if call_id is not None:
+                hit = results_by_id.get(str(call_id))
+                if hit is not None:
+                    text, is_error = hit
+                    entry.result = text
+                    entry.status = "error" if is_error else "completed"
+            trajectory.append(entry)
+
+    return [entry.to_dict() for entry in trajectory], orphan_errors
+
+
+def extract_tokens(response: Any) -> dict:
+    """Pull provider token usage off the final raw response.
+
+    Detects which provider's usage shape is present and maps each onto a stable
+    key scheme (``prompt_tokens`` / ``candidates_tokens`` / ``total_tokens``) so
+    ``results.json`` stays consistent across providers.
+
+    Supported shapes:
+
+    * **Google** — ``response.usage_metadata`` with ``prompt_token_count`` /
+      ``candidates_token_count`` / ``total_token_count``.
+    * **Anthropic** — ``response.usage`` with ``input_tokens`` /
+      ``output_tokens`` (no aggregated total; the sum is used).
+    * **OpenAI / Ollama** — ``response.usage`` with ``prompt_tokens`` /
+      ``completion_tokens`` / ``total_tokens``.
+
+    The "output" field (``candidates_tokens``) absorbs whichever provider name
+    is present (``candidates_token_count`` / ``output_tokens`` /
+    ``completion_tokens``). When ``total`` is absent it is computed from the
+    other two so metrics never see ``0`` for a non-empty run.
+
+    Args:
+        response: The last raw provider response from
+            :attr:`LoopResult.response`, or ``None``.
+
+    Returns:
+        A ``{"prompt_tokens", "candidates_tokens", "total_tokens"}`` dict, or
+        ``{}`` when no usage is reported.
+    """
+    if response is None:
+        return {}
+    usage = getattr(response, "usage_metadata", None) or getattr(response, "usage", None)
+    if usage is None:
+        return {}
+
+    # Try the Google attr first, then the OpenAI-style attr, then the Anthropic
+    # alias.
+    prompt = _first_int_attr(
+        usage, "prompt_token_count", "prompt_tokens", "input_tokens"
+    )
+    candidates = _first_int_attr(
+        usage, "candidates_token_count", "completion_tokens", "output_tokens"
+    )
+    total = _first_int_attr(usage, "total_token_count", "total_tokens")
+    # Anthropic emits no aggregated total; compute it so non-zero usage never
+    # surfaces as ``total_tokens: 0`` in results.json.
+    if total == 0 and (prompt or candidates):
+        total = prompt + candidates
+
+    return {
+        "prompt_tokens": prompt,
+        "candidates_tokens": candidates,
+        "total_tokens": total,
+    }
+
+
+def _first_int_attr(obj: Any, *names: str) -> int:
+    """Return the first ``names`` attribute on ``obj`` that holds a non-``None`` int.
+
+    Provider usage objects are typed namespaces / pydantic models with the
+    counts as plain ints; an unset field is either absent or ``None``. The
+    helper falls through both cases and returns ``0`` when no name matches so
+    the caller never has to ``None``-guard the arithmetic.
+    """
+    for name in names:
+        value = getattr(obj, name, None)
+        if value is not None:
+            return int(value)
+    return 0
+
+
+def _build_dispatch(
+    mcp_client: MCPClient | None,
+    skill_resources: dict[str, str],
+    errors: list[str],
+):
+    """Build the dispatcher passed to :func:`run_tool_loop`.
+
+    Wraps each tool call in its own ``try/except`` because ``run_tool_loop``
+    propagates dispatch errors by design — letting a single tool failure abort
+    the whole run would be wrong for a benchmark agent. Failures are recorded
+    on ``errors`` and returned as the tool result text so the model can react
+    on the next turn.
+
+    Args:
+        mcp_client: Active :class:`MCPClient`, or ``None`` when MCP is off.
+        skill_resources: Map of skill tool name to local file path; populated
+            by :func:`devops_bench.agents.api.skills.discover_skill_tools`.
+        errors: Errors list to mutate when a dispatch raises.
+
+    Returns:
+        An async ``(name, args, call_id) -> str`` callable matching
+        :data:`devops_bench.models.loop.ToolDispatcher`.
+    """
+
+    async def dispatch(name: str, args: Any, call_id: str | None) -> str:
+        try:
+            # Skill tools take priority — they are advertised in the same tool
+            # list but are served locally without round-tripping the MCP server.
+            if name in skill_resources:
+                file_path = skill_resources[name]
+                _log.info("Calling skill tool %s for file %s", name, file_path)
+                return await asyncio.to_thread(read_skill_file, file_path)
+            if mcp_client is None:
+                msg = (
+                    f"Error: tool {name!r} requested but no MCP server is "
+                    "configured for this agent."
+                )
+                errors.append(msg)
+                return msg
+            arg_dict = args if isinstance(args, dict) else {}
+            tool_result = await mcp_client.call_tool(name, arg_dict)
+            return extract_tool_text(tool_result)
+        except Exception as exc:  # noqa: BLE001 - one tool failure must not abort the run
+            msg = f"Error calling tool {name}: {exc}"
+            _log.warning(msg)
+            errors.append(msg)
+            return f"Error: {exc}"
+
+    return dispatch
+
+
+async def _gather_tools(
+    mcp_client: MCPClient | None,
+    skill_tools: list[SkillToolInfo],
+) -> list[Any]:
+    """Return the combined MCP + skill tool list passed to ``format_tools``.
+
+    Args:
+        mcp_client: Active MCP client, or ``None`` when MCP is off.
+        skill_tools: Skill tool descriptors from
+            :func:`discover_skill_tools`.
+
+    Returns:
+        A list of tool objects (MCP-native or :class:`SkillToolInfo`) in MCP
+        order followed by skill order. Both are duck-typed (``name``,
+        ``description``, ``inputSchema``) so adapters' ``format_tools`` handles
+        them uniformly.
+    """
+    tools: list[Any] = []
+    if mcp_client is not None:
+        tools_result = await mcp_client.list_tools()
+        tools.extend(tools_result.tools)
+    tools.extend(skill_tools)
+    return tools
+
+
+async def _run_async(
+    client: LLMClient,
+    prompt: str,
+    mcp_server_path: str | None,
+    skills_paths: tuple[str, ...],
+    rules_text: str | None,
+    max_turns: int,
+) -> tuple[LoopResult, list[str], list[str]]:
+    """Drive the tool-use loop and return its ``(LoopResult, errors, skills)``.
+
+    Opens an MCP session when ``mcp_server_path`` is set and discovers local
+    skills when ``skills_paths`` is non-empty — the two are independent. The
+    tool list is formatted by the caller and passed to :func:`run_tool_loop`
+    pre-formatted.
+
+    Args:
+        client: Neutral LLM client.
+        prompt: Task prompt seeding the loop.
+        mcp_server_path: Command launching the MCP server, or ``None`` to skip
+            MCP entirely.
+        skills_paths: Filesystem locations to discover local skills under.
+        rules_text: Operator-brief text (the ``AgentRules.text`` payload)
+            handed to the provider as the ``system_instruction``; ``None`` /
+            empty means "no preamble".
+        max_turns: Safety cap on turns.
+
+    Returns:
+        A ``(loop_result, errors, skill_names)`` tuple. ``errors`` carries any
+        per-tool dispatch failures recorded by the dispatcher.
+    """
+    errors: list[str] = []
+    skill_tools, skill_resources, skill_names = await asyncio.to_thread(
+        discover_skill_tools, skills_paths
+    )
+    system_instruction = rules_text or None
+
+    if not mcp_server_path:
+        formatted = client.format_tools(skill_tools)
+        dispatch = _build_dispatch(None, skill_resources, errors)
+        loop_result = await run_tool_loop(
+            client=client,
+            goal=prompt,
+            tools=formatted,
+            system_instruction=system_instruction,
+            dispatch=dispatch,
+            max_turns=max_turns,
+        )
+        return loop_result, errors, skill_names
+
+    async with MCPClient(mcp_server_path) as mcp_client:
+        tools = await _gather_tools(mcp_client, skill_tools)
+        formatted = client.format_tools(tools)
+        dispatch = _build_dispatch(mcp_client, skill_resources, errors)
+        loop_result = await run_tool_loop(
+            client=client,
+            goal=prompt,
+            tools=formatted,
+            system_instruction=system_instruction,
+            dispatch=dispatch,
+            max_turns=max_turns,
+        )
+        return loop_result, errors, skill_names
+
+
+@AGENTS.register("api")
+class ApiAgent(AgentHarness):
+    """API agent harness driving a model-agnostic MCP tool-use loop.
+
+    Provider, model, and capability bindings all flow from
+    :class:`~devops_bench.agents.config.AgentConfig` — no environment reads
+    happen inside this class. Capability gates:
+
+    * **MCP on/off** is driven by ``config.capabilities.mcp`` (presence of an
+      :class:`~devops_bench.agents.capabilities.McpBinding` with a non-empty
+      ``command``).
+    * **Skills on/off** is driven by ``config.capabilities.skills.paths``
+      independently of MCP — an agent may run with skills only, MCP only,
+      both, or neither.
+    * **Rules** flow from ``config.capabilities.rules.text`` and ride on the
+      provider's ``system_instruction`` parameter (empty text → no preamble).
+
+    ``__init__`` assigns ``self.mcp_servers`` / ``self.skills`` /
+    ``self.rules`` from the config bindings, which makes
+    ``isinstance(agent, SupportsMcp/SupportsSkills/SupportsRules)`` return
+    ``True`` for orchestrator-side capability negotiation (the Protocols are
+    structural — no mixin required).
+
+    The execute path opens the MCP session (when configured), discovers
+    skills, hands the *pre-formatted* tool list to :func:`run_tool_loop`, and
+    folds the resulting conversation history into canonical
+    :class:`~devops_bench.agents.result.ToolCall` trajectory entries via
+    :func:`fold_trajectory`.
+    """
+
+    def __init__(self, config: AgentConfig | None = None) -> None:
+        # Assign the capability bindings as attributes so the structural
+        # Protocols see the granted bindings.
+        AgentHarness.__init__(self, config)
+        caps = self.config.capabilities
+        self.mcp_servers = caps.mcp_servers
+        self.skills = caps.skills
+        self.rules = caps.rules
+
+    def _execute(self, prompt: str) -> AgentResult:
+        """Build the LLM client, drive the loop, and assemble an AgentResult.
+
+        Args:
+            prompt: Task prompt handed to the agent.
+
+        Returns:
+            An :class:`AgentResult` whose ``trajectory`` is a list of canonical
+            :class:`ToolCall` entries, ``output`` is :attr:`LoopResult.final_text`,
+            and ``tokens`` / ``latency`` carry the loop's accumulated values.
+        """
+        llm_client = get_model(self.config.provider, self.config.model)
+        max_turns = self.config.max_turns or _DEFAULT_MAX_TURNS
+        mcp_binding = self.config.capabilities.mcp
+        # Only open an MCPClient when an MCP binding carries a launch command;
+        # an empty-command binding is treated as "no MCP". ``shlex.join``
+        # round-trips ``MCPClient``'s ``shlex.split`` so a spaced argv token
+        # (``("uv run", "mcp-server")``) is rebuilt as a single quoted word.
+        mcp_server_path = shlex.join(mcp_binding.command) if mcp_binding and mcp_binding.command else None
+        skills_paths = self.config.capabilities.skills.paths
+        rules_text = self.config.capabilities.rules.text
+
+        try:
+            loop_result, dispatch_errors, skill_names = asyncio.run(
+                _run_async(
+                    llm_client,
+                    prompt,
+                    mcp_server_path,
+                    skills_paths,
+                    rules_text,
+                    max_turns,
+                )
+            )
+        except ValueError as exc:
+            # E.g. empty MCP server command; surface as a clean errored result
+            # rather than letting it bubble through the base safety net.
+            return AgentResult.errored(str(exc))
+
+        trajectory, orphan_errors = _fold_with_extraction_errors(loop_result.contents)
+        tokens = extract_tokens(loop_result.response)
+        metadata: dict[str, Any] = {
+            "tools_used": sorted(loop_result.tools_used),
+        }
+        if skill_names:
+            metadata["skills_loaded"] = list(skill_names)
+
+        return AgentResult(
+            output=loop_result.final_text,
+            trajectory=trajectory,
+            tokens=tokens,
+            latency=loop_result.latency,
+            errors=list(dispatch_errors) + orphan_errors,
+            metadata=metadata,
+        )

--- a/devops_bench/agents/api/mcp.py
+++ b/devops_bench/agents/api/mcp.py
@@ -1,0 +1,132 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Async MCP client wrapping the ``mcp`` SDK over a stdio server transport."""
+
+from __future__ import annotations
+
+import shlex
+from contextlib import AsyncExitStack
+from typing import Any
+
+from devops_bench.core import MissingDependencyError, get_logger
+
+__all__ = ["MCPClient", "extract_tool_text"]
+
+_log = get_logger("agents.api.mcp")
+
+
+class MCPClient:
+    """Async context manager over an MCP stdio server.
+
+    Spawns the MCP server given by ``server_path``, initializes a session, and
+    exposes tool discovery and invocation. The ``mcp`` SDK is imported lazily on
+    ``__aenter__`` so merely importing this module never requires the SDK.
+
+    Attributes:
+        server_path: Command used to launch the MCP server over stdio.
+        session: The active ``ClientSession`` once entered, else ``None``.
+
+    Raises:
+        MissingDependencyError: If the ``mcp`` SDK is not installed (on enter).
+        ValueError: If ``server_path`` is empty or whitespace-only (on enter).
+    """
+
+    def __init__(self, server_path: str) -> None:
+        self.server_path = server_path
+        self.exit_stack = AsyncExitStack()
+        self.session: Any = None
+
+    async def __aenter__(self) -> MCPClient:
+        try:
+            from mcp.client.session import ClientSession
+            from mcp.client.stdio import StdioServerParameters, stdio_client
+        except ImportError as exc:  # pragma: no cover - exercised via MissingDependencyError
+            raise MissingDependencyError("the API agent's MCP client", "mcp") from exc
+
+        # Split the command so a multi-word server_path (e.g. "uv run mcp-server")
+        # is spawned as program + args rather than a single executable name; the
+        # stdio transport spawns without a shell, so an unsplit command would fail
+        # with FileNotFoundError.
+        parts = shlex.split(self.server_path or "")
+        if not parts:
+            raise ValueError(
+                "MCP server_path is empty; set AGENT_TARGET/MCP_SERVER_PATH to the "
+                "MCP server command."
+            )
+        server_params = StdioServerParameters(command=parts[0], args=parts[1:])
+        stdio_transport = await self.exit_stack.enter_async_context(
+            stdio_client(server_params)
+        )
+        self.read_stream, self.write_stream = stdio_transport
+        self.session = await self.exit_stack.enter_async_context(
+            ClientSession(self.read_stream, self.write_stream)
+        )
+        await self.session.initialize()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.exit_stack.aclose()
+
+    async def list_tools(self) -> Any:
+        """List the tools advertised by the connected MCP server.
+
+        Returns:
+            The raw ``list_tools`` result whose ``.tools`` is the tool list.
+        """
+        return await self.session.list_tools()
+
+    async def call_tool(self, name: str, arguments: dict) -> Any:
+        """Invoke an MCP tool by name.
+
+        DeepEval's ``@observe`` wrapper is applied when available so MCP calls
+        appear in traces; the import is best-effort and a missing ``deepeval``
+        degrades gracefully to an untraced call.
+
+        Args:
+            name: Tool name as advertised by the server.
+            arguments: Keyword arguments for the tool.
+
+        Returns:
+            The raw tool-call result from the MCP session.
+        """
+        try:
+            from deepeval.tracing import observe
+        except ImportError:
+            return await self.session.call_tool(name, arguments=arguments)
+
+        @observe(span_type="TOOL")
+        async def _call() -> Any:
+            return await self.session.call_tool(name, arguments=arguments)
+
+        return await _call()
+
+
+def extract_tool_text(tool_result: Any) -> str:
+    """Aggregate the text of every content block in an MCP tool result.
+
+    Args:
+        tool_result: The raw result returned by :meth:`MCPClient.call_tool`.
+
+    Returns:
+        The newline-joined text of all blocks exposing a ``text`` attribute. If
+        the result has no ``content`` blocks (or none carry text), the result is
+        stringified instead.
+    """
+    content = getattr(tool_result, "content", None)
+    if content:
+        texts = [block.text for block in content if hasattr(block, "text")]
+        if texts:
+            return "\n".join(texts)
+    return str(tool_result)

--- a/devops_bench/agents/api/skills.py
+++ b/devops_bench/agents/api/skills.py
@@ -1,0 +1,134 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Local skill discovery for the API agent (decoupled from MCP).
+
+A *skill* is a ``SKILL.md`` file under one of the configured paths whose
+frontmatter declares a ``name`` and ``description``. Each discovered skill is
+advertised to the model as a synthetic tool — invoking the tool returns the
+file's contents. Skills are independent of MCP: an agent may have skills
+without an MCP server (and vice versa); the API agent gates each on its own
+config field.
+
+This module performs only blocking filesystem I/O; importing it pulls no
+provider SDK, ``mcp``, or ``deepeval``.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from collections.abc import Iterable
+from typing import Any
+
+from devops_bench.agents.shared.skills import parse_skill_md
+from devops_bench.core import get_logger
+
+__all__ = [
+    "SkillToolInfo",
+    "parse_skill_md",
+    "discover_skill_tools",
+    "read_skill_file",
+]
+
+_log = get_logger("agents.api.skills")
+
+
+class SkillToolInfo:
+    """Duck-typed stand-in for an MCP tool used to advertise a local skill.
+
+    Mirrors the attribute surface (``name``, ``description``, ``inputSchema``)
+    the provider adapters' ``format_tools`` reads from an MCP tool object, so a
+    skill can be added to the same tool list as MCP tools without a separate
+    formatting path.
+
+    Attributes:
+        name: Tool name as exposed to the model (prefixed ``skill_``).
+        description: Free-form description shown to the model.
+        inputSchema: JSON schema for arguments; defaults to ``None`` since
+            skills take no arguments today.
+    """
+
+    def __init__(self, name: str, description: str, inputSchema: Any = None) -> None:  # noqa: N803 - matches MCP tool attr
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema
+
+
+def discover_skill_tools(
+    paths: Iterable[str],
+) -> tuple[list[SkillToolInfo], dict[str, str], list[str]]:
+    """Walk ``paths`` for ``SKILL.md`` files and build tool descriptors.
+
+    Performs blocking filesystem I/O; callers in async contexts should run this
+    via :func:`asyncio.to_thread` to keep the event loop responsive.
+
+    Args:
+        paths: Filesystem locations to search (each is walked recursively for
+            ``SKILL.md`` files). Missing paths are warned and skipped.
+
+    Returns:
+        A ``(tools, resources, names)`` tuple:
+
+        * ``tools`` — :class:`SkillToolInfo` descriptors ready to merge into the
+          MCP tool list before formatting.
+        * ``resources`` — map of normalized tool name to source file path,
+          consumed by the agent's dispatch closure.
+        * ``names`` — discovered skill names (the unnormalized values from each
+          file's frontmatter); useful for diagnostics.
+    """
+    tools: list[SkillToolInfo] = []
+    resources: dict[str, str] = {}
+    names: list[str] = []
+
+    for skills_dir in paths:
+        if not skills_dir:
+            continue
+        if not os.path.exists(skills_dir):
+            _log.warning("Skills directory not found: %s", skills_dir)
+            continue
+        skill_files = glob.glob(os.path.join(skills_dir, "**", "SKILL.md"), recursive=True)
+        for file_path in skill_files:
+            skill_name, description, _ = parse_skill_md(file_path)
+            if not skill_name:
+                continue
+            normalized = "skill_" + skill_name.replace("-", "_")
+            tools.append(
+                SkillToolInfo(
+                    name=normalized,
+                    description=description or f"Exposes skill: {skill_name}",
+                )
+            )
+            resources[normalized] = file_path
+            names.append(skill_name)
+            _log.info("Loaded local skill as tool: %s -> %s", normalized, file_path)
+
+    return tools, resources, names
+
+
+def read_skill_file(file_path: str) -> str:
+    """Read a skill file's contents, returning an error string on failure.
+
+    Args:
+        file_path: Path to the skill file to read.
+
+    Returns:
+        The file contents, or an ``Error reading skill file ...`` message when
+        the file cannot be read.
+    """
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            return f.read()
+    except OSError as exc:
+        return f"Error reading skill file {file_path}: {exc}"

--- a/devops_bench/agents/shared/__init__.py
+++ b/devops_bench/agents/shared/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers shared across agent implementations (API and CLI).
+
+Utilities here are agent-flavour-agnostic so neither the API agent nor a CLI
+agent has to reach into the other's package. Importing this package pulls no
+provider SDK, ``mcp``, or ``deepeval``.
+"""

--- a/devops_bench/agents/shared/skills.py
+++ b/devops_bench/agents/shared/skills.py
@@ -1,0 +1,77 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Frontmatter parsing for ``SKILL.md`` files, shared by every agent.
+
+Both the API agent (advertising skills as synthetic tools) and the CLI agents
+(materializing skills into the launched CLI) need a skill file's ``name`` and
+``description``; keeping the parser here lets either import it without reaching
+into the other's package. Importing this module pulls no provider SDK.
+"""
+
+from __future__ import annotations
+
+import re
+
+import yaml
+
+from devops_bench.core import get_logger
+
+__all__ = ["parse_skill_md"]
+
+_log = get_logger("agents.shared.skills")
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL | re.MULTILINE)
+
+
+def parse_skill_md(file_path: str) -> tuple[str | None, str | None, str | None]:
+    """Parse a ``SKILL.md`` file's YAML frontmatter.
+
+    The frontmatter block is parsed with :func:`yaml.safe_load`, so multi-line
+    block scalars (e.g. a ``description: >-`` spanning several lines) are read
+    in full rather than truncated to the first line.
+
+    Args:
+        file_path: Path to a skill markdown file.
+
+    Returns:
+        A ``(name, description, content)`` tuple. ``name``/``description`` are
+        ``None`` when the field is absent; ``content`` is the full file text, or
+        ``None`` when the file is unreadable or carries no frontmatter block.
+    """
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            content = f.read()
+    except OSError as exc:
+        _log.warning("Error parsing skill file %s: %s", file_path, exc)
+        return None, None, None
+
+    match = _FRONTMATTER_RE.search(content)
+    if not match:
+        return None, None, None
+
+    try:
+        frontmatter = yaml.safe_load(match.group(1))
+    except yaml.YAMLError as exc:
+        _log.warning("Invalid YAML frontmatter in skill file %s: %s", file_path, exc)
+        return None, None, content
+
+    if not isinstance(frontmatter, dict):
+        return None, None, content
+
+    name = frontmatter.get("name")
+    description = frontmatter.get("description")
+    name = str(name).strip() if name is not None else None
+    description = str(description).strip() if description is not None else None
+    return name, description, content

--- a/devops_bench/chaos/__init__.py
+++ b/devops_bench/chaos/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chaos injection: fault/trigger interfaces, registries, and the typed spec.
+
+Exports only ``Fault``, ``Trigger``, ``ChaosResult``, ``FAULTS``, ``TRIGGERS``,
+``ChaosSpec``. :class:`ChaosSpec` parses through the :data:`FAULTS` /
+:data:`TRIGGERS` registries; importing the package imports the concrete
+fault/trigger leaves so their ``@register`` decorators fire. ``ChaosAgent`` and
+the provider SDK chain are not pulled — they load lazily inside
+:meth:`Fault.inject`.
+"""
+
+from __future__ import annotations
+
+from devops_bench.chaos.base import FAULTS, TRIGGERS, ChaosResult, Fault, Trigger
+from devops_bench.chaos.spec import ChaosSpec
+
+__all__ = [
+    "ChaosResult",
+    "ChaosSpec",
+    "FAULTS",
+    "Fault",
+    "TRIGGERS",
+    "Trigger",
+]

--- a/devops_bench/chaos/agent.py
+++ b/devops_bench/chaos/agent.py
@@ -1,0 +1,126 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLM-driven orchestration loop for injecting chaos faults."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from devops_bench.core import first_env, get_logger
+from devops_bench.models import LLMClient, get_model
+from devops_bench.models.utils.loop import LoopResult, run_tool_loop
+
+__all__ = ["ChaosAgent", "ToolHandler"]
+
+_log = get_logger("chaos.agent")
+
+# Safety bound on the agent loop so a misbehaving model cannot spin forever.
+_MAX_TURNS = 8
+
+#: Signature of a chaos command handler: ``(command, chaos_active_event) -> str``.
+#: Concrete faults implement this and pass it to :class:`ChaosAgent` — see
+#: :func:`devops_bench.chaos.faults.generate_load.run_chaos_command`.
+ToolHandler = Callable[[str, threading.Event | None], str]
+
+
+class ChaosAgent:
+    """Drives an :class:`LLMClient` through a tool-calling loop to inject chaos.
+
+    Args:
+        system_instruction: System prompt for the loop; supplied by the fault.
+        tool: Neutral tool descriptor (duck-typed: ``.name`` plus the fields
+            ``LLMClient.format_tools`` consumes). Supplied by the fault.
+        tool_handler: ``(command, chaos_active_event) -> str`` callable. The
+            fault implements this; commonly
+            :func:`~devops_bench.chaos.faults.generate_load.run_chaos_command`.
+        chaos_active_event: Optional :class:`threading.Event` the handler may
+            set when a disruption is observably active (e.g. load is flowing);
+            forwarded unchanged.
+        client: Optional pre-built LLM client. When omitted one is selected
+            via ``first_env("CHAOS_PROVIDER","AGENT_PROVIDER")`` /
+            ``first_env("CHAOS_MODEL","AGENT_MODEL")``.
+        max_turns: Override for the safety turn cap.
+    """
+
+    def __init__(
+        self,
+        system_instruction: str,
+        tool: Any,
+        tool_handler: ToolHandler,
+        chaos_active_event: threading.Event | None = None,
+        client: LLMClient | None = None,
+        max_turns: int = _MAX_TURNS,
+    ) -> None:
+        if client is None:
+            provider = first_env("CHAOS_PROVIDER", "AGENT_PROVIDER")
+            model_name = first_env("CHAOS_MODEL", "AGENT_MODEL")
+            client = get_model(provider=provider, model_name=model_name)
+        self._client = client
+        self._system_instruction = system_instruction
+        self._tool = tool
+        self._tool_handler = tool_handler
+        self._chaos_active_event = chaos_active_event
+        self._max_turns = max_turns
+
+    def run(self, goal: str) -> str:
+        """Run the chaos loop synchronously and return the model's final text.
+
+        Args:
+            goal: The planned-mode goal prompt for the model.
+
+        Returns:
+            The model's final text response.
+        """
+        return asyncio.run(self._run_async(goal)).final_text
+
+    async def _run_async(self, goal: str) -> LoopResult:
+        """Drive :func:`run_tool_loop` with the fault-supplied tool/handler."""
+        tools = self._client.format_tools([self._tool])
+        return await run_tool_loop(
+            client=self._client,
+            goal=goal,
+            tools=tools,
+            system_instruction=self._system_instruction,
+            dispatch=self._dispatch,
+            max_turns=self._max_turns,
+        )
+
+    async def _dispatch(self, name: str, args: Any, call_id: str | None) -> str:
+        """Adapt :data:`~devops_bench.models.utils.loop.ToolDispatcher` to the handler.
+
+        :func:`run_tool_loop` calls this once per function call. We forward to
+        the fault's handler, contributing the only chaos-specific glue (the
+        active-event flag) and reject malformed args / unknown tool names with
+        a descriptive error string so the model sees the failure instead of
+        silently looping.
+
+        Args:
+            name: Tool name requested by the model.
+            args: Raw arguments from the model.
+            call_id: Provider-supplied call id (unused; surfaced by the loop).
+
+        Returns:
+            The handler's textual result, or an ``"Error: ..."`` description.
+        """
+        if not isinstance(args, dict):
+            return "Error: tool args must be an object"
+        expected = getattr(self._tool, "name", None)
+        if name != expected:
+            return f"Error: unknown tool {name!r}"
+        command = args.get("command", "")
+        return self._tool_handler(command, self._chaos_active_event)

--- a/devops_bench/chaos/base.py
+++ b/devops_bench/chaos/base.py
@@ -1,0 +1,125 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Result model, abstract bases, and the :data:`FAULTS` / :data:`TRIGGERS` registries."""
+
+from __future__ import annotations
+
+import threading
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel
+
+from devops_bench.core import Registry
+from devops_bench.core.context import RunContext
+
+__all__ = [
+    "ChaosResult",
+    "Fault",
+    "Trigger",
+    "FAULTS",
+    "TRIGGERS",
+]
+
+#: Registry of concrete :class:`Fault` subclasses, keyed by their ``type``.
+#: ``entry_point_group`` lets external packages register a fault without
+#: touching this tree.
+FAULTS: Registry[type[Fault]] = Registry(
+    "faults", entry_point_group="devops_bench.faults"
+)
+
+#: Registry of concrete :class:`Trigger` subclasses, keyed by their ``type``.
+TRIGGERS: Registry[type[Trigger]] = Registry(
+    "triggers", entry_point_group="devops_bench.triggers"
+)
+
+
+class ChaosResult(BaseModel):
+    """Structured outcome of a chaos fault injection.
+
+    Attributes:
+        success: True when the fault completed without raising.
+        injected_fault: Fault id (``Fault.type``) — keys diagnosis scoring in
+            metrics.
+        output: Free-form text payload (typically the model's final summary).
+        elapsed_time: Wall-clock seconds spent injecting the fault.
+        error: Human-readable error string when ``success`` is False; ``None``
+            on success.
+    """
+
+    success: bool
+    injected_fault: str
+    output: str = ""
+    elapsed_time: float = 0.0
+    error: str | None = None
+
+
+class Fault(BaseModel, ABC):
+    """Abstract base for a ``type``-tagged chaos fault node.
+
+    Concrete faults are pydantic models that carry their own typed parameters
+    plus a ``type: Literal["..."]`` discriminator and self-register under that
+    key via ``@FAULTS.register(...)``. They implement :meth:`inject`, which
+    drives the disruption against the cluster described by ``ctx`` and returns
+    a typed :class:`ChaosResult`.
+
+    Attributes:
+        name: Optional label echoed onto the result; metadata, never structural.
+    """
+
+    name: str | None = None
+
+    @abstractmethod
+    def inject(
+        self,
+        ctx: RunContext,
+        chaos_active_event: threading.Event | None = None,
+    ) -> ChaosResult:
+        """Inject the fault and return its structured outcome.
+
+        Args:
+            ctx: Run context describing the target cluster and workspace.
+            chaos_active_event: Optional event the fault sets when the
+                disruption is observably active (e.g. load is flowing), so the
+                harness can coordinate measurements. ``None`` disables the
+                signal.
+
+        Returns:
+            A :class:`ChaosResult` describing the injection outcome.
+        """
+        raise NotImplementedError
+
+
+class Trigger(BaseModel, ABC):
+    """Abstract base for a ``type``-tagged chaos firing condition.
+
+    Concrete triggers are pydantic models with a ``type: Literal["..."]``
+    discriminator and self-register via ``@TRIGGERS.register(...)``. They
+    implement :meth:`wait`, which blocks until the condition the trigger
+    encodes is met.
+
+    Attributes:
+        name: Optional label echoed onto the result; metadata, never structural.
+    """
+
+    name: str | None = None
+
+    @abstractmethod
+    def wait(self, ctx: RunContext) -> None:
+        """Block until the trigger's condition is satisfied.
+
+        Args:
+            ctx: Run context describing the target cluster and workspace.
+        """
+        raise NotImplementedError

--- a/devops_bench/chaos/faults/__init__.py
+++ b/devops_bench/chaos/faults/__init__.py
@@ -12,22 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Reusable Kubernetes primitives: kubectl wrappers and wait/poll conditions."""
+"""Concrete chaos faults; importing this package fires each ``@FAULTS.register``."""
 
-from devops_bench.k8s.conditions import poll_until
-from devops_bench.k8s.kubectl import (
-    apply,
-    get_resource,
-    port_forward,
-    rollout_status,
-    wait,
-)
+from __future__ import annotations
 
-__all__ = [
-    "apply",
-    "get_resource",
-    "poll_until",
-    "port_forward",
-    "rollout_status",
-    "wait",
-]
+# Imported for the ``@FAULTS.register`` side effect that populates the registry.
+from devops_bench.chaos.faults import generate_load  # noqa: F401
+
+__all__: list[str] = []

--- a/devops_bench/chaos/faults/generate_load.py
+++ b/devops_bench/chaos/faults/generate_load.py
@@ -1,0 +1,350 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The ``generate_load`` fault: LLM-driven fortio traffic spikes.
+
+This module owns every fortio-specific concern: the load-target schema, the SRE
+system prompt, the ``run_command`` tool descriptor, the shell-free argv
+executor, and the typed :class:`GenerateLoadFault` node; the ``kubectl
+port-forward`` tunnel is driven by :func:`devops_bench.k8s.port_forward`. The
+chaos agent is imported lazily inside :meth:`GenerateLoadFault.inject` so
+registering this fault does not pull the agent or :mod:`devops_bench.models`
+chain.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import shlex
+import textwrap
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from devops_bench.chaos.base import FAULTS, ChaosResult, Fault
+from devops_bench.core import get_logger
+from devops_bench.core.context import RunContext
+from devops_bench.core.subprocess import run
+from devops_bench.k8s import port_forward
+
+__all__ = [
+    "GenerateLoadFault",
+    "LoadTarget",
+    "RUN_COMMAND_TOOL",
+    "build_system_instruction",
+    "run_chaos_command",
+]
+
+_log = get_logger("chaos.generate_load")
+
+# Marker substring that, when present in a command, indicates a load spike is
+# active. The harness watches the shared event to coordinate measurements.
+_LOAD_MARKER = "fortio load"
+
+# Wall-clock ceiling for a single chaos command.
+_COMMAND_TIMEOUT = 40
+
+# Local port the cluster workload is exposed on for chaos load generation.
+_LOCAL_PORT = 8080
+
+# Single source of truth for the load target when a spec omits one. The local
+# port-forward URL the cluster workload is exposed on.
+_DEFAULT_TARGET_URL = f"http://localhost:{_LOCAL_PORT}"
+
+# ``RunContext.env`` keys naming the port-forward target the harness writes
+# onto the context before injection.
+_ENV_TARGET_DEPLOYMENT = "CHAOS_TARGET_DEPLOYMENT"
+_ENV_TARGET_NAMESPACE = "CHAOS_TARGET_NAMESPACE"
+_ENV_SKIP_PORT_FORWARD = "CHAOS_SKIP_PORT_FORWARD"
+
+
+def build_system_instruction(target_url: str = _DEFAULT_TARGET_URL) -> str:
+    """Build the SRE system instruction, targeting ``target_url`` for load.
+
+    Args:
+        target_url: URL fortio load should be directed at. Flows from the
+            fault's ``target.service_url`` (rewritten by the harness to the
+            local port-forward), defaulting to :data:`_DEFAULT_TARGET_URL`.
+
+    Returns:
+        The system instruction string with the target URL injected.
+    """
+    # Each paragraph the model sees is one physical source line; ``dedent``
+    # strips the shared leading indentation.
+    return textwrap.dedent(
+        f"""\
+        You are a professional Site Reliability Engineer (SRE) and Chaos Engineering Expert.
+        Your role is to disrupt GKE workloads to test system resilience, which can happen in two modes:
+        1. Planned Mode: Execute a specific GKE chaos disruption according to a provided JSON spec.
+        2. Autonomous Mode: Autonomously explore the GKE cluster state, identify critical targets (pods, nodes, services), and inject transient faults to test recovery.
+
+        You are equipped with the `run_command` tool, which runs a single command locally on the GKE host control machine (which is fully authenticated and has GKE admin kubectl privileges). Each call must be ONE non-piped command: shell pipelines, redirection, command chaining (``|``, ``>``, ``&&``, ``;``) and environment-variable interpolation (``$VAR``) are NOT supported.
+
+        Strict Guidelines for Execution:
+        - Single Execution Policy: You MUST execute exactly one tool call to run the planned 'fortio' load generation spike. Do NOT attempt to rerun, adjust, or tune the load generation if the target service saturates or returns timeouts. Once the single load command is executed, analyze the output, write your final performance summary, and exit immediately.
+        - Safety First: Only inject transient, safe, and recoverable faults (e.g. killing pods, scaling deployments, generating traffic spikes). Do NOT permanently destroy GKE clusters, namespaces, or nodes.
+        - Traffic Generation: For load spikes, use the 'fortio' binary. Since GKE internal service URLs (*.svc.cluster.local) are port-forwarded to the host, you MUST target '{target_url}' instead.
+        - Analysis & Clarity: Analyze command outputs carefully, report stdout/stderr accurately, and confirm in your final response when the disruption has been successfully completed."""
+    )
+
+
+# Neutral, duck-typed tool descriptor consumed by ``LLMClient.format_tools``
+# (mirrors the MCP tool shape: name/description/inputSchema).
+RUN_COMMAND_TOOL = SimpleNamespace(
+    name="run_command",
+    description=(
+        "Run a shell command on the GKE host control machine (authenticated kubectl + fortio). "
+        "Returns combined stdout and stderr."
+    ),
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "command": {
+                "type": "string",
+                "description": "The shell command to execute, e.g. a fortio load invocation.",
+            }
+        },
+        "required": ["command"],
+    },
+)
+
+
+def run_chaos_command(
+    command: str,
+    chaos_active_event: threading.Event | None = None,
+) -> str:
+    """Execute a single chaos command and return its combined output.
+
+    The command is a single, non-piped string produced by the LLM (typically a
+    ``fortio load`` invocation). It is tokenized with :func:`shlex.split` and
+    run shell-free, so shell features (pipes, redirection, ``$VAR``) are not
+    supported; a leading ``~`` in each token is expanded to the user's home.
+    When the command is a load spike and an event is supplied, the event is
+    set so the harness can observe that load is active before measuring impact.
+
+    Args:
+        command: Single command to execute (no shell pipelines or redirection).
+        chaos_active_event: Optional event signaled when a load spike starts.
+
+    Returns:
+        A string combining stdout and stderr, or an ``"Error: ..."`` string if
+        the command could not be parsed or run.
+    """
+    if not command.strip():
+        return "Error: command string is empty"
+
+    try:
+        _log.info("running chaos command: %s", command)
+
+        # The model emits shell strings (e.g. a single fortio invocation); split
+        # into argv so execution stays shell-free. shlex.split does not expand
+        # ``~``, so expand each token's leading home to keep ``~/go/bin/fortio``
+        # style paths resolvable.
+        argv = [os.path.expanduser(arg) for arg in shlex.split(command)]
+
+        # Signal "load active" only once the command parses cleanly and we are
+        # about to execute it, so a parse failure never falsely tells the
+        # harness that load is live.
+        if chaos_active_event is not None and _LOAD_MARKER in command:
+            _log.info("load spike detected; signaling harness via chaos event")
+            chaos_active_event.set()
+
+        completed = run(argv, check=False, timeout=_COMMAND_TIMEOUT)
+        return f"Stdout:\n{completed.stdout}\nStderr:\n{completed.stderr}"
+    except Exception as exc:  # noqa: BLE001 - surface any failure back to the LLM
+        return f"Error: {exc}"
+
+
+class LoadTarget(BaseModel):
+    """Target for a generated load spike.
+
+    Attributes:
+        service_url: HTTP URL the load should be directed at. When the fault
+            opens its own port-forward (see :meth:`GenerateLoadFault.inject`),
+            this in-cluster ``*.svc.cluster.local`` URL is pointed at the local
+            tunnel for the duration of injection.
+        qps: Target queries per second; the LLM passes this to fortio.
+        duration: Optional fortio duration string (e.g. ``"30s"``). When
+            omitted, the model picks one consistent with the goal.
+        concurrency: Optional fortio ``-c`` concurrency override.
+    """
+
+    service_url: str
+    qps: int = Field(default=100, ge=1)
+    duration: str | None = None
+    concurrency: int | None = Field(default=None, ge=1)
+
+
+@FAULTS.register("generate_load")
+class GenerateLoadFault(Fault):
+    """A traffic-spike fault driven by an LLM issuing fortio commands.
+
+    The fault exposes a single command-execution capability to the model and
+    relies on the agent loop to plan and issue exactly one ``fortio load``
+    spike against the port-forwarded target. The fault owns the connectivity:
+    :meth:`inject` opens its own ``kubectl port-forward`` to the target
+    deployment, points the load URL at the local tunnel, and tears the tunnel
+    down when injection completes.
+
+    Attributes:
+        type: Discriminator literal, always ``"generate_load"``.
+        target: Typed load-target description (URL, qps, optional duration /
+            concurrency).
+    """
+
+    type: Literal["generate_load"] = "generate_load"
+    target: LoadTarget
+
+    def goal(self) -> str:
+        """Build the planned-mode goal prompt for the LLM.
+
+        The target URL is read from :attr:`target`; :meth:`inject` points it at
+        the local port-forward for the duration of injection, so the model's
+        prompt always agrees with the URL the load actually hits.
+
+        Returns:
+            The goal prompt instructing the model to issue one fortio spike.
+        """
+        spec_dump: dict[str, Any] = self.model_dump(exclude_none=True)
+        target_url = self.target.service_url
+        spec_json = json.dumps(spec_dump, indent=2)
+        # Dedent the template BEFORE interpolating ``spec_json``: the dumped
+        # JSON is multi-line with no shared leading indentation, so substituting
+        # it first would defeat ``dedent``'s common-prefix strip.
+        template = textwrap.dedent(
+            """\
+            Your goal is to execute the following GKE planned chaos engineering disruption action:
+            ```json
+            {spec_json}
+            ```
+
+            Guidelines for execution:
+            1. Use the 'fortio' tool to inject traffic into GKE.
+            2. Note: GKE service target URLs (like *.svc.cluster.local) are port-forwarded to '{target_url}' on the host, so run fortio against {target_url} instead.
+            Use your run_command tool to execute this disruption safely and effectively."""
+        )
+        return template.format(spec_json=spec_json, target_url=target_url)
+
+    def inject(
+        self,
+        ctx: RunContext,
+        chaos_active_event: threading.Event | None = None,
+    ) -> ChaosResult:
+        """Open a port-forward, run the LLM-planned chaos loop, tear it down.
+
+        The fault owns its own connectivity: when the run context names a
+        target deployment (via :data:`_ENV_TARGET_DEPLOYMENT` /
+        :data:`_ENV_TARGET_NAMESPACE` on ``ctx.env``) and the port-forward is
+        not skipped, :meth:`inject` opens a ``kubectl port-forward`` to that
+        deployment, points the load URL at ``http://localhost:<port>`` for the
+        duration of injection, generates load, and tears the tunnel down in a
+        ``finally``. When the deployment is absent or
+        :data:`_ENV_SKIP_PORT_FORWARD` is set (E2E smoke / unit tests), it runs
+        the chaos loop against whatever URL the target already carries.
+
+        Args:
+            ctx: Run context; ``ctx.env`` carries the port-forward target the
+                harness threaded in (deployment, namespace, skip flag).
+            chaos_active_event: Optional event the executor signals when a
+                load spike starts, so the harness can synchronize measurements.
+
+        Returns:
+            A :class:`ChaosResult` whose ``success`` is True on a clean loop
+            completion. Exceptions raised by the agent or the port-forward are
+            converted to ``success=False`` with the failure surfaced in
+            ``error``.
+        """
+        env = ctx.env or {}
+        deployment = env.get(_ENV_TARGET_DEPLOYMENT)
+        namespace = env.get(_ENV_TARGET_NAMESPACE, "default")
+        skip_port_forward = bool(env.get(_ENV_SKIP_PORT_FORWARD))
+
+        start = time.monotonic()
+        # Open the fault's own tunnel only when a target deployment is named and
+        # the caller did not opt out; otherwise run against the existing URL.
+        if deployment and not skip_port_forward:
+            forward = port_forward(
+                f"deployment/{deployment}", _LOCAL_PORT, namespace=namespace
+            )
+            local_url: str | None = _DEFAULT_TARGET_URL
+        else:
+            forward = contextlib.nullcontext()
+            local_url = None
+
+        try:
+            with forward:
+                output = self._run_agent_loop(local_url, chaos_active_event)
+        except Exception as exc:  # noqa: BLE001 - one fault must never abort the run
+            elapsed = time.monotonic() - start
+            _log.exception("generate_load fault crashed")
+            return ChaosResult(
+                success=False,
+                injected_fault=self.type,
+                output="",
+                elapsed_time=elapsed,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+        elapsed = time.monotonic() - start
+        return ChaosResult(
+            success=True,
+            injected_fault=self.type,
+            output=output,
+            elapsed_time=elapsed,
+        )
+
+    def _run_agent_loop(
+        self,
+        local_url: str | None,
+        chaos_active_event: threading.Event | None,
+    ) -> str:
+        """Drive the chaos agent against the effective target URL.
+
+        When ``local_url`` is set the fault is reaching its target through a
+        port-forward, so the load URL is pointed at the local tunnel for the
+        duration of the loop (and restored afterwards) — this keeps both the
+        system instruction and the goal prompt agreeing with the URL the load
+        actually hits. When ``local_url`` is ``None`` the existing target URL is
+        used unchanged.
+
+        Args:
+            local_url: Local port-forward URL to target, or ``None`` to use the
+                target's own ``service_url``.
+            chaos_active_event: Optional event signaled when load goes active.
+
+        Returns:
+            The agent's final summary string.
+        """
+        # Lazy import keeps the agent + models chain out of sys.modules until a
+        # fault actually injects; registering the fault only needs the class.
+        from devops_bench.chaos.agent import ChaosAgent
+
+        original_url = self.target.service_url
+        if local_url is not None:
+            self.target.service_url = local_url
+        try:
+            system_instruction = build_system_instruction(self.target.service_url)
+            agent = ChaosAgent(
+                system_instruction=system_instruction,
+                tool=RUN_COMMAND_TOOL,
+                tool_handler=run_chaos_command,
+                chaos_active_event=chaos_active_event,
+            )
+            return agent.run(self.goal())
+        finally:
+            self.target.service_url = original_url

--- a/devops_bench/chaos/schema.py
+++ b/devops_bench/chaos/schema.py
@@ -1,0 +1,52 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JSON Schema emission and validation for a single chaos entry."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import ValidationError
+
+from devops_bench.chaos.spec import ChaosSpec
+
+__all__ = ["json_schema", "validate_spec"]
+
+
+def json_schema() -> dict[str, Any]:
+    """Return the JSON Schema for a single chaos entry.
+
+    Returns:
+        A JSON-serializable mapping derived from :class:`ChaosSpec`.
+    """
+    return ChaosSpec.model_json_schema()
+
+
+def validate_spec(data: Any) -> ChaosSpec:
+    """Validate a raw mapping against :class:`ChaosSpec`.
+
+    Args:
+        data: A mapping authored in a task file (one chaos entry).
+
+    Returns:
+        The constructed :class:`ChaosSpec` instance.
+
+    Raises:
+        pydantic.ValidationError: If ``data`` does not match the schema.
+    """
+    try:
+        return ChaosSpec.model_validate(data)
+    except ValidationError:
+        raise

--- a/devops_bench/chaos/spec.py
+++ b/devops_bench/chaos/spec.py
@@ -1,0 +1,196 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry-driven schema for chaos specs.
+
+A chaos entry is a trigger, an action (fault), and an opaque ``verify`` key
+referencing a verification entry by name. :class:`ChaosSpec` parses the trigger
+and action payloads through the :data:`FAULTS` / :data:`TRIGGERS` registries.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic_core import PydanticCustomError
+
+# Importing the leaf packages fires their ``@FAULTS.register`` /
+# ``@TRIGGERS.register`` decorators so the registries are populated before parse.
+from devops_bench.chaos import faults as _faults  # noqa: F401
+from devops_bench.chaos import triggers as _triggers  # noqa: F401
+from devops_bench.chaos.base import FAULTS, TRIGGERS
+from devops_bench.core import NotRegisteredError
+
+__all__ = [
+    "ChaosSpec",
+    "parse_fault",
+    "parse_trigger",
+]
+
+
+def parse_fault(data: Any) -> BaseModel:
+    """Parse a fault (``action``) payload through :data:`FAULTS`.
+
+    Args:
+        data: A mapping carrying a ``type`` discriminator, or an already-parsed
+            :class:`pydantic.BaseModel` (returned as-is when registered).
+
+    Returns:
+        The concrete fault selected by ``data["type"]``.
+
+    Raises:
+        pydantic.ValidationError: If ``data`` is not a mapping, omits ``type``,
+            names an unregistered fault, or fails the target model's validation.
+    """
+    return _parse_through(data, FAULTS, axis="fault")
+
+
+def parse_trigger(data: Any) -> BaseModel:
+    """Parse a trigger payload through :data:`TRIGGERS`.
+
+    Args:
+        data: A mapping carrying a ``type`` discriminator, or an already-parsed
+            :class:`pydantic.BaseModel` (returned as-is when registered).
+
+    Returns:
+        The concrete trigger selected by ``data["type"]``.
+
+    Raises:
+        pydantic.ValidationError: If ``data`` is not a mapping, omits ``type``,
+            names an unregistered trigger, or fails the target model's validation.
+    """
+    return _parse_through(data, TRIGGERS, axis="trigger")
+
+
+def _parse_through(data: Any, registry: Any, *, axis: str) -> BaseModel:
+    """Resolve ``data["type"]`` against ``registry`` and validate the payload.
+
+    Args:
+        data: Authored payload or an already-parsed model instance.
+        registry: The :data:`FAULTS` or :data:`TRIGGERS` registry to consult.
+        axis: ``"fault"`` or ``"trigger"`` — used to label error messages.
+
+    Returns:
+        The validated concrete model instance.
+
+    Raises:
+        pydantic.ValidationError: If ``data`` cannot be resolved or validated.
+    """
+    if isinstance(data, BaseModel):
+        type_key = getattr(data, "type", None)
+        if (
+            isinstance(type_key, str)
+            and type_key in registry
+            and registry.get(type_key) is type(data)
+        ):
+            return data
+        raise _validation_error(
+            f"chaos_spec_unregistered_{axis}_model",
+            (
+                f"chaos {axis} node {type(data).__name__!r} is not a "
+                f"registered {axis}"
+            ),
+            input_value=data,
+        )
+    if not isinstance(data, dict):
+        raise _validation_error(
+            f"chaos_spec_{axis}_not_mapping",
+            f"chaos {axis} node must be a mapping, got {type(data).__name__}",
+            input_value=data,
+        )
+
+    type_key = data.get("type")
+    if not isinstance(type_key, str):
+        raise _validation_error(
+            f"chaos_spec_{axis}_missing_type",
+            f"chaos {axis} node is missing required ``type`` discriminator",
+            input_value=data,
+        )
+
+    try:
+        model_cls = registry.get(type_key)
+    except NotRegisteredError as exc:
+        raise _validation_error(
+            f"chaos_spec_unknown_{axis}_type",
+            (
+                f"unknown chaos {axis} type {type_key!r}; "
+                f"registered: {sorted(registry.keys())}"
+            ),
+            input_value=data,
+        ) from exc
+
+    return model_cls.model_validate(data)
+
+
+def _validation_error(
+    code: str, message: str, *, input_value: Any
+) -> ValidationError:
+    """Build a :class:`ValidationError` around a single :class:`PydanticCustomError`.
+
+    The registry's :class:`NotRegisteredError` carries useful context, but the
+    rest of the codebase catches :class:`pydantic.ValidationError` for spec
+    parsing; wrapping keeps that single error surface.
+    """
+    custom = PydanticCustomError(code, message)
+    return ValidationError.from_exception_data(
+        title=code,
+        line_errors=[
+            {
+                "type": custom,
+                "loc": (),
+                "input": input_value,
+            }
+        ],
+    )
+
+
+class ChaosSpec(BaseModel):
+    """One authored chaos entry: a trigger, an action, and an optional verify ref.
+
+    ``verify`` names a verification entry by key; the ``verification`` alias is
+    also accepted. The key is never an inline verification node — the harness
+    resolves it against its verification registry.
+
+    Attributes:
+        name: Human-readable label echoed onto the chaos report.
+        trigger: ``type``-tagged firing condition (e.g. :class:`TimeTrigger`).
+        action: ``type``-tagged disruption (e.g. :class:`GenerateLoadFault`).
+        verify: Optional verification-key reference; ``None`` skips post-fault
+            verification. Accepts the ``verification`` alias.
+    """
+
+    # Accept the ``verification`` alias; forbid unknown keys.
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    name: str = "Planned Disruption"
+    trigger: Any
+    action: Any
+    verify: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("verify", "verification"),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _parse_nodes(cls, data: Any) -> Any:
+        """Route ``trigger`` / ``action`` payloads through the registry parsers."""
+        if not isinstance(data, dict):
+            return data
+        out = dict(data)
+        if "trigger" in out:
+            out["trigger"] = parse_trigger(out["trigger"])
+        if "action" in out:
+            out["action"] = parse_fault(out["action"])
+        return out

--- a/devops_bench/chaos/triggers/__init__.py
+++ b/devops_bench/chaos/triggers/__init__.py
@@ -12,22 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Reusable Kubernetes primitives: kubectl wrappers and wait/poll conditions."""
+"""Concrete chaos triggers, each self-registering in ``chaos.base.TRIGGERS``.
 
-from devops_bench.k8s.conditions import poll_until
-from devops_bench.k8s.kubectl import (
-    apply,
-    get_resource,
-    port_forward,
-    rollout_status,
-    wait,
-)
+Importing this package pulls each bundled trigger module so its
+``@TRIGGERS.register`` decorator fires. The imports stay light: a trigger
+module loads only the trigger *class* (and ``core`` / ``pydantic``).
+"""
 
-__all__ = [
-    "apply",
-    "get_resource",
-    "poll_until",
-    "port_forward",
-    "rollout_status",
-    "wait",
-]
+from __future__ import annotations
+
+# Imported for the ``@TRIGGERS.register`` side effect that populates the registry.
+from devops_bench.chaos.triggers import time_delay  # noqa: F401
+
+__all__: list[str] = []

--- a/devops_bench/chaos/triggers/time_delay.py
+++ b/devops_bench/chaos/triggers/time_delay.py
@@ -1,0 +1,56 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The ``time`` trigger: blocks for a fixed delay before the fault fires."""
+
+from __future__ import annotations
+
+import time
+from typing import Literal
+
+from pydantic import Field
+
+from devops_bench.chaos.base import TRIGGERS, Trigger
+from devops_bench.core import get_logger
+from devops_bench.core.context import RunContext
+
+__all__ = ["TimeTrigger"]
+
+_log = get_logger("chaos.time_trigger")
+
+
+@TRIGGERS.register("time")
+class TimeTrigger(Trigger):
+    """Sleep for ``delay_seconds`` then return.
+
+    Attributes:
+        type: Discriminator literal, always ``"time"``.
+        delay_seconds: Seconds to block in :meth:`wait`. ``0`` returns
+            immediately; negative values are clamped to zero.
+    """
+
+    type: Literal["time"] = "time"
+    delay_seconds: int = Field(default=0, ge=0)
+
+    def wait(self, ctx: RunContext) -> None:
+        """Block for :attr:`delay_seconds` seconds.
+
+        Args:
+            ctx: Run context (unused; accepted for interface symmetry with
+                triggers that observe cluster state).
+        """
+        if self.delay_seconds <= 0:
+            return
+        _log.info("time trigger sleeping for %d seconds", self.delay_seconds)
+        time.sleep(self.delay_seconds)

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -16,17 +16,29 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
+import subprocess
+import time
+from collections.abc import Iterator
 from typing import Any, Protocol
 
+from devops_bench.core import get_logger
 from devops_bench.core.subprocess import CompletedProcess, run
 
 __all__ = [
     "apply",
     "get_resource",
+    "port_forward",
     "rollout_status",
     "wait",
 ]
+
+_log = get_logger("k8s.kubectl")
+
+# Seconds to let ``kubectl port-forward`` establish the tunnel before yielding.
+_PORT_FORWARD_SETTLE_SEC = 3
 
 
 class KubeconfigProvider(Protocol):
@@ -209,3 +221,80 @@ def rollout_status(
         *_namespace_args(namespace),
     ]
     return _run_kubectl(argv, kubeconfig)
+
+
+@contextlib.contextmanager
+def port_forward(
+    target: str,
+    local_port: int,
+    remote_port: int | None = None,
+    *,
+    namespace: str | None = None,
+    settle_sec: float = _PORT_FORWARD_SETTLE_SEC,
+    kubeconfig: KubeconfigSource = None,
+) -> Iterator[None]:
+    """Hold a ``kubectl port-forward`` open for the duration of the ``with`` body.
+
+    Unlike the one-shot wrappers, this drives :func:`subprocess.Popen` directly
+    so the tunnel can stay open while the body runs. ``stdout`` / ``stderr`` go
+    to ``DEVNULL`` because nothing reads the pipes — ``PIPE`` would let
+    ``kubectl`` block once its output buffer fills under sustained traffic. The
+    tunnel is always terminated on exit, whether the body completes or raises,
+    so it never outlives the ``with`` block.
+
+    Args:
+        target: Resource to forward, e.g. ``"deployment/web-app"`` or
+            ``"svc/web"``.
+        local_port: Local port to bind.
+        remote_port: Port on the target; defaults to ``local_port``.
+        namespace: Optional namespace (``-n``).
+        settle_sec: Seconds to wait for the tunnel to establish before yielding.
+        kubeconfig: Kubeconfig path or context-like object.
+
+    Yields:
+        ``None`` once the tunnel has had time to settle.
+
+    Raises:
+        RuntimeError: If ``kubectl port-forward`` exits before the settle window
+            elapses (e.g. the target does not exist).
+    """
+    remote = remote_port if remote_port is not None else local_port
+    argv = [
+        "kubectl",
+        "port-forward",
+        target,
+        f"{local_port}:{remote}",
+        *_namespace_args(namespace),
+    ]
+    path = _resolve_kubeconfig(kubeconfig)
+    env = {**os.environ, "KUBECONFIG": path} if path else None
+
+    _log.info("establishing port-forward to %s on port %d...", target, local_port)
+    process = subprocess.Popen(
+        argv,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+
+    time.sleep(settle_sec)
+    if process.poll() is not None:
+        # Reap the already-exited child before raising so it does not linger as
+        # a zombie waiting for ``wait()``. ``terminate`` is a no-op on a
+        # process that already exited; ``wait`` collects the exit status.
+        returncode = process.returncode
+        try:
+            process.wait(timeout=settle_sec)
+        except Exception as exc:  # noqa: BLE001 - never mask the raise reason
+            _log.warning("error reaping early-exited port-forward: %s", exc)
+        raise RuntimeError(
+            f"kubectl port-forward exited early (code {returncode}) for {target}"
+        )
+
+    try:
+        yield
+    finally:
+        _log.info("terminating port-forward to %s...", target)
+        process.terminate()
+        process.wait()
+        _log.info("port-forward to %s terminated.", target)

--- a/tests/unit/agents/api/test_agents_api_agent.py
+++ b/tests/unit/agents/api/test_agents_api_agent.py
@@ -1,0 +1,988 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`devops_bench.agents.api.agent`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from devops_bench.agents import AGENTS, AgentConfig
+from devops_bench.agents.api import agent as agent_mod
+from devops_bench.agents.api.agent import (
+    ApiAgent,
+    extract_tokens,
+    fold_trajectory,
+)
+from devops_bench.agents.capabilities import (
+    AgentRules,
+    AllCapabilities,
+    McpBinding,
+    SkillBinding,
+    SupportsMcp,
+    SupportsRules,
+    SupportsSkills,
+)
+from devops_bench.models.base import LLMClient
+
+
+def _mcp_caps(command: str = "server", *, tools: tuple[str, ...] = ()) -> AllCapabilities:
+    """Helper: build capabilities that turn the API agent's MCP path on."""
+    return AllCapabilities(
+        mcp_servers=(McpBinding(name="test", command=tuple(command.split()), tools=tools),),
+    )
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Turn:
+    """One scripted response in :class:`_FakeLLMClient`.
+
+    Attributes:
+        text: ``get_text_content`` payload for this turn.
+        calls: Function calls returned by ``extract_function_calls`` (each in
+            the neutral ``{"name", "args", "id"}`` shape).
+        usage: Optional duck-typed usage object surfaced on the raw response.
+        usage_attr: Which attribute name to attach ``usage`` under. Defaults to
+            ``"usage_metadata"`` (Google shape); set ``"usage"`` to exercise
+            Anthropic / OpenAI / Ollama paths.
+    """
+
+    text: str
+    calls: list[dict] = field(default_factory=list)
+    usage: Any = None
+    usage_attr: str = "usage_metadata"
+
+
+class _FakeLLMClient(LLMClient):
+    """Scripted :class:`LLMClient` that returns ``_Turn`` objects in order.
+
+    Records every ``generate_content`` invocation and tracks whether
+    ``format_tools`` was called so the agent's caller-formats-tools contract is
+    asserted.
+    """
+
+    def __init__(self, turns: list[_Turn]) -> None:
+        self._turns = list(turns)
+        self.calls: list[dict] = []
+        self.format_tools_calls: list[Any] = []
+
+    async def generate_content(
+        self,
+        contents: list[dict[str, Any]],
+        tools: Any,
+        system_instruction: str | None,
+    ) -> Any:
+        if not self._turns:
+            raise AssertionError("FakeLLMClient ran out of scripted turns")
+        turn = self._turns.pop(0)
+        self.calls.append(
+            {
+                "contents": [dict(msg) for msg in contents],
+                "tools": tools,
+                "system_instruction": system_instruction,
+            }
+        )
+        response = SimpleNamespace(text=turn.text, calls=turn.calls)
+        if turn.usage is not None:
+            setattr(response, turn.usage_attr, turn.usage)
+        return response
+
+    def format_tools(self, mcp_tools: Any) -> Any:
+        # Snapshot so tests can assert the agent does pre-format tools before
+        # calling the loop.
+        self.format_tools_calls.append(list(mcp_tools))
+        return ("formatted", tuple(getattr(t, "name", "") for t in mcp_tools))
+
+    def extract_function_calls(self, response: Any) -> list[dict]:
+        return list(response.calls)
+
+    def get_text_content(self, response: Any) -> str:
+        return response.text
+
+
+class _FakeMCPClient:
+    """Stand-in for :class:`MCPClient` exposing only what the agent uses.
+
+    Records every call so tests assert dispatch hit MCP (or skipped it).
+    """
+
+    def __init__(self, tools: list[Any] | None = None) -> None:
+        self._tools = list(tools or [])
+        self.calls: list[tuple[str, dict]] = []
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self) -> _FakeMCPClient:
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *_a: Any) -> None:
+        self.exited = True
+
+    async def list_tools(self) -> Any:
+        return SimpleNamespace(tools=self._tools)
+
+    async def call_tool(self, name: str, arguments: dict) -> Any:
+        self.calls.append((name, arguments))
+        block = SimpleNamespace(text=f"mcp-result-of-{name}")
+        return SimpleNamespace(content=[block])
+
+
+# ---------------------------------------------------------------------------
+# Registration & registry wiring
+# ---------------------------------------------------------------------------
+
+
+def test_api_agent_registered_under_canonical_key():
+    assert AGENTS.get("api") is ApiAgent
+
+
+# ---------------------------------------------------------------------------
+# fold_trajectory
+# ---------------------------------------------------------------------------
+
+
+def test_fold_trajectory_pairs_assistant_calls_with_tool_results():
+    contents = [
+        {"role": "user", "content": "g"},
+        {
+            "role": "assistant",
+            "content": "thinking",
+            "tool_calls": [
+                {"name": "alpha", "args": {"a": 1}, "id": "1"},
+                {"name": "beta", "args": {"b": 2}, "id": "2"},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "1", "name": "alpha", "content": "A-result"},
+        {"role": "tool", "tool_call_id": "2", "name": "beta", "content": "B-result"},
+        {"role": "assistant", "content": "all done"},
+    ]
+    assert fold_trajectory(contents) == [
+        {"name": "alpha", "args": {"a": 1}, "result": "A-result", "status": "completed"},
+        {"name": "beta", "args": {"b": 2}, "result": "B-result", "status": "completed"},
+    ]
+
+
+def test_fold_trajectory_marks_dispatcher_errors_as_error_status():
+    # The dispatcher returns ``"Error: ..."`` for a failed tool call (matching
+    # the agent's _build_dispatch contract) — folding must surface that as the
+    # ``"error"`` status so metrics see the failure mode, not a clean call.
+    contents = [
+        {"role": "user", "content": "g"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "boom", "args": {}, "id": "x"}],
+        },
+        {"role": "tool", "tool_call_id": "x", "name": "boom", "content": "Error: kaboom"},
+        {"role": "assistant", "content": "abort"},
+    ]
+    folded = fold_trajectory(contents)
+    assert folded == [
+        {"name": "boom", "args": {}, "result": "Error: kaboom", "status": "error"},
+    ]
+
+
+def test_fold_trajectory_leaves_unmatched_call_as_called_status():
+    # If a result never lands (e.g. dispatch raised before appending), the call
+    # entry survives with ``status="called"`` and ``result=None`` rather than
+    # being silently dropped.
+    contents = [
+        {"role": "user", "content": "g"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "lost", "args": {}, "id": "9"}],
+        },
+    ]
+    assert fold_trajectory(contents) == [
+        {"name": "lost", "args": {}, "result": None, "status": "called"},
+    ]
+
+
+def test_fold_trajectory_skips_text_only_turns():
+    contents = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "assistant", "content": "bye"},
+    ]
+    assert fold_trajectory(contents) == []
+
+
+def test_fold_trajectory_handles_none_args_and_none_call_id():
+    # Defensive: missing ``args`` becomes ``{}``; an entry with no ``id`` is
+    # emitted as ``status="called"`` (no result to pair with).
+    contents = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "t", "args": None, "id": None}],
+        },
+    ]
+    assert fold_trajectory(contents) == [
+        {"name": "t", "args": {}, "result": None, "status": "called"},
+    ]
+
+
+def test_fold_trajectory_drops_unpaired_tool_results_silently_from_trajectory():
+    """An orphan ``role: tool`` (no matching assistant call_id) is dropped from
+    the canonical trajectory — synthesizing a free-floating entry would break
+    the "every trajectory item is a real ToolCall the model issued" invariant
+    metrics depend on. The diagnostic flows out via ``_fold_with_extraction_errors``
+    instead (asserted in ``test_execute_orphan_tool_result_lands_in_errors``).
+    """
+    contents = [
+        {"role": "user", "content": "g"},
+        # No assistant turn → no matching call_id for the ghost result.
+        {"role": "tool", "tool_call_id": "ghost", "name": "x", "content": "?"},
+    ]
+    assert fold_trajectory(contents) == []
+
+
+def test_fold_with_extraction_errors_surfaces_orphan_results():
+    from devops_bench.agents.api.agent import _fold_with_extraction_errors
+
+    contents = [
+        {"role": "user", "content": "g"},
+        {"role": "tool", "tool_call_id": "ghost", "name": "x", "content": "stray"},
+    ]
+    folded, orphans = _fold_with_extraction_errors(contents)
+    assert folded == []
+    assert len(orphans) == 1
+    assert "no matching call" in orphans[0]
+    assert "ghost" in orphans[0]
+
+
+# ---------------------------------------------------------------------------
+# extract_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_extract_tokens_reads_usage_metadata():
+    usage = SimpleNamespace(prompt_token_count=3, candidates_token_count=5, total_token_count=8)
+    response = SimpleNamespace(usage_metadata=usage)
+    assert extract_tokens(response) == {
+        "prompt_tokens": 3,
+        "candidates_tokens": 5,
+        "total_tokens": 8,
+    }
+
+
+def test_extract_tokens_falls_back_to_usage_attribute():
+    usage = SimpleNamespace(prompt_token_count=1, candidates_token_count=2, total_token_count=3)
+    # No ``usage_metadata``; the function should still find ``usage``.
+    response = SimpleNamespace(usage=usage)
+    assert extract_tokens(response) == {
+        "prompt_tokens": 1,
+        "candidates_tokens": 2,
+        "total_tokens": 3,
+    }
+
+
+def test_extract_tokens_returns_empty_dict_when_no_usage():
+    assert extract_tokens(SimpleNamespace()) == {}
+    assert extract_tokens(None) == {}
+
+
+def test_extract_tokens_defaults_missing_counts_to_zero():
+    """Missing counts default to 0; if the source provided no total but the
+    other two fields are non-zero, the helper computes prompt+candidates so a
+    non-empty run never shows ``total_tokens: 0`` in results.json."""
+    usage = SimpleNamespace(prompt_token_count=4)  # other counts unset
+    response = SimpleNamespace(usage_metadata=usage)
+    assert extract_tokens(response) == {
+        "prompt_tokens": 4,
+        "candidates_tokens": 0,
+        # 4 + 0 (no source total provided, but a non-zero prompt → compute it).
+        "total_tokens": 4,
+    }
+
+
+def test_extract_tokens_reads_anthropic_input_output_shape():
+    """Anthropic emits ``usage.input_tokens`` / ``usage.output_tokens`` and **no**
+    aggregated total. The helper must map both onto the legacy keys and compute
+    the total so non-Google providers do not silently drop tokens.
+
+    Regression test for the blocking bug found in review: the previous
+    extract_tokens only read Google-style fields and returned zeros for any
+    Anthropic response, corrupting token metrics in results.json.
+    """
+    usage = SimpleNamespace(input_tokens=42, output_tokens=17)
+    response = SimpleNamespace(usage=usage)
+    assert extract_tokens(response) == {
+        "prompt_tokens": 42,
+        "candidates_tokens": 17,
+        "total_tokens": 59,
+    }
+
+
+def test_extract_tokens_reads_openai_ollama_shape():
+    """OpenAI / Ollama emit ``usage.prompt_tokens`` / ``completion_tokens`` /
+    ``total_tokens``. The helper must map ``completion_tokens`` → the legacy
+    ``candidates_tokens`` slot and pass ``total_tokens`` through verbatim.
+
+    Regression test for the same blocking bug — Ollama responses returned
+    all-zero tokens before the provider-shape detection landed.
+    """
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+    response = SimpleNamespace(usage=usage)
+    assert extract_tokens(response) == {
+        "prompt_tokens": 10,
+        "candidates_tokens": 20,
+        "total_tokens": 30,
+    }
+
+
+def test_extract_tokens_google_total_passes_through_when_present():
+    """When the provider supplies its own total it wins over the computed sum."""
+    usage = SimpleNamespace(
+        prompt_token_count=5, candidates_token_count=7, total_token_count=99
+    )
+    response = SimpleNamespace(usage_metadata=usage)
+    # The helper does not second-guess a provider-supplied total even when it
+    # disagrees with prompt+candidates (some providers include reasoning/cached
+    # tokens in the total).
+    assert extract_tokens(response)["total_tokens"] == 99
+
+
+def test_extract_tokens_preserves_legacy_on_disk_key_scheme():
+    """The on-disk dict shape must stay ``{prompt_tokens, candidates_tokens,
+    total_tokens}`` for D3 (results.json stability) — three keys, exactly.
+    """
+    usage = SimpleNamespace(input_tokens=1, output_tokens=2)
+    keys = set(extract_tokens(SimpleNamespace(usage=usage)).keys())
+    assert keys == {"prompt_tokens", "candidates_tokens", "total_tokens"}
+
+
+# ---------------------------------------------------------------------------
+# ApiAgent._execute — MCP-off path
+# ---------------------------------------------------------------------------
+
+
+def test_execute_runs_with_no_tools_when_capabilities_default(monkeypatch):
+    """Default capabilities (no MCP binding, no skills) → loop runs tool-less.
+
+    Renamed from ``..._when_target_unset`` because the MCP gate is no longer
+    ``config.target`` — it's ``config.capabilities.mcp``. The old name
+    survives in git history but the new one matches the post-PR3 reality.
+    """
+    fake = _FakeLLMClient(
+        [
+            _Turn(
+                text="done",
+                usage=SimpleNamespace(
+                    prompt_token_count=3,
+                    candidates_token_count=5,
+                    total_token_count=8,
+                ),
+            )
+        ]
+    )
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+
+    agent = ApiAgent(AgentConfig())
+    result = agent.run("hello")
+
+    assert result.output == "done"
+    assert result.trajectory == []
+    assert result.tokens == {
+        "prompt_tokens": 3,
+        "candidates_tokens": 5,
+        "total_tokens": 8,
+    }
+    assert result.errors == []
+    # Caller-formats-tools: the agent must call format_tools on the (empty)
+    # skill list before invoking the loop.
+    assert fake.format_tools_calls == [[]]
+    # The loop saw the pre-formatted tools sentinel, not the raw list.
+    assert fake.calls[0]["tools"] == ("formatted", ())
+
+
+def test_execute_passes_explicit_provider_and_model_to_get_model(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_get_model(provider, model):
+        captured["provider"] = provider
+        captured["model"] = model
+        return _FakeLLMClient([_Turn(text="ok")])
+
+    monkeypatch.setattr(agent_mod, "get_model", fake_get_model)
+    cfg = AgentConfig(provider="anthropic", model="claude-3-5")
+    ApiAgent(cfg).run("p")
+    assert captured == {"provider": "anthropic", "model": "claude-3-5"}
+
+
+def test_execute_records_anthropic_tokens_through_to_agentresult(monkeypatch):
+    """End-to-end: an Anthropic-shaped usage object surfaces on
+    ``AgentResult.tokens`` under the legacy key scheme — regression for the
+    blocking bug where non-Google providers silently logged zero tokens."""
+    fake = _FakeLLMClient(
+        [
+            _Turn(
+                text="done",
+                usage=SimpleNamespace(input_tokens=42, output_tokens=17),
+                usage_attr="usage",
+            )
+        ]
+    )
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    result = ApiAgent(AgentConfig()).run("p")
+    assert result.tokens == {
+        "prompt_tokens": 42,
+        "candidates_tokens": 17,
+        "total_tokens": 59,
+    }
+
+
+def test_execute_records_openai_tokens_through_to_agentresult(monkeypatch):
+    """End-to-end: an OpenAI/Ollama-shaped usage object surfaces under the
+    legacy key scheme."""
+    fake = _FakeLLMClient(
+        [
+            _Turn(
+                text="done",
+                usage=SimpleNamespace(
+                    prompt_tokens=10, completion_tokens=20, total_tokens=30
+                ),
+                usage_attr="usage",
+            )
+        ]
+    )
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    result = ApiAgent(AgentConfig()).run("p")
+    assert result.tokens == {
+        "prompt_tokens": 10,
+        "candidates_tokens": 20,
+        "total_tokens": 30,
+    }
+
+
+# ---------------------------------------------------------------------------
+# ApiAgent._execute — MCP-on, trajectory folding & tools_used metadata
+# ---------------------------------------------------------------------------
+
+
+def test_execute_folds_assistant_tool_pairs_into_canonical_trajectory(monkeypatch):
+    """End-to-end: an MCP tool turn followed by a finishing turn → one ToolCall."""
+    fc = [{"name": "do_thing", "args": {"a": 1}, "id": "call-1"}]
+    fake = _FakeLLMClient(
+        [
+            _Turn(text="working", calls=fc),
+            _Turn(
+                text="done",
+                usage=SimpleNamespace(
+                    prompt_token_count=10,
+                    candidates_token_count=20,
+                    total_token_count=30,
+                ),
+            ),
+        ]
+    )
+    mcp_advertised = [SimpleNamespace(name="do_thing", description="d", inputSchema=None)]
+    mcp = _FakeMCPClient(tools=mcp_advertised)
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+
+    result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("ping")
+
+    assert result.output == "done"
+    assert result.trajectory == [
+        {
+            "name": "do_thing",
+            "args": {"a": 1},
+            "result": "mcp-result-of-do_thing",
+            "status": "completed",
+        },
+    ]
+    assert result.tokens == {
+        "prompt_tokens": 10,
+        "candidates_tokens": 20,
+        "total_tokens": 30,
+    }
+    assert result.errors == []
+    assert result.metadata["tools_used"] == ["do_thing"]
+    # MCP session was entered & exited via the async-context-manager protocol.
+    assert mcp.entered and mcp.exited
+    # The agent passed the MCP-advertised tool through format_tools before
+    # invoking the loop (caller-formats-tools contract).
+    assert fake.format_tools_calls == [mcp_advertised]
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher error handling
+# ---------------------------------------------------------------------------
+
+
+def test_execute_dispatch_error_lands_in_errors_and_continues(monkeypatch):
+    """A tool call that raises must surface on errors, not crash the agent."""
+
+    class _ExplodingMCP(_FakeMCPClient):
+        async def call_tool(self, name: str, arguments: dict) -> Any:
+            raise RuntimeError("kaboom")
+
+    fc = [{"name": "boom", "args": {}, "id": "c1"}]
+    fake = _FakeLLMClient(
+        [
+            _Turn(text="trying", calls=fc),
+            _Turn(text="giving up"),
+        ]
+    )
+    mcp = _ExplodingMCP(tools=[SimpleNamespace(name="boom", description="d", inputSchema=None)])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+
+    result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("ping")
+
+    assert result.output == "giving up"
+    assert any("Error calling tool boom" in e for e in result.errors)
+    # The trajectory still records the failed call with ``status="error"`` so
+    # the metrics layer can see the failure mode.
+    assert result.trajectory == [
+        {"name": "boom", "args": {}, "result": "Error: kaboom", "status": "error"},
+    ]
+
+
+def test_execute_records_missing_mcp_when_tool_requested_without_server(monkeypatch):
+    """No MCP server, but the model still requests a tool → recorded, not crashed."""
+    fc = [{"name": "ghost", "args": {}, "id": "c2"}]
+    fake = _FakeLLMClient(
+        [
+            _Turn(text="requesting", calls=fc),
+            _Turn(text="abandoned"),
+        ]
+    )
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    result = ApiAgent(AgentConfig()).run("p")  # no target -> no MCP
+
+    assert any("no MCP server is configured" in e for e in result.errors)
+    assert result.trajectory == [
+        {
+            "name": "ghost",
+            "args": {},
+            "result": (
+                "Error: tool 'ghost' requested but no MCP server is configured for "
+                "this agent."
+            ),
+            "status": "error",
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Skills are independent of MCP
+# ---------------------------------------------------------------------------
+
+
+def test_execute_skills_discover_without_mcp(monkeypatch, tmp_path):
+    """Skills must be loadable on the MCP-off path, not gated on MCP being on."""
+    skill_dir = tmp_path / "skills"
+    skill = skill_dir / "demo" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill_body = '---\nname: "demo-skill"\ndescription: does things\n---\nbody\n'
+    skill.write_text(skill_body)
+
+    fc = [{"name": "skill_demo_skill", "args": {}, "id": "s1"}]
+    fake = _FakeLLMClient(
+        [
+            _Turn(text="using skill", calls=fc),
+            _Turn(text="done"),
+        ]
+    )
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    cfg = AgentConfig(
+        capabilities=AllCapabilities(skills=SkillBinding(paths=(str(skill_dir),))),
+    )  # NB: no mcp binding → MCP path disabled
+    result = ApiAgent(cfg).run("p")
+
+    assert result.errors == []  # skill dispatch hit the file, not the MCP error
+    # ``read_skill_file`` returns the whole file (frontmatter + body) so the
+    # model can read either as it sees fit — matches the legacy semantic.
+    assert result.trajectory == [
+        {
+            "name": "skill_demo_skill",
+            "args": {},
+            "result": skill_body,
+            "status": "completed",
+        },
+    ]
+    assert result.metadata["skills_loaded"] == ["demo-skill"]
+    # format_tools received the synthetic skill descriptor — one entry.
+    assert len(fake.format_tools_calls[0]) == 1
+    assert fake.format_tools_calls[0][0].name == "skill_demo_skill"
+
+
+def test_execute_no_skills_no_mcp_runs_tool_less(monkeypatch):
+    """Empty skills + no target → loop seen no tools, no metadata noise."""
+    fake = _FakeLLMClient([_Turn(text="hi")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    result = ApiAgent(AgentConfig()).run("p")
+    assert result.output == "hi"
+    assert "skills_loaded" not in result.metadata
+    assert result.metadata["tools_used"] == []
+
+
+# ---------------------------------------------------------------------------
+# Surfaced model-construction errors / empty MCP target
+# ---------------------------------------------------------------------------
+
+
+def test_execute_returns_errored_on_mcpclient_value_error(monkeypatch):
+    """A ``ValueError`` from ``MCPClient.__aenter__`` (e.g. an unspawnable
+    server command) must convert to an errored :class:`AgentResult` rather
+    than bubbling through the base safety net.
+
+    After PR3's ``shlex.join`` fix, a whitespace-only binding command is no
+    longer lossy-collapsed to ``""``, so the *binding* path no longer
+    triggers MCPClient's empty-string guard naturally. We instead patch
+    ``MCPClient`` to raise the same ``ValueError`` directly, which exercises
+    the agent-side conversion path.
+    """
+
+    class _BoomMCP:
+        def __init__(self, _path: str) -> None: ...
+
+        async def __aenter__(self) -> _BoomMCP:
+            raise ValueError(
+                "MCP server_path is empty; set AGENT_MCP_SERVER to the MCP "
+                "server command."
+            )
+
+        async def __aexit__(self, *_a: Any) -> None: ...
+
+    fake = _FakeLLMClient([_Turn(text="never reached")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", _BoomMCP)
+
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="bad", command=("/never-spawned",)),),
+    )
+    result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert result.has_errors()
+    assert "MCP server_path is empty" in result.errors[0]
+    # The base safety net was NOT used (we converted the ValueError ourselves).
+    assert result.output.startswith("Error: ")
+
+
+# ---------------------------------------------------------------------------
+# No env-smuggling — neither BENCH_USE_MCP nor any direct env read
+# ---------------------------------------------------------------------------
+
+
+def test_execute_ignores_bench_use_mcp_env(monkeypatch):
+    """Setting BENCH_USE_MCP must not change the agent's behavior.
+
+    The MCP on/off gate is ``config.capabilities.mcp`` (a binding with a
+    non-empty ``command``), not env.
+    """
+    monkeypatch.setenv("BENCH_USE_MCP", "false")
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    # No MCP binding → loop runs without MCP regardless of the env flag.
+    result = ApiAgent(AgentConfig()).run("p")
+    assert result.output == "ok"
+
+
+def test_agent_source_has_no_bench_use_mcp_or_environ_reads():
+    """Statically verify the agents/api source carries no env-smuggling.
+
+    The conventions doc forbids agents from reading ``BENCH_USE_MCP`` (the
+    harness threads the boolean instead) or any ``os.environ`` lookups inside
+    the agent — capability/MCP on-off comes from ``AgentConfig``. This test
+    walks the agents/api source AST and asserts no code (i.e. anything that is
+    not a docstring or comment) references those names.
+    """
+    import ast
+    import pathlib
+
+    api_root = pathlib.Path(agent_mod.__file__).parent
+    forbidden_names = {"get_env", "get_bool", "first_env", "require_env"}
+    forbidden_strings = {"BENCH_USE_MCP"}
+
+    for src in api_root.glob("*.py"):
+        tree = ast.parse(src.read_text(), filename=str(src))
+
+        for node in ast.walk(tree):
+            # Bare names: ``get_env(...)`` / ``os.environ``.
+            if isinstance(node, ast.Name) and node.id in forbidden_names:
+                pytest.fail(
+                    f"{src.name} references env-helper {node.id!r} at line "
+                    f"{node.lineno}; config flows through AgentConfig"
+                )
+            # Attribute access: ``os.environ``, ``os.getenv``, and the
+            # ``os.environ.get(...)`` call form (which presents as an outer
+            # Attribute("get", Attribute("environ", Name("os")))).
+            if isinstance(node, ast.Attribute):
+                attr_chain = []
+                cur: ast.AST | None = node
+                while isinstance(cur, ast.Attribute):
+                    attr_chain.append(cur.attr)
+                    cur = cur.value
+                if isinstance(cur, ast.Name):
+                    attr_chain.append(cur.id)
+                joined = ".".join(reversed(attr_chain))
+                assert joined != "os.environ", (
+                    f"{src.name} accesses os.environ at line {node.lineno}; "
+                    "config flows through AgentConfig"
+                )
+                assert joined != "os.getenv", (
+                    f"{src.name} calls os.getenv at line {node.lineno}; "
+                    "config flows through AgentConfig"
+                )
+                assert joined != "os.environ.get", (
+                    f"{src.name} calls os.environ.get at line {node.lineno}; "
+                    "config flows through AgentConfig"
+                )
+            # Subscript access: ``os.environ["FOO"]`` / ``os.environ.get(...)``
+            # patterns. The outer ``ast.Subscript`` wraps the ``os.environ``
+            # attribute lookup; the inner Attribute is also caught above via
+            # ast.walk, but checking the Subscript explicitly makes the intent
+            # legible and bug-proofs the guard against future AST refactors.
+            if isinstance(node, ast.Subscript):
+                target = node.value
+                if isinstance(target, ast.Attribute):
+                    attr_chain = []
+                    cur = target
+                    while isinstance(cur, ast.Attribute):
+                        attr_chain.append(cur.attr)
+                        cur = cur.value
+                    if isinstance(cur, ast.Name):
+                        attr_chain.append(cur.id)
+                    joined = ".".join(reversed(attr_chain))
+                    assert joined != "os.environ", (
+                        f"{src.name} subscripts os.environ[...] at line "
+                        f"{node.lineno}; config flows through AgentConfig"
+                    )
+            # String literals: catch ``getenv("BENCH_USE_MCP")`` /
+            # ``os.environ["BENCH_USE_MCP"]`` patterns even when wrapped in a
+            # helper we didn't enumerate. Docstrings are still ``Str``/
+            # ``Constant`` nodes but the parent statement is an ``Expr`` at the
+            # head of a module/function/class — skip those.
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and node.value in forbidden_strings
+            ):
+                # Allow doc references — only reject when the same line names an
+                # env accessor (``environ`` / ``getenv`` / ``get_env``).
+                line_text = src.read_text().splitlines()[node.lineno - 1]
+                accessor_hit = any(
+                    a in line_text for a in ("environ", "getenv", "get_env")
+                )
+                assert not accessor_hit, (
+                    f"{src.name} reads {node.value!r} via an env accessor "
+                    f"at line {node.lineno}"
+                )
+
+
+def test_api_package_does_not_expose_legacy_context_or_system_instruction():
+    """The PR2 contract drops the ``context``/``system_instruction`` grab-bag.
+
+    No symbol or kwarg with that name should remain in the public surface.
+    """
+    import inspect
+
+    sig = inspect.signature(ApiAgent.run)
+    assert list(sig.parameters) == ["self", "prompt"], (
+        "ApiAgent.run must take only (self, prompt); the legacy context/"
+        "system_instruction kwargs are gone."
+    )
+    init_sig = inspect.signature(ApiAgent.__init__)
+    # Inherited from AgentHarness — accepts config only.
+    assert list(init_sig.parameters) == ["self", "config"]
+
+
+@pytest.mark.parametrize("method_name", ["_execute"])
+def test_execute_is_synchronous_and_safe_for_harness_invocation(method_name):
+    """The harness calls ``run(prompt)`` synchronously; ``_execute`` must be sync too."""
+    import inspect
+
+    method = getattr(ApiAgent, method_name)
+    assert not inspect.iscoroutinefunction(method), (
+        f"ApiAgent.{method_name} must be synchronous so the harness can call "
+        "agent.run(prompt) without managing an event loop itself."
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR3 — capability negotiation: ApiAgent implements every Supports* Protocol
+# ---------------------------------------------------------------------------
+
+
+def test_api_agent_satisfies_all_three_capability_protocols():
+    """``isinstance`` against each Protocol is how the harness negotiates
+    capabilities before granting a binding (handoff §6). ApiAgent declares
+    every capability it can drive — MCP, skills, rules — so an instance must
+    pass each ``runtime_checkable`` check."""
+    agent = ApiAgent(AgentConfig())
+    assert isinstance(agent, SupportsMcp)
+    assert isinstance(agent, SupportsSkills)
+    assert isinstance(agent, SupportsRules)
+
+
+def test_api_agent_mirrors_capability_bindings_onto_mixin_attributes():
+    """The structural-Protocol attributes (``mcp_servers``/``skills``/``rules``)
+    must reflect the bindings the orchestrator granted; otherwise capability
+    negotiation would see the mixin defaults instead of the live config."""
+    binding = McpBinding(name="x", command=("/bin/mcp",), tools=("t",))
+    caps = AllCapabilities(
+        mcp_servers=(binding,),
+        skills=SkillBinding(paths=("/sk",)),
+        rules=AgentRules(text="rules"),
+    )
+    agent = ApiAgent(AgentConfig(capabilities=caps))
+    assert agent.mcp_servers == (binding,)
+    assert agent.skills == SkillBinding(paths=("/sk",))
+    assert agent.rules == AgentRules(text="rules")
+
+
+# ---------------------------------------------------------------------------
+# Skills ⊥ MCP independence still holds under the binding-based config
+# ---------------------------------------------------------------------------
+
+
+def test_execute_runs_with_mcp_only_no_skills(monkeypatch):
+    """MCP binding present, skills binding empty → MCP path opens, no skills loaded."""
+    fc = [{"name": "do_thing", "args": {}, "id": "c1"}]
+    fake = _FakeLLMClient([_Turn(text="working", calls=fc), _Turn(text="done")])
+    mcp_tools = [SimpleNamespace(name="do_thing", description="d", inputSchema=None)]
+    mcp = _FakeMCPClient(tools=mcp_tools)
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+
+    result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("p")
+    assert result.errors == []
+    assert mcp.entered
+    assert "skills_loaded" not in result.metadata  # SkillBinding stayed empty
+
+
+def test_execute_runs_with_both_mcp_and_skills(monkeypatch, tmp_path):
+    """Both bindings populated → MCP session is opened *and* skills are discovered."""
+    skill_dir = tmp_path / "skills"
+    (skill_dir / "demo").mkdir(parents=True)
+    (skill_dir / "demo" / "SKILL.md").write_text(
+        '---\nname: "demo"\ndescription: x\n---\nbody\n'
+    )
+
+    fc = [{"name": "do_thing", "args": {}, "id": "c1"}]
+    fake = _FakeLLMClient([_Turn(text="working", calls=fc), _Turn(text="done")])
+    mcp = _FakeMCPClient(tools=[SimpleNamespace(name="do_thing", description="d", inputSchema=None)])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="t", command=("server",)),),
+        skills=SkillBinding(paths=(str(skill_dir),)),
+    )
+    result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert result.errors == []
+    assert mcp.entered
+    assert result.metadata["skills_loaded"] == ["demo"]
+
+
+def test_execute_runs_with_neither_mcp_nor_skills(monkeypatch):
+    """Default capabilities → tool-less run, no MCP session, no skills loaded."""
+    fake = _FakeLLMClient([_Turn(text="bare")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    # If MCPClient is ever entered the test would import mcp; replace with a sentinel.
+    monkeypatch.setattr(
+        agent_mod, "MCPClient", lambda _path: pytest.fail("MCPClient must not be used")
+    )
+    result = ApiAgent(AgentConfig()).run("p")
+    assert result.output == "bare"
+    assert result.errors == []
+    assert "skills_loaded" not in result.metadata
+
+
+# ---------------------------------------------------------------------------
+# Rules flow into the loop's system_instruction
+# ---------------------------------------------------------------------------
+
+
+def test_execute_threads_rules_text_into_system_instruction(monkeypatch):
+    """Non-empty rules text must ride on the provider's ``system_instruction``."""
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    caps = AllCapabilities(rules=AgentRules(text="be careful"))
+    ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert fake.calls[0]["system_instruction"] == "be careful"
+
+
+def test_execute_empty_rules_text_yields_none_system_instruction(monkeypatch):
+    """Empty rules text → ``system_instruction=None`` (the loop's "no preamble")."""
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    ApiAgent(AgentConfig()).run("p")
+    assert fake.calls[0]["system_instruction"] is None
+
+
+# ---------------------------------------------------------------------------
+# Mcp gate: an empty-command McpBinding does NOT open an MCP session in the
+# API agent (it is for CLI agents whose binary launches MCP in-process).
+# ---------------------------------------------------------------------------
+
+
+def test_execute_skips_mcp_when_binding_has_no_command(monkeypatch):
+    """A binding with no launch command (CLI-agent shape) → API agent runs MCP-off."""
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(
+        agent_mod, "MCPClient", lambda _path: pytest.fail("MCPClient must not be used")
+    )
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="cli-shape", command=(), tools=("x",)),),
+    )
+    result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert result.output == "ok"
+
+
+def test_execute_preserves_spaced_command_token_through_shlex_roundtrip(monkeypatch):
+    """A spaced argv token (``("uv run", "mcp-server")``) must reach MCPClient
+    intact: ``shlex.join`` quotes it on the way in, ``MCPClient``'s
+    ``shlex.split`` recovers the original parts on the way out.
+
+    Regression for the lossy ``" ".join`` that previously silently expanded
+    one token into two when the binding carried a spaced word (e.g. a launch
+    command that wraps an interpreter invocation).
+    """
+    import shlex
+
+    captured: dict = {}
+
+    class _RecordingMCP(_FakeMCPClient):
+        def __init__(self, path: str) -> None:
+            super().__init__(tools=[])
+            captured["path"] = path
+
+    fake = _FakeLLMClient([_Turn(text="done")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", _RecordingMCP)
+
+    original = ("uv run", "mcp-server", "--flag")
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="spaced", command=original),),
+    )
+    ApiAgent(AgentConfig(capabilities=caps)).run("p")
+
+    # MCPClient calls ``shlex.split`` on its ``server_path``; re-splitting the
+    # path the agent handed it must recover the original tuple element-for-
+    # element, including the spaced first token.
+    assert tuple(shlex.split(captured["path"])) == original

--- a/tests/unit/agents/api/test_agents_api_import_hygiene.py
+++ b/tests/unit/agents/api/test_agents_api_import_hygiene.py
@@ -1,0 +1,72 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``import devops_bench.agents.api`` must stay light per CONVENTIONS §8."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_agents_api_package_import_pulls_no_sdk_or_mcp():
+    """A fresh interpreter import of ``devops_bench.agents.api`` is mcp/SDK-free."""
+    script = textwrap.dedent(
+        """
+        import sys
+        import devops_bench.agents.api  # noqa: F401
+        loaded = sorted(sys.modules)
+        heavy = ['mcp', 'deepeval', 'anthropic', 'google.genai', 'openai']
+        hits = [m for m in loaded if any(m == h or m.startswith(h + '.') for h in heavy)]
+        if hits:
+            print('LEAKED:', ','.join(hits))
+            sys.exit(1)
+        print('OK')
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK" in result.stdout
+
+
+def test_agents_api_agent_module_import_pulls_no_sdk_or_mcp():
+    """Importing the concrete agent module must not eagerly load mcp / deepeval.
+
+    Even the module that holds the registered :class:`ApiAgent` must keep the
+    heavy imports function-local — the harness imports it (to register the
+    agent) on every benchmark startup, including dry runs that never invoke a
+    real MCP server.
+    """
+    script = textwrap.dedent(
+        """
+        import sys
+        import devops_bench.agents.api.agent  # noqa: F401
+        loaded = sorted(sys.modules)
+        heavy = ['mcp.client', 'mcp.server', 'deepeval', 'anthropic',
+                 'google.genai', 'openai']
+        hits = [m for m in loaded if any(m == h or m.startswith(h + '.') for h in heavy)]
+        if hits:
+            print('LEAKED:', ','.join(hits))
+            sys.exit(1)
+        print('OK')
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK" in result.stdout

--- a/tests/unit/agents/api/test_agents_api_mcp.py
+++ b/tests/unit/agents/api/test_agents_api_mcp.py
@@ -1,0 +1,120 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`devops_bench.agents.api.mcp`."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from devops_bench.agents.api.mcp import MCPClient, extract_tool_text
+
+
+def test_extract_tool_text_joins_text_blocks():
+    blocks = [SimpleNamespace(text="alpha"), SimpleNamespace(text="beta")]
+    assert extract_tool_text(SimpleNamespace(content=blocks)) == "alpha\nbeta"
+
+
+def test_extract_tool_text_skips_blocks_without_text():
+    # A block missing ``.text`` must not crash; mixed lists fall through to the
+    # text-only blocks.
+    blocks = [SimpleNamespace(text="alpha"), SimpleNamespace()]
+    assert extract_tool_text(SimpleNamespace(content=blocks)) == "alpha"
+
+
+def test_extract_tool_text_falls_back_to_str_when_no_blocks():
+    obj = SimpleNamespace(content=[])
+    assert extract_tool_text(obj) == str(obj)
+
+
+def test_extract_tool_text_falls_back_to_str_when_no_content_attr():
+    obj = SimpleNamespace()
+    assert extract_tool_text(obj) == str(obj)
+
+
+def test_mcp_client_enter_rejects_empty_server_path():
+    # We must surface a clear error rather than spawning ``""``; ValueError
+    # surfaces through the agent's _execute as an errored result (see
+    # test_execute_returns_errored_on_empty_mcp_server_string).
+    client = MCPClient("   ")
+    with pytest.raises(ValueError, match="MCP server_path is empty"):
+        asyncio.run(client.__aenter__())
+
+
+def test_call_tool_degrades_gracefully_when_deepeval_missing(monkeypatch):
+    """If ``deepeval`` is not installed, ``call_tool`` still works (untraced).
+
+    The legacy implementation imported ``deepeval.tracing.observe`` at the top
+    of ``call_tool``, so a host without deepeval would crash with ImportError
+    on the first tool call. The fix mirrors
+    :func:`devops_bench.agents.base._maybe_observe`: try the import, fall
+    through to the bare ``call_tool`` on failure.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("deepeval"):
+            raise ImportError(f"simulated missing dependency: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    sentinel = SimpleNamespace(content=[SimpleNamespace(text="ok")])
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict]] = []
+
+        async def call_tool(self, name: str, arguments: dict) -> SimpleNamespace:
+            self.calls.append((name, arguments))
+            return sentinel
+
+    client = MCPClient("does-not-matter")
+    client.session = _FakeSession()
+
+    result = asyncio.run(client.call_tool("t", {"k": "v"}))
+    assert result is sentinel
+    assert client.session.calls == [("t", {"k": "v"})]
+
+
+def test_mcp_module_does_not_import_sdk_at_module_load():
+    """Importing the module must not pull the ``mcp`` SDK — it loads on enter."""
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import sys
+        import devops_bench.agents.api.mcp  # noqa: F401
+        forbidden = ("mcp.client", "mcp.server", "deepeval", "anthropic",
+                     "google.genai", "openai")
+        hits = sorted(
+            m for m in sys.modules
+            if any(m == p or m.startswith(p + ".") for p in forbidden)
+        )
+        if hits:
+            sys.stderr.write("LEAKED:" + ",".join(hits))
+            sys.exit(1)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/agents/api/test_agents_api_skills.py
+++ b/tests/unit/agents/api/test_agents_api_skills.py
@@ -1,0 +1,159 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`devops_bench.agents.api.skills`."""
+
+from __future__ import annotations
+
+from devops_bench.agents.api.skills import (
+    SkillToolInfo,
+    discover_skill_tools,
+    parse_skill_md,
+    read_skill_file,
+)
+
+
+def test_parse_skill_md_extracts_frontmatter(tmp_path):
+    f = tmp_path / "SKILL.md"
+    f.write_text('---\nname: "my-skill"\ndescription: does things\n---\nbody text\n')
+    name, description, content = parse_skill_md(str(f))
+    assert name == "my-skill"
+    assert description == "does things"
+    assert "body text" in content
+
+
+def test_parse_skill_md_strips_single_and_double_quotes(tmp_path):
+    f = tmp_path / "SKILL.md"
+    f.write_text("---\nname: 'quoted'\ndescription: \"plain\"\n---\n")
+    name, description, _ = parse_skill_md(str(f))
+    assert name == "quoted"
+    assert description == "plain"
+
+
+def test_parse_skill_md_reads_multiline_block_scalar(tmp_path):
+    f = tmp_path / "SKILL.md"
+    f.write_text(
+        "---\n"
+        "name: multi\n"
+        "description: >-\n"
+        "  use this skill when rotating\n"
+        "  a secret across namespaces\n"
+        "---\nbody\n"
+    )
+    name, description, _ = parse_skill_md(str(f))
+    assert name == "multi"
+    assert description == "use this skill when rotating a secret across namespaces"
+
+
+def test_parse_skill_md_missing_file_returns_none():
+    assert parse_skill_md("/nonexistent/SKILL.md") == (None, None, None)
+
+
+def test_parse_skill_md_no_frontmatter_returns_none(tmp_path):
+    f = tmp_path / "SKILL.md"
+    f.write_text("just body, no frontmatter")
+    assert parse_skill_md(str(f)) == (None, None, None)
+
+
+def test_discover_skill_tools_empty_paths_returns_empty_lists():
+    tools, resources, names = discover_skill_tools(())
+    assert tools == []
+    assert resources == {}
+    assert names == []
+
+
+def test_discover_skill_tools_missing_path_is_skipped(tmp_path):
+    tools, resources, names = discover_skill_tools((str(tmp_path / "missing"),))
+    assert tools == []
+    assert resources == {}
+    assert names == []
+
+
+def test_discover_skill_tools_normalizes_dashes_to_underscores(tmp_path):
+    skill = tmp_path / "first" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text('---\nname: "my-cool-skill"\ndescription: ok\n---\nbody\n')
+
+    tools, resources, names = discover_skill_tools((str(tmp_path),))
+    assert len(tools) == 1
+    assert isinstance(tools[0], SkillToolInfo)
+    assert tools[0].name == "skill_my_cool_skill"
+    assert tools[0].description == "ok"
+    assert resources == {"skill_my_cool_skill": str(skill)}
+    assert names == ["my-cool-skill"]
+
+
+def test_discover_skill_tools_falls_back_to_default_description(tmp_path):
+    """Missing description still loads the skill with a synthetic description."""
+    skill = tmp_path / "SKILL.md"
+    skill.write_text('---\nname: "noun"\n---\nbody\n')
+    tools, _resources, _names = discover_skill_tools((str(tmp_path),))
+    assert tools[0].description == "Exposes skill: noun"
+
+
+def test_discover_skill_tools_walks_multiple_paths(tmp_path):
+    a = tmp_path / "a" / "SKILL.md"
+    b = tmp_path / "b" / "SKILL.md"
+    for path, name in [(a, "alpha"), (b, "beta")]:
+        path.parent.mkdir(parents=True)
+        path.write_text(f'---\nname: "{name}"\ndescription: d\n---\n')
+
+    tools, _resources, names = discover_skill_tools((str(a.parent), str(b.parent)))
+    assert sorted(t.name for t in tools) == ["skill_alpha", "skill_beta"]
+    assert sorted(names) == ["alpha", "beta"]
+
+
+def test_discover_skill_tools_skips_empty_path_strings(tmp_path):
+    # Empty / whitespace-only entries from CSV parsing must not be treated as
+    # the current working directory.
+    tools, _resources, _names = discover_skill_tools(("", str(tmp_path)))
+    assert tools == []
+
+
+def test_read_skill_file_returns_contents(tmp_path):
+    f = tmp_path / "SKILL.md"
+    f.write_text("hello, skill")
+    assert read_skill_file(str(f)) == "hello, skill"
+
+
+def test_read_skill_file_returns_error_message_when_missing():
+    out = read_skill_file("/no/such/file")
+    assert out.startswith("Error reading skill file")
+    assert "/no/such/file" in out
+
+
+def test_skills_module_pulls_no_heavy_dependencies():
+    """``skills`` does only stdlib filesystem work — no SDK/deepeval/mcp."""
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import sys
+        import devops_bench.agents.api.skills  # noqa: F401
+        forbidden = ("mcp", "deepeval", "anthropic", "google.genai", "openai")
+        hits = sorted(
+            m for m in sys.modules
+            if any(m == p or m.startswith(p + ".") for p in forbidden)
+        )
+        if hits:
+            sys.stderr.write("LEAKED:" + ",".join(hits))
+            sys.exit(1)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/chaos/test_agent.py
+++ b/tests/unit/chaos/test_agent.py
@@ -1,0 +1,238 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ChaosAgent tests with a fake LLMClient (no SDK / no network).
+
+These cover the agent's three responsibilities: drive
+:func:`run_tool_loop` correctly via the fault-supplied tool descriptor and
+handler; reject malformed tool args / unknown tool names with a descriptive
+error string; and retain the model's final text across the turn cap.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from typing import Any
+
+from devops_bench.chaos.agent import ChaosAgent
+from devops_bench.models.base import LLMClient
+
+
+class _ScriptedClient(LLMClient):
+    """Replays a scripted sequence of (text, function_calls) tuples per turn."""
+
+    def __init__(self, script: list[tuple[str, list[dict]]]) -> None:
+        self._script = list(script)
+        self.format_tools_called_with: Any = None
+        self.contents_log: list[list[dict]] = []
+
+    async def generate_content(self, contents, tools, system_instruction):
+        # Snapshot what the loop has accumulated so tests can pin the message
+        # history shape per CONVENTIONS §5.
+        self.contents_log.append([dict(m) for m in contents])
+        text, calls = self._script.pop(0)
+        return SimpleNamespace(_text=text, _calls=calls)
+
+    def format_tools(self, mcp_tools):
+        self.format_tools_called_with = list(mcp_tools)
+        return ("formatted", tuple(getattr(t, "name", "?") for t in mcp_tools))
+
+    def extract_function_calls(self, response):
+        return list(response._calls)
+
+    def get_text_content(self, response):
+        return response._text
+
+
+_TOOL = SimpleNamespace(
+    name="run_command",
+    description="run",
+    inputSchema={"type": "object"},
+)
+
+
+def _handler_returning(text: str):
+    seen: list[tuple[str, threading.Event | None]] = []
+
+    def _handler(command: str, event: threading.Event | None) -> str:
+        seen.append((command, event))
+        if event is not None:
+            event.set()
+        return text
+
+    return _handler, seen
+
+
+def test_agent_runs_one_turn_when_model_emits_no_tool_calls():
+    client = _ScriptedClient([("done, nothing to do", [])])
+    handler, _ = _handler_returning("unused")
+    agent = ChaosAgent(
+        system_instruction="be safe",
+        tool=_TOOL,
+        tool_handler=handler,
+        client=client,
+    )
+
+    out = agent.run("goal")
+
+    assert out == "done, nothing to do"
+    # CONVENTIONS §5: format_tools is called by the agent before run_tool_loop.
+    assert client.format_tools_called_with == [_TOOL]
+
+
+def test_agent_dispatches_tool_calls_and_returns_final_text():
+    client = _ScriptedClient(
+        [
+            (
+                "running fortio now",
+                [{"name": "run_command", "args": {"command": "fortio load -qps 50 http://x"}, "id": "c1"}],
+            ),
+            ("done; saturated at 50 qps", []),
+        ]
+    )
+    handler, seen = _handler_returning("Stdout: ok")
+    event = threading.Event()
+    agent = ChaosAgent(
+        system_instruction="be safe",
+        tool=_TOOL,
+        tool_handler=handler,
+        chaos_active_event=event,
+        client=client,
+    )
+
+    out = agent.run("planned spike")
+
+    assert out == "done; saturated at 50 qps"
+    # Handler observed the model's command + the same event we passed in.
+    assert seen == [("fortio load -qps 50 http://x", event)]
+    # Conversation acquired the assistant message + the tool result entry.
+    final_contents = client.contents_log[-1]
+    assert final_contents[0] == {"role": "user", "content": "planned spike"}
+    assert final_contents[1]["role"] == "assistant"
+    assert final_contents[1]["tool_calls"][0]["name"] == "run_command"
+    assert final_contents[2] == {
+        "role": "tool",
+        "tool_call_id": "c1",
+        "name": "run_command",
+        "content": "Stdout: ok",
+    }
+
+
+def test_agent_returns_error_string_for_non_dict_tool_args():
+    # Model fabricates a tool call with a list payload instead of a dict.
+    client = _ScriptedClient(
+        [
+            ("calling tool", [{"name": "run_command", "args": ["nope"], "id": "c1"}]),
+            ("acknowledged the error", []),
+        ]
+    )
+    handler, seen = _handler_returning("never invoked")
+    agent = ChaosAgent(
+        system_instruction="x",
+        tool=_TOOL,
+        tool_handler=handler,
+        client=client,
+    )
+
+    out = agent.run("goal")
+
+    assert out == "acknowledged the error"
+    assert seen == []  # handler must not run for malformed args
+    tool_msg = client.contents_log[-1][-1]
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["content"] == "Error: tool args must be an object"
+
+
+def test_agent_returns_error_string_for_unknown_tool_name():
+    client = _ScriptedClient(
+        [
+            ("calling fake tool", [{"name": "rm_rf", "args": {}, "id": "c1"}]),
+            ("backed off", []),
+        ]
+    )
+    handler, seen = _handler_returning("nope")
+    agent = ChaosAgent(
+        system_instruction="x",
+        tool=_TOOL,
+        tool_handler=handler,
+        client=client,
+    )
+
+    out = agent.run("goal")
+
+    assert out == "backed off"
+    assert seen == []
+    tool_msg = client.contents_log[-1][-1]
+    assert tool_msg["content"] == "Error: unknown tool 'rm_rf'"
+
+
+def test_agent_retains_final_text_when_turn_cap_hits_with_tool_call():
+    # Loop the model forever requesting a tool; the cap should stop the loop
+    # but the most recent text must be preserved (the regression fix in §5.1).
+    script: list[tuple[str, list[dict]]] = []
+    for i in range(20):
+        script.append(
+            (
+                f"step {i}",
+                [{"name": "run_command", "args": {"command": f"echo {i}"}, "id": f"c{i}"}],
+            )
+        )
+    client = _ScriptedClient(script)
+    handler, seen = _handler_returning("ok")
+    agent = ChaosAgent(
+        system_instruction="x",
+        tool=_TOOL,
+        tool_handler=handler,
+        client=client,
+        max_turns=3,
+    )
+
+    out = agent.run("goal")
+
+    # Final text comes from the third (capped) turn.
+    assert out == "step 2"
+    assert len(seen) == 3
+
+
+def test_agent_returns_error_string_when_command_key_is_missing():
+    # Model emits the right tool but forgets the ``command`` key entirely.
+    # The dispatcher must not crash — it forwards an empty command to the
+    # handler, which surfaces it as an "Error: ..." string the model can read.
+    client = _ScriptedClient(
+        [
+            ("calling tool wrong", [{"name": "run_command", "args": {}, "id": "c1"}]),
+            ("fixed up", []),
+        ]
+    )
+    handler, seen = _handler_returning("never invoked")
+    agent = ChaosAgent(
+        system_instruction="x",
+        tool=_TOOL,
+        tool_handler=handler,
+        client=client,
+    )
+
+    out = agent.run("goal")
+
+    assert out == "fixed up"
+    # Handler IS invoked (with an empty command) — the actual fault handler
+    # decides whether to error; this asserts the dispatcher never crashes.
+    assert seen == [("", None)]
+    tool_msg = client.contents_log[-1][-1]
+    assert tool_msg["role"] == "tool"
+    # The handler returned its scripted text since this test stubs it; the
+    # production handler (run_chaos_command) returns "Error: command string is
+    # empty" — covered in test_generate_load.test_run_chaos_command_rejects_empty_command.
+    assert tool_msg["content"] == "never invoked"

--- a/tests/unit/chaos/test_base.py
+++ b/tests/unit/chaos/test_base.py
@@ -1,0 +1,58 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the chaos base abstractions (``ChaosResult``, ABCs)."""
+
+from __future__ import annotations
+
+import pytest
+
+from devops_bench.chaos.base import ChaosResult, Fault, Trigger
+
+
+def test_chaos_result_defaults_are_minimal():
+    res = ChaosResult(success=True, injected_fault="generate_load")
+    assert res.success is True
+    assert res.injected_fault == "generate_load"
+    assert res.output == ""
+    assert res.elapsed_time == 0.0
+    assert res.error is None
+
+
+def test_chaos_result_with_failure_carries_error_string():
+    res = ChaosResult(
+        success=False,
+        injected_fault="generate_load",
+        elapsed_time=1.5,
+        error="RuntimeError: provider blew up",
+    )
+    assert res.success is False
+    assert res.elapsed_time == 1.5
+    assert res.error.startswith("RuntimeError")
+
+
+def test_chaos_result_serialises_round_trip():
+    res = ChaosResult(success=True, injected_fault="x", output="ok", elapsed_time=0.25)
+    again = ChaosResult.model_validate(res.model_dump())
+    assert again == res
+
+
+def test_fault_is_abstract_and_cannot_be_instantiated():
+    with pytest.raises(TypeError):
+        Fault()  # type: ignore[abstract]
+
+
+def test_trigger_is_abstract_and_cannot_be_instantiated():
+    with pytest.raises(TypeError):
+        Trigger()  # type: ignore[abstract]

--- a/tests/unit/chaos/test_extension_axis.py
+++ b/tests/unit/chaos/test_extension_axis.py
@@ -1,0 +1,170 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extension-axis acceptance: a dummy fault / trigger lands with no central edit.
+
+CONVENTIONS §9 ("Extension-axis tests"): the harness-resolution path is the
+:data:`FAULTS` / :data:`TRIGGERS` registries. Phase 4 (CONVENTIONS §4) makes
+this stricter — :class:`ChaosSpec` is now registry-driven, so a dummy
+``@FAULTS.register("dummy")`` must additionally **parse through ChaosSpec**
+with no edit to ``chaos/spec.py`` (the bar verification met). That is what
+these tests pin.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Literal
+
+import pytest
+
+from devops_bench.chaos import ChaosSpec
+from devops_bench.chaos.base import FAULTS, TRIGGERS, ChaosResult, Fault, Trigger
+from devops_bench.core.context import RunContext
+
+
+@pytest.fixture
+def _isolated_registries():
+    """Register dummies for one test and rip them out afterwards.
+
+    The chaos registries are module-scoped and mutable; we snapshot them on
+    entry and restore on exit so dummies registered here cannot leak into other
+    tests in the same interpreter.
+
+    The bundled ``generate_load`` / ``time`` concretes register **eagerly** on
+    ``import devops_bench.chaos`` now (Phase 4 dropped the lazy first-parse
+    load), so the snapshot taken here already contains the real baseline — no
+    explicit pre-load step is needed before snapshotting.
+    """
+    saved_faults = dict(FAULTS.items())
+    saved_triggers = dict(TRIGGERS.items())
+    try:
+        yield
+    finally:
+        for key in list(FAULTS.keys()):
+            if key not in saved_faults:
+                del FAULTS._items[key]  # type: ignore[attr-defined]
+        for key in list(TRIGGERS.keys()):
+            if key not in saved_triggers:
+                del TRIGGERS._items[key]  # type: ignore[attr-defined]
+
+
+def test_dummy_fault_resolves_via_registry_with_no_central_edit(_isolated_registries):
+    @FAULTS.register("dummy")
+    class _DummyFault(Fault):
+        type: Literal["dummy"] = "dummy"
+        payload: str = ""
+
+        def inject(
+            self,
+            ctx: RunContext,
+            chaos_active_event: threading.Event | None = None,
+        ) -> ChaosResult:
+            return ChaosResult(
+                success=True, injected_fault=self.type, output=self.payload
+            )
+
+    # Harness-resolution path: registry.get(key) — no edit to chaos/spec.py
+    # required for the harness to find a brand-new fault.
+    assert "dummy" in FAULTS
+    cls = FAULTS.get("dummy")
+    assert cls is _DummyFault
+    res = _DummyFault(payload="ok").inject(RunContext(task_id="t"))
+    assert res.success is True
+    assert res.injected_fault == "dummy"
+
+
+def test_dummy_trigger_resolves_via_registry_with_no_central_edit(_isolated_registries):
+    @TRIGGERS.register("dummy")
+    class _DummyTrigger(Trigger):
+        type: Literal["dummy"] = "dummy"
+
+        def wait(self, ctx: RunContext) -> None:
+            return None
+
+    assert "dummy" in TRIGGERS
+    cls = TRIGGERS.get("dummy")
+    assert cls is _DummyTrigger
+    _DummyTrigger().wait(RunContext(task_id="t"))  # smoke: no crash
+
+
+def test_dummy_fault_parses_through_chaos_spec_with_no_spec_edit(_isolated_registries):
+    """Phase 4 bar: ``ChaosSpec`` finds a new fault via the registry alone."""
+
+    @FAULTS.register("dummy")
+    class _DummyFault(Fault):
+        type: Literal["dummy"] = "dummy"
+        payload: str = "hi"
+
+        def inject(
+            self,
+            ctx: RunContext,
+            chaos_active_event: threading.Event | None = None,
+        ) -> ChaosResult:  # pragma: no cover - parser-only test
+            return ChaosResult(success=True, injected_fault=self.type)
+
+    spec = ChaosSpec.model_validate(
+        {
+            "trigger": {"type": "time", "delay_seconds": 0},
+            "action": {"type": "dummy", "payload": "from-parse"},
+        }
+    )
+
+    assert isinstance(spec.action, _DummyFault)
+    assert spec.action.type == "dummy"
+    assert spec.action.payload == "from-parse"
+
+
+def test_dummy_trigger_parses_through_chaos_spec_with_no_spec_edit(_isolated_registries):
+    """Phase 4 bar: ``ChaosSpec`` finds a new trigger via the registry alone."""
+
+    @TRIGGERS.register("dummy")
+    class _DummyTrigger(Trigger):
+        type: Literal["dummy"] = "dummy"
+        label: str = ""
+
+        def wait(self, ctx: RunContext) -> None:  # pragma: no cover - parser-only test
+            return None
+
+    spec = ChaosSpec.model_validate(
+        {
+            "trigger": {"type": "dummy", "label": "from-parse"},
+            "action": {
+                "type": "generate_load",
+                "target": {"service_url": "http://x", "qps": 1},
+            },
+        }
+    )
+
+    assert isinstance(spec.trigger, _DummyTrigger)
+    assert spec.trigger.label == "from-parse"
+
+
+def test_unknown_type_error_message_lists_registered_keys(_isolated_registries):
+    """The registry-driven parser surfaces ``registered: [...]`` in its error."""
+
+    # No dummy registered — assert the error names the bundled concretes so
+    # authors can see the available options.
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError) as exc_info:
+        ChaosSpec.model_validate(
+            {
+                "trigger": {"type": "time"},
+                "action": {"type": "definitely_unknown"},
+            }
+        )
+    msg = str(exc_info.value)
+    assert "definitely_unknown" in msg
+    assert "generate_load" in msg

--- a/tests/unit/chaos/test_generate_load.py
+++ b/tests/unit/chaos/test_generate_load.py
@@ -1,0 +1,311 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for GenerateLoadFault — inject path, command runner, system prompt.
+
+The port-forward the load fault uses to reach its target lives in this fault
+(#33): :meth:`GenerateLoadFault.inject` opens its own ``kubectl port-forward``,
+points the load URL at the local tunnel, and tears the tunnel down — so the
+port-forward lifecycle is covered here, not in the harness scenario tests.
+"""
+
+from __future__ import annotations
+
+import threading
+from subprocess import CompletedProcess
+from unittest.mock import MagicMock, patch
+
+from devops_bench.chaos.base import ChaosResult
+from devops_bench.chaos.faults import generate_load as gl
+from devops_bench.chaos.faults.generate_load import (
+    _ENV_SKIP_PORT_FORWARD,
+    _ENV_TARGET_DEPLOYMENT,
+    _ENV_TARGET_NAMESPACE,
+    GenerateLoadFault,
+    LoadTarget,
+    build_system_instruction,
+    run_chaos_command,
+)
+from devops_bench.core.context import RunContext
+from devops_bench.k8s import kubectl as k8s_kubectl
+
+
+def _make_ctx(env: dict[str, str] | None = None) -> RunContext:
+    return RunContext(task_id="test", env=env or {})
+
+
+def test_build_system_instruction_embeds_target_url():
+    msg = build_system_instruction("http://localhost:9999")
+    assert "http://localhost:9999" in msg
+    assert "fortio" in msg
+
+
+def test_run_chaos_command_rejects_empty_command():
+    assert run_chaos_command("   ") == "Error: command string is empty"
+
+
+def test_run_chaos_command_sets_event_only_on_load_marker():
+    event = threading.Event()
+    fake = CompletedProcess(args=["fortio"], returncode=0, stdout="OUT", stderr="ERR")
+    with patch.object(gl, "run", return_value=fake) as run_mock:
+        out = run_chaos_command("fortio load -qps 50 http://x", chaos_active_event=event)
+
+    assert event.is_set()
+    assert "Stdout:\nOUT" in out
+    assert "Stderr:\nERR" in out
+    # shlex-split argv reached the executor, not a shell string.
+    argv = run_mock.call_args.args[0]
+    assert argv[0] == "fortio"
+    assert argv[1:3] == ["load", "-qps"]
+
+
+def test_run_chaos_command_does_not_set_event_for_unrelated_command():
+    event = threading.Event()
+    fake = CompletedProcess(args=["kubectl"], returncode=0, stdout="x", stderr="")
+    with patch.object(gl, "run", return_value=fake):
+        run_chaos_command("kubectl get pods", chaos_active_event=event)
+    assert not event.is_set()
+
+
+def test_run_chaos_command_surfaces_executor_exception_as_error_string():
+    with patch.object(gl, "run", side_effect=RuntimeError("boom")):
+        out = run_chaos_command("fortio load http://x")
+    assert out.startswith("Error: ")
+    assert "boom" in out
+
+
+def test_inject_returns_chaos_result_on_success():
+    fault = GenerateLoadFault(
+        target=LoadTarget(service_url="http://localhost:8080", qps=50)
+    )
+
+    # Patch the ChaosAgent the fault constructs so no model / SDK / network runs.
+    class _StubAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def run(self, goal: str) -> str:
+            assert "http://localhost:8080" in goal  # goal carries the rewritten URL
+            return "spike complete"
+
+    # ``ChaosAgent`` is imported lazily inside ``inject`` (Phase 4 keeps the
+    # agent + models chain out of sys.modules until injection runs), so the
+    # patch must target the source module rather than the fault module.
+    with patch("devops_bench.chaos.agent.ChaosAgent", _StubAgent):
+        result = fault.inject(_make_ctx())
+
+    assert isinstance(result, ChaosResult)
+    assert result.success is True
+    assert result.injected_fault == "generate_load"
+    assert result.output == "spike complete"
+    assert result.elapsed_time >= 0.0
+    assert result.error is None
+
+
+def test_inject_converts_agent_failure_to_failed_chaos_result():
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://x", qps=1))
+
+    class _BoomAgent:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(self, goal: str) -> str:
+            raise RuntimeError("model offline")
+
+    with patch("devops_bench.chaos.agent.ChaosAgent", _BoomAgent):
+        result = fault.inject(_make_ctx())
+
+    assert result.success is False
+    assert result.injected_fault == "generate_load"
+    assert result.error is not None
+    assert "model offline" in result.error
+
+
+def test_inject_threads_chaos_active_event_through_to_agent():
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://x", qps=1))
+    event = threading.Event()
+
+    captured: dict = {}
+
+    class _CapturingAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def run(self, goal: str) -> str:
+            return "ok"
+
+    with patch("devops_bench.chaos.agent.ChaosAgent", _CapturingAgent):
+        fault.inject(_make_ctx(), chaos_active_event=event)
+
+    assert captured["chaos_active_event"] is event
+    assert captured["tool"] is gl.RUN_COMMAND_TOOL
+    assert captured["tool_handler"] is gl.run_chaos_command
+    # The system instruction targets the rewritten URL from the spec.
+    assert "http://x" in captured["system_instruction"]
+
+
+def test_goal_dumps_spec_with_target_url():
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://svc", qps=42))
+    goal = fault.goal()
+    assert "generate_load" in goal
+    assert "http://svc" in goal
+    assert "42" in goal
+
+
+# -- port-forward lifecycle (moved from the harness scenario tests, #33) ------
+
+
+def _live_popen() -> MagicMock:
+    """A fake ``Popen`` that looks like a healthy, still-running tunnel."""
+    proc = MagicMock()
+    proc.poll.return_value = None  # still running after the settle window
+    proc.returncode = None
+    return proc
+
+
+def test_inject_opens_port_forward_and_points_url_at_local_tunnel():
+    """With a target deployment on ``ctx.env``, inject port-forwards + rewrites URL.
+
+    The agent must see ``http://localhost:8080`` (the tunnel), not the
+    in-cluster URL, and the tunnel must be terminated when injection finishes.
+    """
+    fault = GenerateLoadFault(
+        target=LoadTarget(service_url="http://example.svc.cluster.local", qps=50)
+    )
+    proc = _live_popen()
+    captured: dict = {}
+
+    class _StubAgent:
+        def __init__(self, **kwargs):
+            captured["system_instruction"] = kwargs["system_instruction"]
+
+        def run(self, goal: str) -> str:
+            captured["goal"] = goal
+            captured["url_during_run"] = fault.target.service_url
+            return "spike complete"
+
+    ctx = _make_ctx(
+        {_ENV_TARGET_DEPLOYMENT: "web-app", _ENV_TARGET_NAMESPACE: "prod"}
+    )
+    with (
+        patch.object(k8s_kubectl.subprocess, "Popen", return_value=proc) as popen_mock,
+        patch.object(k8s_kubectl.time, "sleep"),  # don't actually sleep the settle window
+        patch("devops_bench.chaos.agent.ChaosAgent", _StubAgent),
+    ):
+        result = fault.inject(ctx)
+
+    # Port-forward opened against the threaded deployment / namespace.
+    popen_mock.assert_called_once()
+    pf_cmd = popen_mock.call_args.args[0]
+    assert pf_cmd[:3] == ["kubectl", "port-forward", "deployment/web-app"]
+    assert "prod" in pf_cmd
+    assert pf_cmd[3] == "8080:8080"
+
+    # The agent saw the local tunnel URL, both in the system prompt and the
+    # goal, while the tunnel was open.
+    assert "http://localhost:8080" in captured["system_instruction"]
+    assert "http://localhost:8080" in captured["goal"]
+    assert captured["url_during_run"] == "http://localhost:8080"
+
+    # Tunnel torn down; the fault's stored URL restored afterwards.
+    proc.terminate.assert_called_once()
+    proc.wait.assert_called()
+    assert fault.target.service_url == "http://example.svc.cluster.local"
+
+    assert result.success is True
+    assert result.output == "spike complete"
+
+
+def test_inject_early_port_forward_exit_becomes_failed_result():
+    """A port-forward that dies in the settle window yields a failed ChaosResult."""
+    fault = GenerateLoadFault(
+        target=LoadTarget(service_url="http://x.svc.cluster.local", qps=1)
+    )
+    dead = MagicMock()
+    dead.poll.return_value = 1  # exited during the settle window
+    dead.returncode = 1
+
+    ctx = _make_ctx({_ENV_TARGET_DEPLOYMENT: "web-app"})
+    with (
+        patch.object(k8s_kubectl.subprocess, "Popen", return_value=dead),
+        patch.object(k8s_kubectl.time, "sleep"),
+        # The agent must never be constructed when the tunnel fails to come up.
+        patch(
+            "devops_bench.chaos.agent.ChaosAgent",
+            side_effect=AssertionError("agent ran despite dead port-forward"),
+        ),
+    ):
+        result = fault.inject(ctx)
+
+    assert result.success is False
+    assert result.error is not None
+    assert "port-forward exited early" in result.error
+
+
+def test_inject_skips_port_forward_when_flagged():
+    """``CHAOS_SKIP_PORT_FORWARD`` runs the loop against the existing URL, no Popen."""
+    fault = GenerateLoadFault(
+        target=LoadTarget(service_url="http://existing", qps=1)
+    )
+    captured: dict = {}
+
+    class _StubAgent:
+        def __init__(self, **kwargs):
+            captured["system_instruction"] = kwargs["system_instruction"]
+
+        def run(self, goal: str) -> str:
+            captured["url_during_run"] = fault.target.service_url
+            return "ok"
+
+    ctx = _make_ctx(
+        {
+            _ENV_TARGET_DEPLOYMENT: "web-app",
+            _ENV_SKIP_PORT_FORWARD: "1",
+        }
+    )
+    with (
+        patch.object(k8s_kubectl.subprocess, "Popen") as popen_mock,
+        patch("devops_bench.chaos.agent.ChaosAgent", _StubAgent),
+    ):
+        result = fault.inject(ctx)
+
+    popen_mock.assert_not_called()
+    # Skip flag means no rewrite — the agent targets the spec's own URL.
+    assert captured["url_during_run"] == "http://existing"
+    assert "http://existing" in captured["system_instruction"]
+    assert result.success is True
+
+
+def test_inject_without_target_deployment_runs_against_existing_url():
+    """No deployment on ``ctx.env`` -> no port-forward, existing URL preserved."""
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://plain", qps=1))
+    captured: dict = {}
+
+    class _StubAgent:
+        def __init__(self, **kwargs):
+            pass
+
+        def run(self, goal: str) -> str:
+            captured["url_during_run"] = fault.target.service_url
+            return "ok"
+
+    with (
+        patch.object(k8s_kubectl.subprocess, "Popen") as popen_mock,
+        patch("devops_bench.chaos.agent.ChaosAgent", _StubAgent),
+    ):
+        result = fault.inject(_make_ctx())
+
+    popen_mock.assert_not_called()
+    assert captured["url_during_run"] == "http://plain"
+    assert result.success is True

--- a/tests/unit/chaos/test_optimize_scale_regression.py
+++ b/tests/unit/chaos/test_optimize_scale_regression.py
@@ -1,0 +1,69 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression: the REAL ``optimize-scale`` chaos entry parses through ChaosSpec.
+
+Pins a **literal** of the real ``complextasks/optimize-scale`` chaos entry (with
+the harness placeholders already resolved) and asserts it validates through the
+typed :class:`ChaosSpec` and discriminates to
+:class:`GenerateLoadFault` / :class:`TimeTrigger` with the documented
+``target.service_url`` / ``qps`` / ``delay_seconds`` values.
+
+This is the gap CONVENTIONS §9 locks for every component — without it the typed
+nodes can drift away from the only real spec in the repo. The literal mirrors
+the verification component's regression test and keeps this test independent of
+*when* the task file itself is migrated to native YAML (that migration, and the
+end-to-end check against the real file, live with the harness PR).
+"""
+
+from __future__ import annotations
+
+from devops_bench.chaos import ChaosSpec
+from devops_bench.chaos.faults.generate_load import GenerateLoadFault
+from devops_bench.chaos.triggers.time_delay import TimeTrigger
+
+# The real optimize-scale chaos entry, native-YAML shape, with the harness
+# placeholders ({{TARGET_DEPLOYMENT_NAME}} / {{NAMESPACE}}) resolved as the
+# harness does at run time. ``verification`` is the legacy alias for ``verify``.
+_OPTIMIZE_SCALE_CHAOS_ENTRY: dict = {
+    "name": "Planned Load Spike",
+    "trigger": {"type": "time", "delay_seconds": 5},
+    "action": {
+        "type": "generate_load",
+        "target": {
+            "service_url": "http://web-app.default.svc.cluster.local",
+            "qps": 300,
+        },
+    },
+    "verification": "Planned Load Spike Verification",
+}
+
+
+def test_optimize_scale_chaos_entry_parses_and_discriminates():
+    spec = ChaosSpec.model_validate(_OPTIMIZE_SCALE_CHAOS_ENTRY)
+
+    assert spec.name == "Planned Load Spike"
+    # Trigger discriminates to the time-delay node and carries the authored delay.
+    assert isinstance(spec.trigger, TimeTrigger)
+    assert spec.trigger.type == "time"
+    assert spec.trigger.delay_seconds == 5
+    # Action discriminates to the generate-load fault with the resolved URL, the
+    # authored qps, and no spurious defaults overriding it.
+    assert isinstance(spec.action, GenerateLoadFault)
+    assert spec.action.type == "generate_load"
+    assert spec.action.target.service_url == "http://web-app.default.svc.cluster.local"
+    assert spec.action.target.qps == 300
+    # The legacy ``verification`` alias resolves into the canonical ``verify``
+    # reference field — chaos never imports a verification node.
+    assert spec.verify == "Planned Load Spike Verification"

--- a/tests/unit/chaos/test_package_import.py
+++ b/tests/unit/chaos/test_package_import.py
@@ -1,0 +1,125 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Import-hygiene guard: ``devops_bench.chaos`` keeps the SDK chain lazy.
+
+CONVENTIONS §8 (revised) — light init is a guideline, not a rule: importing
+the chaos package may now pull ``deepeval`` / ``mcp`` and the concrete
+fault/trigger modules (they register eagerly). What it must **never** pull is a
+provider model SDK or the agent + models chain — those stay lazy, gated inside
+:meth:`GenerateLoadFault.inject`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_import_pulls_no_provider_sdk():
+    # Fresh interpreter so other tests cannot pollute sys.modules. Provider
+    # SDKs are the only modules that must stay out — ``deepeval`` / ``mcp`` are
+    # now permitted eagerly.
+    code = (
+        "import sys\n"
+        "import devops_bench.chaos  # noqa: F401\n"
+        "loaded = set(sys.modules)\n"
+        "for forbidden in ('anthropic', 'google.genai', 'google.generativeai', 'openai', 'ollama'):\n"
+        "    assert forbidden not in loaded, forbidden\n"
+        "print('ok')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout
+
+
+def test_import_does_not_pull_chaos_agent_or_models_chain():
+    # Acceptance: importing the chaos package must NOT pull ``chaos.agent``
+    # (the LLM driver) or any ``models.*`` module — the only consumer,
+    # :meth:`Fault.inject`, lazy-imports them. The concrete fault / trigger
+    # modules, by contrast, DO load eagerly now (registry registration), so we
+    # assert their presence to pin the new eager behavior.
+    code = (
+        "import sys\n"
+        "import devops_bench.chaos  # noqa: F401\n"
+        "loaded = set(sys.modules)\n"
+        "for forbidden in (\n"
+        "    'devops_bench.chaos.agent',\n"
+        "    'devops_bench.models',\n"
+        "    'devops_bench.models.utils.loop',\n"
+        "    'devops_bench.models.base',\n"
+        "):\n"
+        "    assert forbidden not in loaded, forbidden\n"
+        "# The concrete fault / trigger modules now register eagerly on import.\n"
+        "for expected in (\n"
+        "    'devops_bench.chaos.faults.generate_load',\n"
+        "    'devops_bench.chaos.triggers.time_delay',\n"
+        "):\n"
+        "    assert expected in loaded, expected\n"
+        "print('ok')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout
+
+
+def test_parsing_a_spec_does_not_pull_the_agent_or_models_chain():
+    # The stronger Phase-4 invariant: even after ``ChaosSpec.model_validate``
+    # has loaded the concrete fault/trigger modules (and exercised the
+    # registry-driven parser), the agent + models chain stays out of
+    # ``sys.modules`` until a fault actually injects.
+    code = (
+        "import sys\n"
+        "from devops_bench.chaos import ChaosSpec\n"
+        "spec = ChaosSpec.model_validate({\n"
+        "    'trigger': {'type': 'time', 'delay_seconds': 0},\n"
+        "    'action': {\n"
+        "        'type': 'generate_load',\n"
+        "        'target': {'service_url': 'http://x', 'qps': 1},\n"
+        "    },\n"
+        "})\n"
+        "loaded = set(sys.modules)\n"
+        "for forbidden in (\n"
+        "    'devops_bench.chaos.agent',\n"
+        "    'devops_bench.models.utils.loop',\n"
+        "    'devops_bench.models.base',\n"
+        "):\n"
+        "    assert forbidden not in loaded, forbidden\n"
+        "print('ok')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout
+
+
+def test_chaos_init_exports_match_handoff():
+    import devops_bench.chaos as chaos
+
+    # Handoff §5.5: export only Fault, Trigger, ChaosResult, FAULTS, TRIGGERS,
+    # ChaosSpec. ChaosAgent is NOT exported.
+    assert set(chaos.__all__) == {
+        "ChaosResult",
+        "ChaosSpec",
+        "FAULTS",
+        "Fault",
+        "TRIGGERS",
+        "Trigger",
+    }
+    assert not hasattr(chaos, "ChaosAgent")

--- a/tests/unit/chaos/test_spec.py
+++ b/tests/unit/chaos/test_spec.py
@@ -1,0 +1,200 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the registry-driven chaos spec."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from devops_bench.chaos import FAULTS, TRIGGERS, ChaosSpec
+from devops_bench.chaos.faults.generate_load import GenerateLoadFault, LoadTarget
+from devops_bench.chaos.schema import json_schema, validate_spec
+from devops_bench.chaos.triggers.time_delay import TimeTrigger
+
+
+def test_minimal_chaos_spec_parses_and_discriminates():
+    spec = ChaosSpec.model_validate(
+        {
+            "trigger": {"type": "time", "delay_seconds": 3},
+            "action": {
+                "type": "generate_load",
+                "target": {"service_url": "http://web", "qps": 50},
+            },
+        }
+    )
+
+    assert spec.name == "Planned Disruption"
+    assert isinstance(spec.trigger, TimeTrigger)
+    assert spec.trigger.delay_seconds == 3
+    assert isinstance(spec.action, GenerateLoadFault)
+    assert spec.action.target.service_url == "http://web"
+    assert spec.action.target.qps == 50
+    assert spec.verify is None
+
+
+def test_chaos_spec_with_name_and_verify_reference():
+    spec = ChaosSpec.model_validate(
+        {
+            "name": "spike",
+            "trigger": {"type": "time", "delay_seconds": 0},
+            "action": {
+                "type": "generate_load",
+                "target": {"service_url": "http://svc", "qps": 1},
+            },
+            "verify": "post_spike_check",
+        }
+    )
+
+    assert spec.name == "spike"
+    assert spec.verify == "post_spike_check"
+
+
+def test_legacy_verification_alias_is_accepted():
+    # The real ``optimize-scale/task.yaml`` ships ``verification`` (not
+    # ``verify``); the spec accepts both so Phase A lands without touching
+    # task files. Phase B will migrate the on-disk shape.
+    spec = ChaosSpec.model_validate(
+        {
+            "trigger": {"type": "time", "delay_seconds": 5},
+            "action": {
+                "type": "generate_load",
+                "target": {"service_url": "http://svc", "qps": 1},
+            },
+            "verification": "Planned Load Spike Verification",
+        }
+    )
+
+    assert spec.verify == "Planned Load Spike Verification"
+
+
+def test_bare_list_or_dict_at_node_position_is_rejected():
+    # A bare list is the legacy authoring anti-pattern: the spec must be a
+    # typed mapping, not a free-form list/dict.
+    with pytest.raises(ValidationError):
+        ChaosSpec.model_validate([{"type": "time"}])
+    with pytest.raises(ValidationError, match="must be a mapping"):
+        # action position taking a bare list — the registry-driven parser
+        # surfaces "chaos fault node must be a mapping" via ValidationError.
+        ChaosSpec.model_validate(
+            {
+                "trigger": {"type": "time"},
+                "action": [{"type": "generate_load"}],
+            }
+        )
+
+
+def test_unknown_extra_field_is_forbidden():
+    # ``extra="forbid"`` keeps schema drift loud.
+    with pytest.raises(ValidationError):
+        ChaosSpec.model_validate(
+            {
+                "trigger": {"type": "time"},
+                "action": {
+                    "type": "generate_load",
+                    "target": {"service_url": "http://x", "qps": 1},
+                },
+                "wat": "unexpected",
+            }
+        )
+
+
+def test_unknown_discriminator_value_raises_validation_error():
+    # Phase 4: unknown ``type`` keys raise a ValidationError that lists the
+    # registered keys in the message — the registry-driven parser builds this
+    # text from ``FAULTS.keys()`` / ``TRIGGERS.keys()`` so a new fault Just
+    # Works with no central edit.
+    with pytest.raises(ValidationError) as exc_info:
+        ChaosSpec.model_validate(
+            {
+                "trigger": {"type": "made_up"},
+                "action": {
+                    "type": "generate_load",
+                    "target": {"service_url": "http://x", "qps": 1},
+                },
+            }
+        )
+    assert "made_up" in str(exc_info.value)
+    assert "time" in str(exc_info.value)
+
+    with pytest.raises(ValidationError) as exc_info:
+        ChaosSpec.model_validate(
+            {
+                "trigger": {"type": "time"},
+                "action": {"type": "no_such_fault"},
+            }
+        )
+    assert "no_such_fault" in str(exc_info.value)
+    assert "generate_load" in str(exc_info.value)
+
+
+def test_missing_type_discriminator_is_rejected():
+    # Phase 4: a node without ``type`` is rejected at parse time, not silently
+    # accepted as a free-form dict.
+    with pytest.raises(ValidationError, match="missing required"):
+        ChaosSpec.model_validate(
+            {
+                "trigger": {"delay_seconds": 5},  # missing type
+                "action": {
+                    "type": "generate_load",
+                    "target": {"service_url": "http://x", "qps": 1},
+                },
+            }
+        )
+
+
+def test_validate_spec_returns_typed_chaos_spec():
+    parsed = validate_spec(
+        {
+            "trigger": {"type": "time"},
+            "action": {
+                "type": "generate_load",
+                "target": {"service_url": "http://x", "qps": 1},
+            },
+        }
+    )
+    assert isinstance(parsed, ChaosSpec)
+    assert isinstance(parsed.action, GenerateLoadFault)
+
+
+def test_json_schema_emits_a_top_level_object():
+    # Phase 4: ``ChaosSpec`` is registry-driven, so its JSON schema no longer
+    # enumerates concrete fault/trigger types under ``action`` / ``trigger`` —
+    # that is exactly what lets a new fault land without a schema edit. The
+    # schema still exposes the top-level shape (``name``, ``trigger``,
+    # ``action``, ``verify``) for editor tooling.
+    schema = json_schema()
+    assert schema.get("type") == "object"
+    properties = schema.get("properties", {})
+    assert set(properties).issuperset({"name", "trigger", "action", "verify"})
+    assert "trigger" in schema.get("required", [])
+    assert "action" in schema.get("required", [])
+
+
+def test_registries_advertise_the_bundled_concretes():
+    assert "generate_load" in FAULTS
+    assert FAULTS.get("generate_load") is GenerateLoadFault
+    assert "time" in TRIGGERS
+    assert TRIGGERS.get("time") is TimeTrigger
+
+
+def test_load_target_qps_must_be_positive():
+    with pytest.raises(ValidationError):
+        LoadTarget.model_validate({"service_url": "http://x", "qps": 0})
+
+
+def test_time_trigger_delay_must_be_non_negative():
+    with pytest.raises(ValidationError):
+        TimeTrigger.model_validate({"type": "time", "delay_seconds": -1})

--- a/tests/unit/chaos/test_time_trigger.py
+++ b/tests/unit/chaos/test_time_trigger.py
@@ -1,0 +1,41 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the time-delay chaos trigger."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from devops_bench.chaos.triggers import time_delay
+from devops_bench.chaos.triggers.time_delay import TimeTrigger
+from devops_bench.core.context import RunContext
+
+
+def _ctx() -> RunContext:
+    return RunContext(task_id="t1")
+
+
+def test_zero_delay_returns_without_sleeping():
+    trigger = TimeTrigger(delay_seconds=0)
+    with patch.object(time_delay.time, "sleep") as sleep_mock:
+        trigger.wait(_ctx())
+    sleep_mock.assert_not_called()
+
+
+def test_positive_delay_sleeps_for_that_many_seconds():
+    trigger = TimeTrigger(delay_seconds=4)
+    with patch.object(time_delay.time, "sleep") as sleep_mock:
+        trigger.wait(_ctx())
+    sleep_mock.assert_called_once_with(4)


### PR DESCRIPTION
The API/MCP agent used to live in `pkg/agents/runner/api/` as a monolithic loop with the MCP client, skill discovery, and LLM-adapter dispatch intermingled; this refactors it into `devops_bench/agents/api/` (`agent.py` harness, `mcp.py`, `skills.py`) built on the shared `run_tool_loop` and the `models` layer, with MCP/skills/rules and provider/model resolved from `AgentConfig` rather than env reads.

**Behavior changes**
- MCP and skills are now independent gates: skills-only, MCP-only, both, or neither — previously they were coupled.
- Capability bindings and provider/model flow from `AgentConfig.capabilities` instead of env reads (`AGENT_TARGET`, `BENCH_USE_MCP`); the orchestrator wires them explicitly.
- The agent reuses the shared `run_tool_loop` (provider-agnostic; the caller pre-formats tools) rather than carrying its own loop.
- Optional provider/MCP SDKs are imported lazily.

**Bugs fixed**
- MCP server commands with arguments (e.g. `uv run mcp-server`) are parsed with `shlex.split` instead of being treated as a single executable.
- Token usage is mapped across the Gemini/Claude/Ollama response shapes (totals computed when absent) instead of assuming one provider's field names.
- Skill files are read on a worker thread instead of blocking the async event loop.