### PR TITLE
feat(metrics): metrics suite + bundled skills

### DIFF
--- a/complextasks/optimize-scale/task.yaml
+++ b/complextasks/optimize-scale/task.yaml
@@ -7,32 +7,34 @@ expected_output: |
   - Agent adds resource requests and limits to the deployment.
   - Agent creates an HPA with minReplicas > 1 and appropriate target CPU.
   - Agent detects and takes appropriate actions to handle the chaos event (load spike).
-chaos_spec: |
-  [
-    {
-      "name": "Planned Load Spike",
-      "trigger": { "type": "time", "delay_seconds": 5 },
-      "action": { 
-        "type": "generate_load", 
-        "target": { "service_url": "http://{{TARGET_DEPLOYMENT_NAME}}.{{NAMESPACE}}.svc.cluster.local", "qps": 300 } 
-      },
-      "verification": "Planned Load Spike Verification"
-    }
-  ]
-verification_spec: |
-  [
-    {
-      "name": "Planned Load Spike Verification",
-      "pod_spec": {
-        "type": "pod_healthy",
-        "selector": "app={{TARGET_DEPLOYMENT_NAME}}",
-        "namespace": "{{NAMESPACE}}"
-      },
-      "scaling_spec": {
-        "type": "scaling_complete",
-        "deployment": "{{TARGET_DEPLOYMENT_NAME}}",
-        "min_replicas": 2,
-        "namespace": "{{NAMESPACE}}"
-      }
-    }
-  ]
+# Native YAML (Decision D2): field names ``chaos_spec`` and ``verification_spec``
+# are unchanged; only the values are migrated from JSON-in-YAML strings to plain
+# YAML mappings so authors edit one shape. Placeholder substitution still
+# round-trips through the rendered string before validation.
+chaos_spec:
+  - name: "Planned Load Spike"
+    trigger:
+      type: time
+      delay_seconds: 5
+    action:
+      type: generate_load
+      target:
+        service_url: "http://{{TARGET_DEPLOYMENT_NAME}}.{{NAMESPACE}}.svc.cluster.local"
+        qps: 300
+    # Cross-reference: matched against ``verification_spec[*].name`` below.
+    verify: "Planned Load Spike Verification"
+verification_spec:
+  - name: "Planned Load Spike Verification"
+    spec:
+      type: parallel
+      name: "Planned Load Spike Verification"
+      checks:
+        - type: pod_healthy
+          name: pod_spec
+          selector: "app={{TARGET_DEPLOYMENT_NAME}}"
+          namespace: "{{NAMESPACE}}"
+        - type: scaling_complete
+          name: scaling_spec
+          deployment: "{{TARGET_DEPLOYMENT_NAME}}"
+          min_replicas: 2
+          namespace: "{{NAMESPACE}}"

--- a/devops_bench/evalharness/__init__.py
+++ b/devops_bench/evalharness/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Orchestration engine: the harness that wires every component into one pipeline."""
+
+from __future__ import annotations
+
+from devops_bench.evalharness.base import Harness
+from devops_bench.evalharness.default import DefaultHarness
+from devops_bench.evalharness.reporter import ResultReporter
+from devops_bench.evalharness.scenario import ScenarioManager
+
+__all__ = ["DefaultHarness", "Harness", "ResultReporter", "ScenarioManager"]

--- a/devops_bench/evalharness/artifacts.py
+++ b/devops_bench/evalharness/artifacts.py
@@ -1,0 +1,93 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Capture files an agent generates by diffing a directory before and after."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+from devops_bench.core import get_logger
+
+__all__ = ["snapshot_dir", "collect_generated_files"]
+
+_log = get_logger("evalharness.artifacts")
+
+
+def snapshot_dir(path: str | os.PathLike[str] = ".") -> set[str]:
+    """Snapshot the immediate entries of a directory.
+
+    Args:
+        path: Directory to list; defaults to the current working directory.
+
+    Returns:
+        The set of entry names directly under ``path``. An empty set is
+        returned when ``path`` does not exist, so the diff stays well-defined
+        when the workspace is created lazily by the agent.
+    """
+    target = os.fspath(path)
+    if not os.path.isdir(target):
+        return set()
+    return set(os.listdir(target))
+
+
+def collect_generated_files(
+    before: set[str],
+    run_dir: str | os.PathLike[str],
+    *,
+    source_dir: str | os.PathLike[str] = ".",
+) -> list[str]:
+    """Copy entries created since ``before`` into the run's artifact directory.
+
+    New files and directories (those present now but absent from ``before``) are
+    copied into ``<run_dir>/generated_files/``. The destination directory is
+    created only when there is at least one new entry to copy.
+
+    Args:
+        before: Entry names captured by :func:`snapshot_dir` prior to the run.
+        run_dir: The run output directory; artifacts land under its
+            ``generated_files`` subdirectory.
+        source_dir: Directory the agent wrote into; defaults to the current
+            working directory. The harness threads
+            :attr:`~devops_bench.core.RunContext.workspace_path` here so the
+            artifact diff is bound to the per-task workspace, not the process
+            cwd.
+
+    Returns:
+        The names of the entries that were copied.
+    """
+    after = snapshot_dir(source_dir)
+    new_entries = after - before
+    if not new_entries:
+        return []
+
+    gen_files_dir = Path(run_dir) / "generated_files"
+    gen_files_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: list[str] = []
+    src_root = os.fspath(source_dir)
+    for name in new_entries:
+        src = os.path.join(src_root, name)
+        dst = os.fspath(gen_files_dir / name)
+        if os.path.isdir(src):
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+            copied.append(name)
+        elif os.path.isfile(src):
+            shutil.copy(src, dst)
+            copied.append(name)
+
+    _log.info("collected %d generated artifact(s) into %s", len(copied), gen_files_dir)
+    return copied

--- a/devops_bench/evalharness/base.py
+++ b/devops_bench/evalharness/base.py
@@ -1,0 +1,82 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Harness interface: the engine that runs the end-to-end evaluation pipeline."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+from devops_bench.core import RunContext
+from devops_bench.tasks import Task
+
+__all__ = ["Harness"]
+
+
+class Harness(ABC):
+    """Abstract engine orchestrating a full benchmark evaluation.
+
+    A harness sits above every component (deployers, agents, chaos, verification,
+    metrics) and threads them together for each task: provision infrastructure,
+    optionally start a background chaos scenario, run the agent under test,
+    collect artifacts, tear down, then score and report. It owns the
+    :class:`~devops_bench.core.RunContext` carried across these phases.
+
+    Concrete harnesses implement :meth:`run` to execute a batch of typed
+    :class:`~devops_bench.tasks.Task` objects; :meth:`make_context` is a helper
+    for building the per-task context.
+    """
+
+    @abstractmethod
+    def run(self, tasks: list[Task]) -> list[dict[str, Any]]:
+        """Run the full pipeline over a batch of typed tasks.
+
+        Args:
+            tasks: The :class:`~devops_bench.tasks.Task` objects to evaluate
+                in order. Each task is provisioned, run, scored, and torn
+                down independently.
+
+        Returns:
+            The detailed per-task result dicts, scored in place, in the
+            ``results.json`` schema produced by routing every typed component
+            result through ``to_dict()``/``to_entry()``.
+        """
+
+    def make_context(
+        self,
+        task: Task,
+        *,
+        cluster: Any | None = None,
+        workspace_path: Path | None = None,
+    ) -> RunContext:
+        """Build the per-task run context carried across pipeline phases.
+
+        Args:
+            task: The task being evaluated.
+            cluster: Provisioned cluster details, if any.
+            workspace_path: Working directory the agent operates in; ``None``
+                lets the caller leave the field unset (the harness defaults to
+                the current working directory when it needs a concrete path).
+
+        Returns:
+            A :class:`~devops_bench.core.RunContext` seeded with task metadata.
+        """
+        return RunContext(
+            task_id=str(task.id or task.name or ""),
+            task_name=task.name,
+            workspace_path=workspace_path,
+            cluster=cluster,
+        )

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -1,0 +1,893 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DefaultHarness: wires agents, chaos, verification, and metrics into one pipeline."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import json
+import os
+import threading
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from devops_bench.agents import AGENTS, AgentConfig, AgentResult
+from devops_bench.agents.capabilities import (
+    AgentRules,
+    AllCapabilities,
+    McpBinding,
+    SkillBinding,
+)
+from devops_bench.chaos import ChaosSpec
+from devops_bench.core import (
+    MissingDependencyError,
+    NotRegisteredError,
+    RunContext,
+    get_bool,
+    get_env,
+    get_logger,
+)
+from devops_bench.deployers.factory import get_deployer
+from devops_bench.evalharness.artifacts import collect_generated_files, snapshot_dir
+from devops_bench.evalharness.base import Harness
+from devops_bench.evalharness.reporter import ResultReporter
+from devops_bench.evalharness.scenario import VERIFICATION_TIMEOUT_SEC, ScenarioManager
+from devops_bench.tasks import Task
+from devops_bench.verification import VerificationSpec
+
+__all__ = ["DefaultHarness"]
+
+_log = get_logger("evalharness.default")
+
+# Builtin agent modules imported at call time so their ``@AGENTS.register``
+# decorators run. External packages add agents by registering with the same
+# registry, with no edit here.
+_BUILTIN_AGENT_MODULES: tuple[str, ...] = (
+    "devops_bench.agents.cli.gemini_cli",
+    "devops_bench.agents.cli.openclaw",
+    "devops_bench.agents.api.agent",
+)
+
+# Aliases normalized to canonical agent keys before registry lookup.
+_AGENT_TYPE_ALIASES: dict[str, str] = {
+    "cli": "gemini",
+    "binary": "gemini",
+}
+
+# Default target deployment + namespace used both for placeholder
+# substitution in the agent prompt and as the chaos port-forward target, so the
+# operator agent and the chaos injector address the same workload when env is
+# unset.
+_DEFAULT_TARGET_DEPLOYMENT = "hypercomputer-d1-frontend"
+_DEFAULT_NAMESPACE = "default"
+
+# How long to wait for the chaos agent to establish its load spike before
+# starting the operator agent.
+_CHAOS_ACTIVE_WAIT_SEC = 45
+
+# Budget for draining the scenario thread. Kept above the verification budget
+# so a slow-but-completing verification is not cut off, which would otherwise
+# yield partial reports and race teardown.
+_SCENARIO_JOIN_SEC = VERIFICATION_TIMEOUT_SEC + 60
+
+
+def _ensure_builtin_agents_registered() -> None:
+    """Import the builtin agent modules so their registrations fire.
+
+    The registry is the only source of truth — this function exists so the
+    harness can resolve canonical keys at call time without naming any module
+    path in ``AGENTS.get``. Re-imports are no-ops thanks to ``sys.modules``.
+
+    Catches **only** missing-dependency / import errors (an agent module may
+    pull an optional SDK like ``anthropic`` that is absent on the host) — a
+    real bug in an agent module (``SyntaxError``, an ``AttributeError`` at
+    module top) re-raises so it cannot hide behind a silent ``debug`` log.
+    """
+    for module in _BUILTIN_AGENT_MODULES:
+        try:
+            importlib.import_module(module)
+        except (ImportError, MissingDependencyError) as exc:
+            # Optional SDK absent on this host. ``AGENTS.get`` will still
+            # raise a clear ``NotRegisteredError`` later if the user selects
+            # an agent whose module did not load.
+            _log.debug("optional agent module %s not importable: %s", module, exc)
+
+
+class DefaultHarness(Harness):
+    """Standard harness wiring every component into one pipeline.
+
+    Each task flows through provisioning, optional background chaos, agent
+    execution, artifact collection, teardown, and batch scoring. Every layer
+    is consumed through its typed contract: ``Task`` in, ``AgentResult`` from
+    the agent, ``ChaosResult`` / ``VerificationResult`` from the scenario,
+    ``MetricScore`` from each metric. The harness routes those typed values
+    through ``to_dict()`` / ``to_entry()`` / ``model_dump()`` so the on-disk
+    ``results.json`` schema stays byte-stable.
+
+    Args:
+        project_id: Default GCP project ID for provisioning and placeholders.
+        cluster_name: Default cluster name for provisioning and placeholders.
+        judge_model: A ``DeepEvalBaseLLM`` judge used for scoring; when ``None``
+            one is built from ``JUDGE_PROVIDER`` / ``JUDGE_MODEL`` on first use.
+        results_root: Directory under which timestamped run dirs are created.
+        reporter: Optional explicit result reporter. A default
+            :class:`ResultReporter` rooted at ``results_root`` is built when
+            omitted.
+        default_target_deployment: Fallback deployment name used both for
+            placeholder substitution and as the chaos port-forward target when
+            ``TARGET_DEPLOYMENT_NAME`` is unset.
+        default_namespace: Fallback namespace used for the same two purposes
+            when ``NAMESPACE`` is unset.
+    """
+
+    def __init__(
+        self,
+        project_id: str,
+        cluster_name: str,
+        judge_model: Any | None = None,
+        results_root: str = "results",
+        *,
+        reporter: ResultReporter | None = None,
+        default_target_deployment: str = _DEFAULT_TARGET_DEPLOYMENT,
+        default_namespace: str = _DEFAULT_NAMESPACE,
+    ) -> None:
+        self.project_id = project_id
+        self.cluster_name = cluster_name
+        self._judge_model = judge_model
+        self.results_root = results_root
+        self.agent_type = (get_env("BENCH_AGENT_TYPE", "cli") or "cli").lower()
+        # Single, harness-owned read of ``BENCH_USE_MCP``. The resolved boolean
+        # is threaded into both the AgentConfig capabilities and the metrics
+        # scoring call.
+        self.use_mcp: bool = get_bool("BENCH_USE_MCP", True)
+        # Build the gated :class:`AgentConfig` once and hold the snapshot for
+        # the lifetime of this harness, so every agent run and every record's
+        # ``capabilities_granted`` field reads the same object.
+        self._agent_config: AgentConfig = self._build_agent_config_snapshot()
+        self.default_target_deployment = default_target_deployment
+        self.default_namespace = default_namespace
+        # Resolve the run-level placeholder inputs once into instance
+        # attributes that ``replace_placeholders`` / ``start_scenario`` read.
+        self.app_location = get_env("APP_LOCATION", "") or ""
+        self.target_deployment = (
+            get_env("TARGET_DEPLOYMENT_NAME", self.default_target_deployment)
+            or self.default_target_deployment
+        )
+        self.namespace = (
+            get_env("NAMESPACE", self.default_namespace) or self.default_namespace
+        )
+        self.reporter = reporter or ResultReporter(results_root)
+
+    @property
+    def _granted_skill_paths(self) -> tuple[str, ...]:
+        """Skill paths the harness granted, derived from the config snapshot.
+
+        Single source of truth: the same tuple lives on
+        ``self._agent_config.capabilities.skills.paths`` and is read by every
+        agent the harness constructs. Keeping it as a derived property (not a
+        second copy) makes it structurally impossible for the recorded
+        ``skills`` to disagree with what the agent saw.
+        """
+        return self._agent_config.capabilities.skills.paths
+
+    # -- agent resolution (model/provider-agnostic) -----------------------
+
+    def resolve_agent(self, agent_type: str) -> Any:
+        """Resolve and instantiate the agent under test from the registry.
+
+        The builtin agent modules are imported once so their
+        ``@AGENTS.register`` decorators run, the alias is normalized to the
+        canonical key, and the class is fetched from
+        :data:`~devops_bench.agents.AGENTS`. An externally-registered agent
+        resolves the same way with no harness edit.
+
+        Args:
+            agent_type: Configured agent type (e.g. ``cli`` / ``api`` /
+                ``gemini`` / ``openclaw``).
+
+        Returns:
+            An instantiated agent harness. The instance is built with the
+            harness-resolved :class:`AgentConfig` so capabilities (MCP / skills /
+            rules) reflect the orchestrator's catalog × run-arm decision.
+
+        Raises:
+            NotRegisteredError: If no agent is registered under the resolved
+                canonical key.
+        """
+        _ensure_builtin_agents_registered()
+        key = _AGENT_TYPE_ALIASES.get(agent_type, agent_type)
+        agent_cls = AGENTS.get(key)
+        if agent_cls is None:
+            raise NotRegisteredError(AGENTS.name, key, AGENTS.keys())
+        return agent_cls(self.build_agent_config())
+
+    # -- agent config + capabilities (explicit; no env detour) ------------
+
+    def build_agent_config(self) -> AgentConfig:
+        """Return the harness's snapshotted :class:`AgentConfig`.
+
+        The config is built once in :meth:`__init__` and reused for every agent
+        run plus every record's ``capabilities_granted`` field.
+
+        Returns:
+            The :class:`AgentConfig` snapshot. The same object is handed to
+            every agent the harness constructs.
+        """
+        return self._agent_config
+
+    def _build_agent_config_snapshot(self) -> AgentConfig:
+        """Build the gated :class:`AgentConfig` from the env layer.
+
+        Called exactly once, from :meth:`__init__`. Starts from
+        :meth:`AgentConfig.from_env` so existing ``AGENT_*`` knobs continue
+        to flow through (``model``, ``provider``, ``api_key``, ``target``,
+        ``timeout``, ``max_turns``, ``extra_env``), then replaces
+        capabilities with the orchestrator-owned aggregate so the agent
+        cannot see a granted MCP binding when ``use_mcp`` is False.
+        """
+        base = AgentConfig.from_env()
+        capabilities = self._gate_capabilities(base.capabilities, self.use_mcp)
+        return AgentConfig(
+            model=base.model,
+            provider=base.provider,
+            api_key=base.api_key,
+            target=base.target,
+            timeout_sec=base.timeout_sec,
+            max_turns=base.max_turns,
+            capabilities=capabilities,
+            extra_env=base.extra_env,
+        )
+
+    @staticmethod
+    def _gate_capabilities(
+        env_caps: AllCapabilities, use_mcp: bool
+    ) -> AllCapabilities:
+        """Apply the harness's ``use_mcp`` gate to an env-derived capability set.
+
+        Skills and rules are independent of MCP and pass through unchanged;
+        only the MCP binding is dropped when ``use_mcp`` is False. The
+        returned aggregate is always a fresh frozen dataclass so the caller
+        does not mutate the input.
+
+        Args:
+            env_caps: Capabilities derived from the ``AGENT_*`` env layer.
+            use_mcp: Whether the orchestrator granted MCP for this run.
+
+        Returns:
+            The gated :class:`AllCapabilities` to attach to the next
+            :class:`AgentConfig`.
+        """
+        if use_mcp:
+            mcp_servers: tuple[McpBinding, ...] = env_caps.mcp_servers
+        else:
+            # MCP gated off: drop the binding so the agent's tools-enabled gate
+            # is False and metrics' ``use_mcp`` agrees with what ran.
+            mcp_servers = ()
+
+        return AllCapabilities(
+            mcp_servers=mcp_servers,
+            skills=env_caps.skills if env_caps.skills.paths else SkillBinding(),
+            rules=env_caps.rules if env_caps.rules.text else AgentRules(),
+        )
+
+    # -- placeholder substitution -----------------------------------------
+
+    def replace_placeholders(self, text: str, cluster_name: str) -> str:
+        """Substitute infrastructure placeholders in a prompt or expectation.
+
+        ``TARGET_DEPLOYMENT_NAME`` and ``NAMESPACE`` form the integration
+        contract supplied by the provisioning layer after cluster bring-up;
+        their fallbacks come from the constructor's
+        :attr:`default_target_deployment` / :attr:`default_namespace`.
+
+        Args:
+            text: Text containing ``{{...}}`` placeholders.
+            cluster_name: Active cluster name to substitute.
+
+        Returns:
+            The text with all known placeholders replaced.
+        """
+        return (
+            text.replace("{{PROJECT_ID}}", self.project_id)
+            .replace("{{GCP_PROJECT_ID}}", self.project_id)
+            .replace("{{CLUSTER_NAME}}", cluster_name)
+            .replace("{{GKE_CLUSTER_NAME}}", cluster_name)
+            .replace("{{APP_LOCATION}}", self.app_location)
+            .replace("{{TARGET_DEPLOYMENT_NAME}}", self.target_deployment)
+            .replace("{{NAMESPACE}}", self.namespace)
+        )
+
+    def _resolve_spec_placeholders(self, spec: Any, cluster_name: str) -> Any:
+        """Walk a nested spec and substitute placeholders in every string leaf.
+
+        Args:
+            spec: An opaque chaos / verification spec value (mapping, list,
+                scalar, or ``None``).
+            cluster_name: Active cluster name passed through to
+                :meth:`replace_placeholders`.
+
+        Returns:
+            A new structure with placeholders resolved. ``None`` round-trips
+            unchanged so a missing spec stays missing.
+        """
+        if spec is None:
+            return None
+        if isinstance(spec, str):
+            return self.replace_placeholders(spec, cluster_name)
+        if isinstance(spec, list):
+            return [self._resolve_spec_placeholders(item, cluster_name) for item in spec]
+        if isinstance(spec, dict):
+            return {
+                key: self._resolve_spec_placeholders(value, cluster_name)
+                for key, value in spec.items()
+            }
+        return spec
+
+    # -- spec parsing (typed contracts at every seam) ---------------------
+
+    def _parse_chaos_specs(self, raw: Any, cluster_name: str) -> list[ChaosSpec]:
+        """Parse the raw task ``chaos_spec`` blob into typed :class:`ChaosSpec` list.
+
+        Accepts either a JSON-in-YAML string or a native-YAML list. Each entry
+        is placeholder-substituted, then validated through :class:`ChaosSpec`.
+        """
+        if not raw:
+            return []
+        resolved = self._resolve_spec_placeholders(raw, cluster_name)
+        # A placeholder-substituted JSON string round-trips through
+        # ``json.loads`` to a list/dict the discriminated union can validate.
+        if isinstance(resolved, str):
+            try:
+                resolved = json.loads(resolved)
+            except json.JSONDecodeError as exc:
+                _log.warning("could not parse chaos_spec JSON string: %s", exc)
+                return []
+        entries = resolved if isinstance(resolved, list) else [resolved]
+        return [ChaosSpec.model_validate(entry) for entry in entries if entry]
+
+    def _build_verification_mapping(
+        self, raw: Any, cluster_name: str
+    ) -> tuple[dict[str, Any], list[dict[str, str]]]:
+        """Build a name-keyed verification mapping the chaos seam consumes.
+
+        Canonical authoring shape is a list of wrapped entries::
+
+            verification_spec:
+              - name: "Planned Load Spike Verification"
+                spec:
+                  type: parallel
+                  checks: [...]
+
+        ``name`` is the cross-reference key the chaos ``verify:`` field
+        resolves against; ``spec`` carries the typed verification node. When no
+        ``spec`` key is present the entry mapping itself is accepted as the
+        node. Every authoring failure is **surfaced** — both warn-logged and
+        accumulated into the returned ``errors`` list so the harness can
+        record it on the run result, instead of silently dropping a
+        verification (which would make a typo'd cross-reference invisible to
+        the operator).
+
+        Args:
+            raw: The task's ``verification_spec`` blob.
+            cluster_name: Active cluster name for placeholder substitution.
+
+        Returns:
+            A pair ``(mapping, errors)``:
+
+            * ``mapping`` — ``{name -> parsed VerificationSpec}``.
+            * ``errors`` — one ``{"name", "reason"}`` entry per authoring
+              failure (a non-mapping entry, a missing ``name``, a JSON
+              parse failure on a string blob, or a ``VerificationSpec``
+              validation failure). Empty when every entry parsed.
+        """
+        if not raw:
+            return {}, []
+
+        errors: list[dict[str, str]] = []
+        resolved = self._resolve_spec_placeholders(raw, cluster_name)
+        if isinstance(resolved, str):
+            try:
+                resolved = json.loads(resolved)
+            except json.JSONDecodeError as exc:
+                _log.warning("could not parse verification_spec JSON string: %s", exc)
+                errors.append({"name": "<root>", "reason": f"json parse: {exc}"})
+                return {}, errors
+        entries = resolved if isinstance(resolved, list) else [resolved]
+
+        mapping: dict[str, Any] = {}
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                msg = (
+                    f"verification_spec entry [{index}] must be a mapping, "
+                    f"got {type(entry).__name__}"
+                )
+                _log.warning(msg)
+                errors.append({"name": f"<index {index}>", "reason": msg})
+                continue
+            name = entry.get("name")
+            if not name:
+                msg = f"verification_spec entry [{index}] missing required ``name`` key"
+                _log.warning(msg)
+                errors.append({"name": f"<index {index}>", "reason": msg})
+                continue
+            # Canonical shape ``{name, spec: <typed-node>}``; an entry without
+            # a ``spec`` key is itself treated as the typed node.
+            node = entry.get("spec") if "spec" in entry else entry
+            try:
+                mapping[name] = VerificationSpec(node)
+            except Exception as exc:  # noqa: BLE001 - surface every failure
+                _log.warning(
+                    "verification entry %r failed to validate; skipping: %s",
+                    name,
+                    exc,
+                )
+                errors.append({"name": str(name), "reason": str(exc)})
+        return mapping, errors
+
+    # -- scenario (background chaos) --------------------------------------
+
+    def start_scenario(
+        self,
+        chaos_specs: list[ChaosSpec],
+        verification_mapping: dict[str, Any],
+        ctx: RunContext,
+        *,
+        skip_port_forward: bool = False,
+    ) -> tuple[ScenarioManager, threading.Thread] | None:
+        """Start a background chaos+verification scenario on a daemon thread.
+
+        Args:
+            chaos_specs: Typed chaos entries. Only the first spec is driven.
+            verification_mapping: Name-keyed mapping of typed verification
+                specs the chaos ``verify:`` key is resolved against.
+            ctx: Per-task run context handed to triggers / faults.
+            skip_port_forward: When True, do not open ``kubectl port-forward``;
+                used by the E2E smoke harness when running against the
+                :class:`~devops_bench.deployers.NoOpDeployer`.
+
+        Returns:
+            A ``(scenario_manager, thread)`` pair, or ``None`` when no chaos
+            specs were provided.
+        """
+        if not chaos_specs:
+            return None
+
+        spec = chaos_specs[0]
+        scenario_manager = ScenarioManager(
+            self.target_deployment,
+            self.namespace,
+            verification_mapping=verification_mapping,
+            skip_port_forward=skip_port_forward,
+        )
+        thread = threading.Thread(
+            target=scenario_manager.run_chaos_and_verification,
+            args=(spec, ctx),
+            daemon=True,
+        )
+        thread.start()
+        return scenario_manager, thread
+
+    # -- agent execution --------------------------------------------------
+
+    def execute_agent(self, prompt: str, _ctx: RunContext) -> AgentResult:
+        """Run the configured agent against ``prompt`` through the registry.
+
+        Args:
+            prompt: The (placeholder-resolved) task prompt.
+            _ctx: The per-task run context. Reserved for future per-run hooks;
+                agents consume only the resolved prompt and rely on their
+                :class:`AgentConfig` for everything else.
+
+        Returns:
+            The typed :class:`AgentResult` the agent emitted.
+        """
+        agent = self.resolve_agent(self.agent_type)
+        return agent.run(prompt)
+
+    # -- pipeline ---------------------------------------------------------
+
+    def run(self, tasks: list[Task]) -> list[dict[str, Any]]:
+        """Run the full pipeline over ``tasks`` and return scored results.
+
+        Args:
+            tasks: Typed :class:`Task` objects produced by
+                :func:`~devops_bench.tasks.load_tasks`.
+
+        Returns:
+            The detailed per-task result dicts, scored in place, in the
+            ``results.json`` schema.
+        """
+        run_dir = self.reporter.new_run_dir()
+        detailed_results: list[dict[str, Any]] = [
+            self._run_one(task, run_dir) for task in tasks
+        ]
+
+        # Persist raw execution outputs before the (slower) scoring pass.
+        self.reporter.write(run_dir, detailed_results)
+        _log.info("execution complete; results saved to %s/results.json", run_dir)
+
+        # Scoring is best-effort: a judge/config failure (e.g. get_judge_model()
+        # or an unexpected error in a metric) must not sink an otherwise
+        # successful execution pass, whose raw results are already on disk above.
+        try:
+            self._score(detailed_results)
+            self.reporter.write(run_dir, detailed_results)
+            _log.info(
+                "post-processing evaluation complete; updated results saved to %s/results.json",
+                run_dir,
+            )
+        except Exception:  # noqa: BLE001 - execution results must survive scoring errors
+            _log.exception(
+                "scoring failed; returning unscored execution results from %s", run_dir
+            )
+        return detailed_results
+
+    def _run_one(self, task: Task, run_dir: Path) -> dict[str, Any]:
+        """Provision, run the agent, collect artifacts, tear down for one task.
+
+        Args:
+            task: The typed task being evaluated.
+            run_dir: The run output directory for generated artifacts.
+
+        Returns:
+            The detailed result dict. On any failure a ``status: "failed"``
+            record is returned instead of being dropped, so failures stay
+            visible to downstream parsers. Success and failed records carry
+            the same top-level key set so a parser can iterate either shape
+            without a ``KeyError``.
+        """
+        infra_config = task.infrastructure or {}
+        deployer: Any | None = None
+        scenario_manager: ScenarioManager | None = None
+        scenario_thread: threading.Thread | None = None
+        result: dict[str, Any] | None = None
+        workspace_path = Path(os.getcwd())
+        verification_parse_errors: list[dict[str, str]] = []
+        # Track the substituted prompt / expectation as they are computed so a
+        # failed record can carry the same resolved strings a success record
+        # would, falling back to the raw task fields before substitution.
+        prompt: str | None = None
+        expected_output: str | None = None
+
+        try:
+            # Build the deployer inside the try so a factory failure (e.g. an
+            # unknown deployer type) becomes a failed record for this task
+            # rather than crashing the whole batch.
+            deployer = get_deployer(infra_config, self.project_id, self.cluster_name)
+            _log.info("provisioning infrastructure for: %s", task.name)
+            deployer.up()
+            cluster_info = deployer.get_cluster_info()
+            active_cluster_name = cluster_info.name or self.cluster_name
+            context = self.make_context(
+                task, cluster=cluster_info, workspace_path=workspace_path
+            )
+
+            prompt = self.replace_placeholders(task.prompt, active_cluster_name)
+
+            chaos_specs = self._parse_chaos_specs(task.chaos_spec, active_cluster_name)
+            verification_mapping, verification_parse_errors = (
+                self._build_verification_mapping(
+                    task.verification_spec, active_cluster_name
+                )
+            )
+
+            # Hand the background scenario its own context with an isolated
+            # env dict so its in-thread env mutations never touch the context
+            # the agent runs against.
+            scenario = self.start_scenario(
+                chaos_specs,
+                verification_mapping,
+                replace(context, env=dict(context.env)),
+            )
+            if scenario is not None:
+                scenario_manager, scenario_thread = scenario
+                _log.info("waiting for chaos agent to establish the cluster load spike...")
+                scenario_manager.chaos_active_event.wait(timeout=_CHAOS_ACTIVE_WAIT_SEC)
+                _log.info("cluster load spike active; proceeding with operator agent...")
+
+            _log.info("executing agent for prompt: %s", prompt)
+            before_files = snapshot_dir(workspace_path)
+            agent_res = self.execute_agent(prompt, context)
+            collect_generated_files(before_files, run_dir, source_dir=workspace_path)
+
+            expected_output = self.replace_placeholders(
+                task.expected_output, active_cluster_name
+            )
+
+            chaos_report, perf_report = self._drain_scenario(
+                scenario_manager, scenario_thread
+            )
+
+            result = self._build_success_record(
+                task=task,
+                prompt=prompt,
+                expected_output=expected_output,
+                agent_res=agent_res,
+                chaos_report=chaos_report,
+                perf_report=perf_report,
+                verification_parse_errors=verification_parse_errors,
+            )
+            _log.info("agent response for %s:\n%s", task.name, result["output"])
+        except Exception as exc:  # noqa: BLE001 - surface every task failure
+            _log.error("critical error during task %s: %s", task.name, exc)
+            result = self._build_failed_record(
+                task,
+                exc,
+                prompt=prompt,
+                expected_output=expected_output,
+                verification_parse_errors=verification_parse_errors,
+            )
+        finally:
+            if scenario_manager is not None:
+                scenario_manager.stop()
+            if deployer is not None:
+                self._teardown(deployer, infra_config, task.name)
+
+        return result
+
+    #: Top-level keys present on **every** record (success and failed alike).
+    #: Exposed so downstream parsers / tests can pin the symmetric schema
+    #: without reproducing the literal in every spot.
+    _RECORD_KEYS: frozenset[str] = frozenset(
+        {
+            "input",
+            "output",
+            "latency",
+            "tokens",
+            "tools",
+            "trajectory",
+            "skills",
+            "name",
+            "status",
+            "error",
+            "errors",
+            "scores",
+            "expected_output",
+            "expected_output_raw",
+            "retrieval_context",
+            "chaos_spec",
+            "verification_spec",
+            "chaos_report",
+            "perf_report",
+            "documentation",
+            "capabilities_granted",
+            "verification_parse_errors",
+        }
+    )
+
+    def _build_success_record(
+        self,
+        *,
+        task: Task,
+        prompt: str,
+        expected_output: str,
+        agent_res: AgentResult,
+        chaos_report: dict[str, Any],
+        perf_report: dict[str, Any],
+        verification_parse_errors: list[dict[str, str]] | None = None,
+    ) -> dict[str, Any]:
+        """Shape a typed :class:`AgentResult` + reports into the on-disk schema.
+
+        Routes every typed value through ``to_dict()`` / ``model_dump()`` and
+        emits the **symmetric** key union (every key in :attr:`_RECORD_KEYS`
+        is present on every record), so success and failed records never differ
+        in top-level shape — a downstream parser iterating one shape can never
+        ``KeyError`` crossing into the other.
+
+        Capability metadata (``capabilities_granted``) is recorded so metrics
+        / downstream consumers can read what the agent was actually granted
+        rather than re-reading ``BENCH_USE_MCP``.
+        """
+        dumped = agent_res.to_dict()
+        agent_errors = list(dumped.get("errors") or [])
+        record = self._empty_record(task)
+        record.update(
+            {
+                "input": prompt,
+                "output": dumped.get("output", ""),
+                "latency": dumped.get("latency", 0.0),
+                "tokens": dumped.get("tokens", {}),
+                # Expose a flat ``tools`` key alongside the typed trajectory
+                # for consumers that only sample tool names; the trajectory is
+                # the source of truth.
+                "tools": [
+                    entry.get("name")
+                    for entry in dumped.get("trajectory", [])
+                    if entry.get("name")
+                ],
+                "trajectory": dumped.get("trajectory", []),
+                "status": "success",
+                "errors": agent_errors,
+                # First-error scalar so a parser reading ``error`` finds the
+                # same key on the success shape (None when nothing went wrong).
+                "error": agent_errors[0] if agent_errors else None,
+                "expected_output": expected_output,
+                "chaos_report": chaos_report,
+                "perf_report": perf_report,
+                "verification_parse_errors": list(verification_parse_errors or []),
+            }
+        )
+        return record
+
+    def _build_failed_record(
+        self,
+        task: Task,
+        exc: Exception,
+        *,
+        prompt: str | None = None,
+        expected_output: str | None = None,
+        verification_parse_errors: list[dict[str, str]] | None = None,
+    ) -> dict[str, Any]:
+        """Build a failed-task record so the failure stays visible.
+
+        Emits the **same** top-level key set as :meth:`_build_success_record`
+        (pinned in :attr:`_RECORD_KEYS`): a downstream parser iterating either
+        shape never trips a ``KeyError`` crossing between them. The differences
+        are values only — ``status=\"failed\"``, ``error`` carries the
+        exception text, ``scores`` stays empty.
+
+        Args:
+            task: The task that failed.
+            exc: The exception that aborted the run.
+            prompt: The placeholder-substituted prompt if it was computed before
+                the failure; falls back to the raw ``task.prompt`` otherwise, so
+                the record matches the success shape when substitution had run.
+            expected_output: The substituted expectation if computed; falls back
+                to the raw ``task.expected_output``.
+            verification_parse_errors: Any spec-parse errors collected so far.
+        """
+        error_text = str(exc)
+        record = self._empty_record(task)
+        record.update(
+            {
+                "input": prompt if prompt is not None else task.prompt,
+                "expected_output": (
+                    expected_output
+                    if expected_output is not None
+                    else task.expected_output
+                ),
+                "status": "failed",
+                "error": error_text,
+                "errors": [error_text],
+                "verification_parse_errors": list(verification_parse_errors or []),
+            }
+        )
+        return record
+
+    def _empty_record(self, task: Task) -> dict[str, Any]:
+        """Seed every record with the symmetric key set.
+
+        Centralizes the default values for the keys that match across
+        success/failed records (task identifying fields, opaque blobs, empty
+        containers for ``scores`` / ``tools`` / ``trajectory`` etc.). Both
+        builder methods overlay the differing keys on top of this seed; the
+        seed itself never contains a ``status`` value so the caller must set
+        it explicitly.
+        """
+        return {
+            "input": task.prompt,
+            "output": "",
+            "latency": 0.0,
+            "tokens": {},
+            "tools": [],
+            "trajectory": [],
+            "skills": list(self._granted_skill_paths),
+            "name": task.name,
+            "status": "",
+            "error": None,
+            "errors": [],
+            # ``scores`` (the per-metric mapping) is populated by ``_score`` for
+            # success records; failed records leave it as the empty dict so the
+            # key is always present. There is no aggregate scalar score: the
+            # per-metric map is the source of truth.
+            "scores": {},
+            "expected_output": "",
+            "expected_output_raw": task.expected_output,
+            "retrieval_context": list(task.retrieval_context),
+            "chaos_spec": task.chaos_spec,
+            "verification_spec": task.verification_spec,
+            "chaos_report": {},
+            "perf_report": {},
+            "documentation": [doc.model_dump() for doc in task.documentation],
+            "capabilities_granted": {
+                "use_mcp": self.use_mcp,
+                "skills": list(self._granted_skill_paths),
+            },
+            "verification_parse_errors": [],
+        }
+
+    def _drain_scenario(
+        self,
+        scenario_manager: ScenarioManager | None,
+        scenario_thread: threading.Thread | None,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Join the scenario thread and return its chaos and perf reports.
+
+        If the join times out (i.e. ``thread.is_alive()`` after the budget),
+        a warning is logged and the returned ``chaos_report["status"]`` is
+        stamped to ``"timed_out"`` so a partial report is flagged on the
+        record rather than silently mislabelled as the last status the
+        scenario reached before the cutoff.
+
+        Args:
+            scenario_manager: The running scenario, or None.
+            scenario_thread: The scenario's daemon thread, or None.
+
+        Returns:
+            A ``(chaos_report, perf_report)`` pair; both empty when no chaos
+            was scheduled for the task.
+        """
+        if scenario_manager is None or scenario_thread is None:
+            return {}, {}
+        _log.info("waiting for background metrics collection to complete...")
+        scenario_thread.join(timeout=_SCENARIO_JOIN_SEC)
+        chaos_report, perf_report = scenario_manager.get_reports()
+        if scenario_thread.is_alive():
+            _log.warning(
+                "scenario thread still alive after %ss join budget; "
+                "stamping chaos_report.status='timed_out'",
+                _SCENARIO_JOIN_SEC,
+            )
+            # The daemon thread is still running and may be mid-write, so deep-
+            # copy the live report before stamping it: a shallow ``dict()`` would
+            # share nested objects and could capture a torn structure. This
+            # preserves any partial fields populated before the cutoff
+            # (injected_fault / name / output) so the operator sees how far it got.
+            chaos_report = copy.deepcopy(chaos_report)
+            chaos_report["status"] = "timed_out"
+        return chaos_report, perf_report
+
+    def _teardown(
+        self, deployer: Any, infra_config: dict[str, Any], name: str
+    ) -> None:
+        """Tear down infrastructure unless disabled by config or env.
+
+        Args:
+            deployer: The deployer to tear down.
+            infra_config: Task infrastructure config (``teardown`` flag).
+            name: Task name, for logging.
+        """
+        if get_bool("BENCH_NO_TEARDOWN"):
+            return
+        if not infra_config.get("teardown", True):
+            return
+        _log.info("tearing down infrastructure for: %s", name)
+        try:
+            deployer.down()
+        except Exception as exc:  # noqa: BLE001 - never raise during teardown
+            _log.error("teardown failed (potential resource leak): %s", exc)
+
+    def _score(self, detailed_results: list[dict[str, Any]]) -> None:
+        """Score the batch in place via the metrics pipeline.
+
+        The harness threads its single resolved ``use_mcp`` boolean into the
+        metrics call, so the agent and the judge cannot disagree on whether
+        tools were enabled.
+
+        Args:
+            detailed_results: Execution results to score; ``scores`` is written
+                into each in place. Records marked ``status: "failed"`` are
+                skipped, since there is no agent output to judge.
+        """
+        scorable = [r for r in detailed_results if r.get("status") != "failed"]
+        if not scorable:
+            return
+        # Lazy import keeps ``deepeval`` / provider SDKs out of harness import.
+        from devops_bench.metrics import evaluate_metrics_batch, get_judge_model
+
+        judge_model = self._judge_model or get_judge_model()
+        evaluate_metrics_batch(scorable, judge_model, use_mcp=self.use_mcp)

--- a/devops_bench/evalharness/reporter.py
+++ b/devops_bench/evalharness/reporter.py
@@ -1,0 +1,88 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Result sink: write the per-run ``results.json`` and collect artifacts.
+
+The harness depends on a :class:`ResultReporter` rather than calling
+:func:`json.dump` inline, so output sinks (DB, dashboard, blob store) can be
+added by substituting the reporter without editing the orchestrator.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from devops_bench.core import get_logger
+
+__all__ = ["ResultReporter"]
+
+_log = get_logger("evalharness.reporter")
+
+_RESULTS_FILENAME = "results.json"
+
+
+class ResultReporter:
+    """Default reporter writing ``results.json`` to a timestamped run directory.
+
+    Every value written through this reporter has already been routed through
+    ``MetricScore.to_entry()`` / ``AgentResult.to_dict()`` /
+    ``ChaosResult.model_dump()`` / ``VerificationResult.model_dump()`` by the
+    orchestrator, so the reporter itself only knows how to JSON-encode the
+    final dicts.
+
+    Args:
+        results_root: Root directory under which per-run subdirectories are
+            created. Defaults to ``"results"``.
+        run_dir_prefix: Prefix for the timestamped subdirectory name.
+    """
+
+    def __init__(
+        self,
+        results_root: str | os.PathLike[str] = "results",
+        *,
+        run_dir_prefix: str = "run_",
+    ) -> None:
+        self.results_root = Path(results_root)
+        self.run_dir_prefix = run_dir_prefix
+
+    def new_run_dir(self) -> Path:
+        """Create and return a fresh timestamped run directory under the root.
+
+        Returns:
+            The absolute path of the newly created directory.
+        """
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        run_dir = self.results_root / f"{self.run_dir_prefix}{timestamp}"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        return run_dir
+
+    def write(self, run_dir: str | os.PathLike[str], results: list[dict[str, Any]]) -> Path:
+        """Write ``results`` to ``<run_dir>/results.json`` and return the path.
+
+        Args:
+            run_dir: Run directory previously returned by :meth:`new_run_dir`.
+            results: Per-task result dicts already shaped to the on-disk schema.
+
+        Returns:
+            The path of the JSON file written.
+        """
+        path = Path(run_dir) / _RESULTS_FILENAME
+        with open(path, "w") as f:
+            json.dump(results, f, indent=2)
+        _log.info("wrote results.json with %d entries to %s", len(results), path)
+        return path

--- a/devops_bench/evalharness/scenario.py
+++ b/devops_bench/evalharness/scenario.py
@@ -1,0 +1,305 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Background chaos + verification on a daemon thread.
+
+Connectivity is owned by the fault: the :class:`ScenarioManager` threads the
+port-forward target env onto the run context and runs chaos plus verification
+on a daemon thread, resolving :attr:`ChaosSpec.verify` against a name-keyed
+verification mapping supplied by the caller.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+from devops_bench.chaos import ChaosSpec
+from devops_bench.chaos.faults.generate_load import (
+    _ENV_SKIP_PORT_FORWARD,
+    _ENV_TARGET_DEPLOYMENT,
+    _ENV_TARGET_NAMESPACE,
+)
+from devops_bench.core import get_logger
+from devops_bench.core.context import RunContext
+from devops_bench.verification import VerifierAgent
+
+__all__ = ["ScenarioManager", "VERIFICATION_TIMEOUT_SEC"]
+
+_log = get_logger("evalharness.scenario")
+
+# Verification budget shared across the (possibly nested) checks.
+VERIFICATION_TIMEOUT_SEC = 120
+
+
+class ScenarioManager:
+    """Orchestrate a background chaos disruption and its verification.
+
+    The manager runs on a daemon thread alongside the agent under test: it
+    waits on the typed trigger, drives the typed
+    :class:`~devops_bench.chaos.base.Fault` (via ``action.inject``) to inject
+    the planned disruption, then resolves the spec's ``verify:`` key against the
+    per-task verification mapping and runs
+    :meth:`~devops_bench.verification.VerifierAgent.wait_for_condition` on the
+    resolved node. The ``kubectl port-forward`` the load fault needs to reach
+    its target is owned by the fault, not the manager — the manager only threads
+    the target deployment / namespace onto ``ctx.env`` so the fault can open it.
+
+    Args:
+        target_deployment: Deployment the load fault should port-forward and
+            disrupt; threaded onto ``ctx.env`` for the fault.
+        namespace: Namespace the deployment lives in; threaded onto ``ctx.env``.
+        verification_mapping: Name-keyed mapping of verification specs the
+            chaos ``verify:`` reference is resolved against. The mapping carries
+            already-validated :class:`VerificationSpec` instances (or any value
+            ``VerifierAgent.wait_for_condition`` accepts); the manager never
+            re-validates. Empty mapping disables verification lookups.
+        skip_port_forward: When True, the fault runs without opening a
+            ``kubectl port-forward``. The E2E smoke harness (against
+            :class:`~devops_bench.deployers.NoOpDeployer`) flips this on so
+            tests can exercise the wiring without a real cluster.
+
+    Attributes:
+        chaos_active_event: Set by the chaos fault once the disruption is
+            observably active, so the harness can synchronize the operator
+            agent's start.
+    """
+
+    def __init__(
+        self,
+        target_deployment: str,
+        namespace: str,
+        verification_mapping: dict[str, Any] | None = None,
+        *,
+        skip_port_forward: bool = False,
+    ) -> None:
+        self.target_deployment = target_deployment
+        self.namespace = namespace
+        self.verification_mapping: dict[str, Any] = dict(verification_mapping or {})
+        self.skip_port_forward = skip_port_forward
+        self.chaos_active_event = threading.Event()
+        self.verifier_agent = VerifierAgent()
+        self.result_holder: dict[str, dict[str, Any]] = {
+            "chaos_report": {},
+            "perf_report": {},
+        }
+        self.start_time: float | None = None
+        self._aborted = threading.Event()
+
+    def run_chaos_and_verification(
+        self,
+        spec: ChaosSpec,
+        ctx: RunContext,
+    ) -> None:
+        """Inject the planned fault, then gather verification metrics.
+
+        Args:
+            spec: A typed :class:`ChaosSpec` carrying the trigger, action, and
+                opaque ``verify:`` key to resolve.
+            ctx: The per-task run context (forwarded to the trigger / fault).
+        """
+        self.start_time = time.time()
+
+        # Record initial chaos metadata before injection begins, so a crash
+        # mid-injection still produces a partial report rather than silence.
+        self.result_holder["chaos_report"] = {
+            "injected_fault": spec.action.type,
+            "name": spec.name,
+            "status": "initiated",
+        }
+
+        try:
+            chaos_result = self._inject_chaos(spec, ctx)
+            self.result_holder["chaos_report"] = self._chaos_report_from_result(
+                spec, chaos_result
+            )
+        except Exception as exc:  # noqa: BLE001 - surface failure into the report
+            _log.error("error running scenario: %s", exc)
+            self.result_holder["chaos_report"]["status"] = "failed"
+            self.result_holder["chaos_report"]["error"] = str(exc)
+            # Unblock the main thread immediately: it waits on this event to
+            # learn the disruption is active, and a failed injection never sets
+            # it via the fault, so without this it stalls for the full
+            # ``_CHAOS_ACTIVE_WAIT_SEC`` timeout before proceeding.
+            self.chaos_active_event.set()
+            return
+
+        if self._aborted.is_set():
+            return
+
+        verification_node = self._resolve_verification(spec.verify)
+        if verification_node is None:
+            # No verification scheduled (``verify`` was None) — leave the
+            # chaos_report alone. An UNKNOWN key, on the other hand, has
+            # already stamped ``chaos_report["verification"]`` with the
+            # failure record so the operator sees the typo'd cross-reference
+            # on the run record, not just in the log.
+            return
+
+        _log.info("starting planned verification using VerifierAgent...")
+        try:
+            verification_result = self.verifier_agent.wait_for_condition(
+                verification_node, timeout_sec=VERIFICATION_TIMEOUT_SEC
+            )
+            _log.info(
+                "verification completed: %s",
+                verification_result.model_dump_json(indent=2),
+            )
+            self.result_holder["chaos_report"]["verification"] = (
+                verification_result.model_dump()
+            )
+            self.result_holder["perf_report"] = self._perf_from_verification(
+                verification_result
+            )
+        except Exception as exc:  # noqa: BLE001 - surface failure into the report
+            _log.error("verification failed with exception: %s", exc)
+            self.result_holder["chaos_report"]["verification"] = {
+                "success": False,
+                "reason": f"Verification exception: {exc}",
+            }
+
+    def _inject_chaos(self, spec: ChaosSpec, ctx: RunContext):
+        """Wait on the trigger, then drive ``action.inject`` with the target env.
+
+        The trigger is a typed node; wait through its own ``wait(ctx)`` rather
+        than reading raw ``delay_seconds`` here — the harness only knows the
+        ``Trigger`` Protocol, not the concrete trigger's parameters. Before
+        injecting, the port-forward target the load fault needs is threaded onto
+        ``ctx.env``; the fault opens and tears down its own tunnel.
+
+        Args:
+            spec: Typed chaos spec.
+            ctx: Run context handed to the trigger / fault.
+
+        Returns:
+            The :class:`~devops_bench.chaos.ChaosResult` returned by the fault.
+        """
+        spec.trigger.wait(ctx)
+
+        # Thread the port-forward target onto the context so the fault can open
+        # its own tunnel. ``ctx.env`` values are strings; the skip flag is set
+        # only when truthy so the fault's ``bool(env.get(...))`` reads cleanly.
+        ctx.env[_ENV_TARGET_DEPLOYMENT] = self.target_deployment
+        ctx.env[_ENV_TARGET_NAMESPACE] = self.namespace
+        if self.skip_port_forward:
+            ctx.env[_ENV_SKIP_PORT_FORWARD] = "1"
+
+        return spec.action.inject(ctx, self.chaos_active_event)
+
+    @staticmethod
+    def _chaos_report_from_result(spec: ChaosSpec, result: Any) -> dict[str, Any]:
+        """Shape a typed ``ChaosResult`` into the chaos-report dict.
+
+        Args:
+            spec: The originating spec (carries the human-readable ``name``).
+            result: A :class:`~devops_bench.chaos.ChaosResult`.
+
+        Returns:
+            The ``chaos_report`` dict consumed by the result reporter; the
+            ``status`` field is derived from ``ChaosResult.success``.
+        """
+        dumped = result.model_dump()
+        # Carry both the human-readable name and the typed result fields so
+        # downstream consumers see a superset of both.
+        report: dict[str, Any] = {
+            "injected_fault": result.injected_fault,
+            "name": spec.name,
+            "status": "success" if result.success else "failed",
+            "output": dumped.get("output", ""),
+            "elapsed_time": dumped.get("elapsed_time", 0.0),
+        }
+        if dumped.get("error") is not None:
+            report["error"] = dumped["error"]
+        return report
+
+    @staticmethod
+    def _perf_from_verification(result: Any) -> dict[str, Any]:
+        """Derive ``perf_report`` from a verification result.
+
+        Deployment time flows through on success; the uptime / utilization
+        fields collapse to a success binary.
+        """
+        success = bool(result.success)
+        elapsed = float(result.elapsed_time)
+        return {
+            "deployment_time_seconds": elapsed if success else None,
+            "uptime_percentage": 100.0 if success else 0.0,
+            "resource_utilization_efficiency": 1.0 if success else 0.0,
+        }
+
+    def _resolve_verification(self, verify_ref: str | None) -> Any | None:
+        """Resolve the chaos spec's opaque ``verify`` key against the mapping.
+
+        Args:
+            verify_ref: The string key carried on :attr:`ChaosSpec.verify`, or
+                ``None`` when the spec opts out of verification.
+
+        Returns:
+            The mapped verification node (already validated) when the key is
+            present and known; ``None`` when the spec opts out **or** the
+            key is unknown. The unknown-key case is *not* silent — a
+            verification-failure entry is written into ``chaos_report``
+            naming the missing key + the available keys, so a typo'd
+            cross-reference shows up on the run record (not just in the
+            log).
+        """
+        if not verify_ref:
+            return None
+        node = self.verification_mapping.get(verify_ref)
+        if node is None:
+            known = sorted(self.verification_mapping.keys())
+            reason = (
+                f"chaos verify reference {verify_ref!r} not found in "
+                f"verification mapping; known keys: {known}"
+            )
+            _log.warning(reason)
+            # Surface the unresolved reference on the chaos_report so the
+            # operator sees the typo'd cross-reference in results.json, not
+            # just in the log. The shape mirrors the typed
+            # VerificationResult dump (success/reason/name) so downstream
+            # consumers don't need a special-case parse path.
+            self.result_holder["chaos_report"]["verification"] = {
+                "success": False,
+                "reason": reason,
+                "name": verify_ref,
+                "unresolved_reference": verify_ref,
+                "known_references": known,
+            }
+            return None
+        return node
+
+    def get_reports(self) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Return the aggregated chaos and performance reports.
+
+        Returns:
+            A ``(chaos_report, perf_report)`` pair derived from the most recent
+            scenario run; each is an empty dict before the run produces it.
+        """
+        return (
+            self.result_holder.get("chaos_report", {}),
+            self.result_holder.get("perf_report", {}),
+        )
+
+    def stop(self) -> None:
+        """Abort the scenario so a pending verification is skipped.
+
+        Sets an abort flag the scenario thread checks before dispatching
+        verification. The ``kubectl port-forward`` is owned by the load fault
+        (which tears it down in its own ``finally``), so there is nothing for
+        the manager to release here. Safe to call more than once and from a
+        different thread than the scenario's; it never raises, so it can run
+        from a ``finally`` block during cleanup.
+        """
+        self._aborted.set()

--- a/devops_bench/metrics/__init__.py
+++ b/devops_bench/metrics/__init__.py
@@ -1,0 +1,63 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLM-as-judge scoring for benchmark runs.
+
+The public extension surface is :data:`METRICS` (the registry), :class:`MetricScore`,
+:class:`MetricContext`, and :func:`run_geval`. The batch entry point
+:func:`evaluate_metrics_batch` consumes the registry; concrete metric modules
+self-register on import. Importing this package pulls ``deepeval``, but never a
+provider SDK — those stay lazy in the models layer.
+"""
+
+from __future__ import annotations
+
+from devops_bench.metrics.base import (
+    METRICS,
+    MetricContext,
+    MetricEvaluator,
+    MetricScore,
+    run_geval,
+)
+from devops_bench.metrics.chaos_metrics import evaluate_chaos_metrics
+from devops_bench.metrics.geval import ModelLayerJudge, get_judge_model
+from devops_bench.metrics.grounding import (
+    calculate_doc_retrieval_rate,
+    evaluate_documentation_grounding,
+)
+from devops_bench.metrics.outcome_validity import build_outcome_validity_metric
+from devops_bench.metrics.pipeline import (
+    CHECKLIST_THRESHOLD,
+    evaluate_metrics_batch,
+    extract_checklist_items,
+)
+from devops_bench.metrics.tool_invocation import build_tool_invocation_metric
+
+__all__ = [
+    "CHECKLIST_THRESHOLD",
+    "METRICS",
+    "MetricContext",
+    "MetricEvaluator",
+    "MetricScore",
+    "ModelLayerJudge",
+    "build_outcome_validity_metric",
+    "build_tool_invocation_metric",
+    "calculate_doc_retrieval_rate",
+    "evaluate_chaos_metrics",
+    "evaluate_documentation_grounding",
+    "evaluate_metrics_batch",
+    "extract_checklist_items",
+    "get_judge_model",
+    "run_geval",
+]

--- a/devops_bench/metrics/_skills.py
+++ b/devops_bench/metrics/_skills.py
@@ -1,0 +1,45 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Load judge skill markdown packaged under ``devops_bench/skills``."""
+
+from __future__ import annotations
+
+from importlib import resources
+
+__all__ = ["SKILLS_PACKAGE", "load_skill_text"]
+
+# Package (not a filesystem path) holding the judge skill markdown as package
+# data, so the files resolve under ``pip install`` / wheels, not just the repo.
+SKILLS_PACKAGE = "devops_bench.skills"
+
+
+def load_skill_text(filename: str) -> str:
+    """Read a judge skill markdown file from the ``devops_bench.skills`` package.
+
+    Args:
+        filename: Skill file name, e.g. ``"outcome-validity-checklist.md"``.
+
+    Returns:
+        The full markdown text used as a GEval criteria.
+
+    Raises:
+        FileNotFoundError: If the skill file is not present in the package.
+    """
+    resource = resources.files(SKILLS_PACKAGE) / filename
+    if not resource.is_file():
+        raise FileNotFoundError(
+            f"Judge skill {filename!r} not found in package {SKILLS_PACKAGE!r}"
+        )
+    return resource.read_text(encoding="utf-8")

--- a/devops_bench/metrics/base.py
+++ b/devops_bench/metrics/base.py
@@ -26,12 +26,18 @@ if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from deepeval.test_case import LLMTestCase
 
 __all__ = [
+    "GEVAL_PASS_THRESHOLD",
     "METRICS",
     "MetricContext",
     "MetricEvaluator",
     "MetricScore",
     "run_geval",
 ]
+
+# Default pass cutoff for a single GEval judgment. DeepEval's own default is
+# 0.5; the builtin metrics deliberately score at 0.8, so every GEval-backed
+# metric passes this explicitly rather than inheriting the looser SDK default.
+GEVAL_PASS_THRESHOLD = 0.8
 
 # Entry-point discovery lets external packages add metrics.
 METRICS: Registry[type[MetricEvaluator]] = Registry(

--- a/devops_bench/metrics/base.py
+++ b/devops_bench/metrics/base.py
@@ -1,0 +1,152 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Core extension surface for metrics: registry, typed score, run context."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from devops_bench.core import Registry
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from deepeval.test_case import LLMTestCase
+
+__all__ = [
+    "METRICS",
+    "MetricContext",
+    "MetricEvaluator",
+    "MetricScore",
+    "run_geval",
+]
+
+# Entry-point discovery lets external packages add metrics.
+METRICS: Registry[type[MetricEvaluator]] = Registry(
+    "metrics", entry_point_group="devops_bench.metrics"
+)
+
+
+@dataclass
+class MetricScore:
+    """One score entry produced by a metric evaluator.
+
+    Attributes:
+        name: Score key written into ``res["scores"]``.
+        score: Numeric score, or ``None`` for metrics that only report success.
+        success: Pass/fail flag; ``None`` for bare-value metrics (rates / perf
+            passthroughs).
+        reason: Human-readable explanation, when the metric produced one.
+    """
+
+    name: str
+    score: float | None
+    success: bool | None = None
+    reason: str | None = None
+
+    def to_entry(self) -> dict[str, Any] | float | None:
+        """Serialize into the ``results.json`` score shape.
+
+        Returns:
+            The dict form for judged metrics, or the bare value when both
+            ``success`` and ``reason`` are ``None``.
+
+        Example:
+            >>> MetricScore("DocRetrievalRate", 0.5).to_entry()
+            0.5
+            >>> MetricScore(
+            ...     "OutcomeValidity", 1.0, success=True, reason="ok"
+            ... ).to_entry()
+            {'score': 1.0, 'success': True, 'reason': 'ok'}
+        """
+        if self.success is None and self.reason is None:
+            return self.score
+        return {"score": self.score, "success": self.success, "reason": self.reason}
+
+
+@dataclass
+class MetricContext:
+    """Everything a metric needs to score one execution result.
+
+    Attributes:
+        result: The raw execution result dict.
+        judge: A ``DeepEvalBaseLLM`` judge model.
+        use_mcp: Whether the run was granted MCP tool capabilities.
+        outcome_case: The outcome-focused ``LLMTestCase``.
+        tool_case: The tools-and-trajectory ``LLMTestCase``.
+        all_case: The combined (text + trace) ``LLMTestCase``.
+    """
+
+    result: dict[str, Any]
+    judge: Any
+    use_mcp: bool
+    outcome_case: LLMTestCase
+    tool_case: LLMTestCase
+    all_case: LLMTestCase
+
+
+@runtime_checkable
+class MetricEvaluator(Protocol):
+    """A self-registering metric family.
+
+    Concrete evaluators are registered via ``@METRICS.register("<key>")`` and
+    implement two methods: :meth:`applies` (gate) and :meth:`evaluate` (yield
+    zero or more :class:`MetricScore`).
+
+    Attributes:
+        name: Identifier used in logs; per-score keys come from each
+            :class:`MetricScore`'s ``name`` instead.
+    """
+
+    name: str
+
+    def applies(self, ctx: MetricContext) -> bool:
+        """Whether this metric runs for the given result."""
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        """Produce zero or more score entries for the result."""
+
+
+def run_geval(case: LLMTestCase, metrics: list[Any]) -> list[MetricScore]:
+    """Evaluate GEval ``metrics`` against ``case`` and return clean scores.
+
+    The trailing ``" [GEval]"`` suffix DeepEval appends to GEval metric names is
+    stripped from the resulting score keys.
+
+    Args:
+        case: The test case to score.
+        metrics: GEval metric instances to evaluate against ``case``.
+
+    Returns:
+        One :class:`MetricScore` per metric reported by DeepEval.
+    """
+    # ``deepeval`` is imported lazily so ``import devops_bench.metrics.base``
+    # (and the registry registrations it triggers) never pulls the SDK.
+    from deepeval import evaluate
+
+    out: list[MetricScore] = []
+    result = evaluate([case], metrics=metrics)
+    for test_result in result.test_results:
+        for md in test_result.metrics_data:
+            name = md.name[:-8] if md.name.endswith(" [GEval]") else md.name
+            out.append(
+                MetricScore(
+                    name=name,
+                    score=md.score,
+                    success=md.success,
+                    reason=getattr(md, "reason", None),
+                )
+            )
+    return out

--- a/devops_bench/metrics/chaos_metrics.py
+++ b/devops_bench/metrics/chaos_metrics.py
@@ -1,0 +1,144 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chaos-mode scoring: diagnosis/recovery GEval plus performance numbers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+from devops_bench.core import get_logger
+from devops_bench.metrics.base import (
+    METRICS,
+    MetricContext,
+    MetricScore,
+    run_geval,
+)
+
+__all__ = ["ChaosMetric", "evaluate_chaos_metrics"]
+
+_log = get_logger("metrics.chaos_metrics")
+
+_DEFAULT_FAULT = "pod deletion"
+
+
+def evaluate_chaos_metrics(
+    all_test_case: LLMTestCase,
+    judge_model: Any,
+    chaos_report: dict[str, Any],
+    perf_report: dict[str, Any],
+    scores: dict[str, Any],
+) -> None:
+    """Score chaos diagnosis/recovery and record performance numbers.
+
+    Runs the ``DiagnosisAccuracy`` and ``GracefulRecovery`` GEval metrics against
+    ``all_test_case`` and copies the raw performance figures from ``perf_report``
+    into ``scores`` in place. This operates purely on the report dicts handed in;
+    it never inspects or imports the chaos package.
+
+    Args:
+        all_test_case: The combined test case (text output + trace) to judge.
+        judge_model: A ``DeepEvalBaseLLM`` judge model.
+        chaos_report: Chaos run report; ``injected_fault`` keys the diagnosis
+            criteria (defaults to ``"pod deletion"``).
+        perf_report: Performance report with ``deployment_time_seconds``,
+            ``uptime_percentage``, and ``resource_utilization_efficiency``.
+        scores: Mutable scores dict updated in place.
+    """
+    _log.info("Evaluating Planned Chaos Mode and Performance metrics...")
+    actual_fault = chaos_report.get("injected_fault", _DEFAULT_FAULT)
+
+    diag_metric = GEval(
+        name="DiagnosisAccuracy",
+        criteria=(
+            "Did the agent accurately identify that the fault injected was"
+            f" '{actual_fault}'?"
+        ),
+        evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+        model=judge_model,
+    )
+
+    rec_metric = GEval(
+        name="GracefulRecovery",
+        criteria=(
+            "Did the agent follow a graceful recovery process (e.g., maintaining"
+            " uptime, zero downtime)?"
+        ),
+        evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+        model=judge_model,
+    )
+
+    try:
+        for ms in run_geval(all_test_case, [diag_metric, rec_metric]):
+            scores[ms.name] = ms.to_entry()
+    except Exception as e:  # noqa: BLE001 - scoring must survive a judge failure
+        _log.error("Error evaluating chaos metrics: %s", e)
+
+    scores["Workload_Deployment_Time_Seconds"] = perf_report.get(
+        "deployment_time_seconds"
+    )
+    scores["Workload_Uptime_Percentage"] = perf_report.get("uptime_percentage")
+    scores["Resource_Utilization_Efficiency"] = perf_report.get(
+        "resource_utilization_efficiency"
+    )
+
+
+@METRICS.register("chaos")
+class ChaosMetric:
+    """Registered evaluator for chaos diagnosis + recovery + perf passthroughs.
+
+    Runs only when the result carries a ``chaos_spec``. Yields the
+    DiagnosisAccuracy / GracefulRecovery judged scores plus the three bare-value
+    performance passthroughs.
+
+    Attributes:
+        name: Identifier for logging; per-score keys come from each yielded
+            :class:`MetricScore`.
+    """
+
+    name = "chaos"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        """Run only when the harness recorded a chaos spec on the result."""
+        return bool(ctx.result.get("chaos_spec"))
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        """Score diagnosis/recovery and pass perf numbers through verbatim."""
+        scores: dict[str, Any] = {}
+        evaluate_chaos_metrics(
+            ctx.all_case,
+            ctx.judge,
+            ctx.result.get("chaos_report", {}),
+            ctx.result.get("perf_report", {}),
+            scores,
+        )
+        out: list[MetricScore] = []
+        for name, entry in scores.items():
+            if isinstance(entry, dict):
+                out.append(
+                    MetricScore(
+                        name=name,
+                        score=entry.get("score"),
+                        success=entry.get("success"),
+                        reason=entry.get("reason"),
+                    )
+                )
+            else:
+                # Bare-value perf passthroughs (None when missing).
+                out.append(MetricScore(name=name, score=entry))
+        return out

--- a/devops_bench/metrics/checklist.py
+++ b/devops_bench/metrics/checklist.py
@@ -29,6 +29,7 @@ from deepeval.test_case import SingleTurnParams
 
 from devops_bench.core import get_logger
 from devops_bench.metrics.base import (
+    GEVAL_PASS_THRESHOLD,
     METRICS,
     MetricContext,
     MetricScore,
@@ -123,6 +124,7 @@ class ChecklistMetric:
                     "Verify that the actual output fulfills this specific"
                     f" requirement: {item}"
                 ),
+                threshold=GEVAL_PASS_THRESHOLD,
                 evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
                 model=ctx.judge,
             )

--- a/devops_bench/metrics/checklist.py
+++ b/devops_bench/metrics/checklist.py
@@ -1,0 +1,154 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-requirement checklist metric and its expected-output parser.
+
+Scores each ``-`` bulleted "Critical Requirements" item from a task's expected
+output with its own GEval and emits the aggregate ``ChecklistScore``. Registered
+under the ``checklist`` key; the batch pipeline picks it up via :data:`METRICS`.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+from deepeval.metrics import GEval
+from deepeval.test_case import SingleTurnParams
+
+from devops_bench.core import get_logger
+from devops_bench.metrics.base import (
+    METRICS,
+    MetricContext,
+    MetricScore,
+    run_geval,
+)
+
+__all__ = [
+    "CHECKLIST_THRESHOLD",
+    "ChecklistMetric",
+    "extract_checklist_items",
+]
+
+_log = get_logger("metrics.checklist")
+
+# Per-task checklist pass cutoff.
+CHECKLIST_THRESHOLD = 0.8
+
+
+def extract_checklist_items(expected_output: str, use_mcp: bool) -> list[str]:
+    """Parse per-requirement checklist items from an expected-output string.
+
+    Items are the ``-`` bulleted lines inside the "Critical Requirements" section
+    (everything before an "Expected Manifest Generated" marker). When MCP is
+    disabled, "expected tool call" requirements are dropped since the agent has
+    no tools to invoke.
+
+    Args:
+        expected_output: The task's expected-output text.
+        use_mcp: Whether the run used MCP tools.
+
+    Returns:
+        The cleaned list of requirement strings (bullet markers stripped).
+    """
+    reqs_section = expected_output
+    if "critical requirements:" in reqs_section.lower():
+        parts = re.split(r"(?i)critical requirements\s*:", reqs_section, maxsplit=1)
+        if len(parts) > 1:
+            reqs_section = parts[1]
+
+    if "expected manifest generated:" in reqs_section.lower():
+        parts = re.split(
+            r"(?i)expected manifest generated\s*:", reqs_section, maxsplit=1
+        )
+        reqs_section = parts[0]
+
+    # Strip only the leading "- " bullet; ``str.strip("- ")`` would also eat
+    # trailing hyphens and corrupt items like "...staging-".
+    raw_checklist_items = [
+        line.lstrip("- ").strip()
+        for line in reqs_section.split("\n")
+        if line.strip().startswith("-")
+    ]
+    checklist_items = []
+    for item in raw_checklist_items:
+        if not use_mcp and "expected tool call" in item.lower():
+            _log.info("Skipping Expected Tool Call criteria: '%s'", item)
+            continue
+        checklist_items.append(item)
+    return checklist_items
+
+
+@METRICS.register("checklist")
+class ChecklistMetric:
+    """Registered evaluator scoring per-requirement checklist items.
+
+    For each parsed checklist item the evaluator builds a per-item ``Check: …``
+    GEval, scores it, and emits the aggregate ``ChecklistScore`` using
+    :data:`CHECKLIST_THRESHOLD` as the pass cutoff.
+
+    Attributes:
+        name: Identifier for logging; per-score keys come from each yielded
+            :class:`MetricScore`.
+    """
+
+    name = "checklist"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        """Run only when the result's ``expected_output`` carries bullets."""
+        return bool(
+            extract_checklist_items(ctx.result.get("expected_output", ""), ctx.use_mcp)
+        )
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        """Score each requirement and emit the aggregate ChecklistScore."""
+        items = extract_checklist_items(
+            ctx.result.get("expected_output", ""), ctx.use_mcp
+        )
+        dynamic_metrics = [
+            GEval(
+                name=f"Check: {item}",
+                criteria=(
+                    "Verify that the actual output fulfills this specific"
+                    f" requirement: {item}"
+                ),
+                evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+                model=ctx.judge,
+            )
+            for item in items
+        ]
+
+        out: list[MetricScore] = []
+        passed = 0
+        total = len(dynamic_metrics)
+        for m in dynamic_metrics:
+            try:
+                _log.info("Evaluating metric: %s...", m.name)
+                for ms in run_geval(ctx.all_case, [m]):
+                    out.append(ms)
+                    if ms.success:
+                        passed += 1
+            except Exception as e:  # noqa: BLE001 - keep scoring the rest
+                _log.error("Error evaluating metric %s: %s", m.name, e)
+
+        ratio = passed / total if total > 0 else 0.0
+        out.append(
+            MetricScore(
+                name="ChecklistScore",
+                score=ratio,
+                success=ratio >= CHECKLIST_THRESHOLD if total > 0 else False,
+                reason=f"Passed {passed} out of {total} checks.",
+            )
+        )
+        return out

--- a/devops_bench/metrics/geval.py
+++ b/devops_bench/metrics/geval.py
@@ -1,0 +1,127 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provider-agnostic DeepEval judge backed by the models layer."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+from deepeval.models import DeepEvalBaseLLM
+
+from devops_bench.core import get_env, get_logger
+from devops_bench.models import LLMClient, get_model
+
+__all__ = ["ModelLayerJudge", "get_judge_model"]
+
+_log = get_logger("metrics.geval")
+
+
+class ModelLayerJudge(DeepEvalBaseLLM):
+    """DeepEval judge that routes generation through the models layer.
+
+    Routes generation through an :class:`~devops_bench.models.LLMClient`
+    (the models layer), so the judge is provider-agnostic. Judge prompts are
+    text-only: generation issues a single user turn with no tools and returns
+    the response's text content.
+
+    Args:
+        client: Pre-built LLM client to wrap. When omitted, one is constructed
+            from ``provider``/``model_name`` (or the ``JUDGE_PROVIDER`` /
+            ``JUDGE_MODEL`` environment variables) via ``get_model``.
+        provider: Provider key forwarded to ``get_model`` when ``client`` is not
+            supplied. Falls back to the ``JUDGE_PROVIDER`` environment variable.
+        model_name: Model override forwarded to ``get_model`` when ``client`` is
+            not supplied. Falls back to the ``JUDGE_MODEL`` environment variable.
+    """
+
+    def __init__(
+        self,
+        client: LLMClient | None = None,
+        *,
+        provider: str | None = None,
+        model_name: str | None = None,
+    ) -> None:
+        if client is None:
+            provider = provider or get_env("JUDGE_PROVIDER")
+            model_name = model_name or get_env("JUDGE_MODEL")
+            client = get_model(provider=provider, model_name=model_name)
+        self.client = client
+        # Mirror the adapter's resolved model name so DeepEval can label results.
+        self._model_name = model_name or getattr(client, "model_name", None) or "judge"
+
+    def load_model(self) -> LLMClient:
+        """Return the wrapped LLM client (DeepEval contract)."""
+        return self.client
+
+    async def a_generate(self, prompt: str) -> str:
+        """Generate judge text for ``prompt`` asynchronously.
+
+        Args:
+            prompt: The fully rendered judge prompt.
+
+        Returns:
+            The model's text response, or an empty string when none was produced.
+        """
+        response = await self.client.generate_content(
+            contents=[{"role": "user", "content": prompt}],
+            tools=None,
+            system_instruction=None,
+        )
+        return self.client.get_text_content(response) or ""
+
+    def generate(self, prompt: str) -> str:
+        """Generate judge text for ``prompt`` synchronously.
+
+        Runs the async :meth:`a_generate` to completion. This is loop-aware: when
+        called from outside an event loop it uses :func:`asyncio.run`; when an
+        event loop is already running on the calling thread (``asyncio.run`` would
+        raise there) it runs the coroutine on a separate worker thread and blocks
+        for the result.
+
+        Args:
+            prompt: The fully rendered judge prompt.
+
+        Returns:
+            The model's text response, or an empty string when none was produced.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.a_generate(prompt))
+
+        # A loop is already running on this thread; offload to a worker thread
+        # that owns its own loop so we never call asyncio.run() re-entrantly.
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(lambda: asyncio.run(self.a_generate(prompt))).result()
+
+    def get_model_name(self) -> str:
+        """Return the configured judge model name (DeepEval contract)."""
+        return self._model_name
+
+
+def get_judge_model(
+    provider: str | None = None, model_name: str | None = None
+) -> ModelLayerJudge:
+    """Build the default judge model from configuration.
+
+    Args:
+        provider: Provider key; falls back to ``JUDGE_PROVIDER``.
+        model_name: Model override; falls back to ``JUDGE_MODEL``.
+
+    Returns:
+        A :class:`ModelLayerJudge` wrapping the selected provider's client.
+    """
+    return ModelLayerJudge(provider=provider, model_name=model_name)

--- a/devops_bench/metrics/grounding.py
+++ b/devops_bench/metrics/grounding.py
@@ -1,0 +1,231 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Documentation grounding metrics: constraint GEval scoring and retrieval rate."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Any
+
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+from devops_bench.core import get_logger
+from devops_bench.metrics.base import (
+    METRICS,
+    MetricContext,
+    MetricScore,
+    run_geval,
+)
+
+__all__ = [
+    "GroundingMetric",
+    "calculate_doc_retrieval_rate",
+    "evaluate_documentation_grounding",
+]
+
+_log = get_logger("metrics.grounding")
+
+
+def calculate_doc_retrieval_rate(
+    documentation: list[dict[str, Any]], trajectory: list[Any]
+) -> float:
+    """Compute the fraction of mapped documentation guides seen in a trajectory.
+
+    A guide counts as accessed when its ``doc_name`` or ``url`` (case-insensitive)
+    appears anywhere in the JSON-serialized trajectory steps.
+
+    Args:
+        documentation: Mapped guides, each with ``doc_name`` and ``url`` keys.
+        trajectory: Agent execution steps (any JSON-serializable objects).
+
+    Returns:
+        The accessed fraction in ``[0.0, 1.0]``; ``0.0`` when there is no
+        documentation.
+    """
+    if not documentation:
+        return 0.0
+
+    # Serialize each step once up front rather than re-serializing the whole
+    # trajectory for every documentation guide (it does not depend on the doc).
+    step_strs = [json.dumps(step).lower() for step in trajectory]
+
+    accessed_docs = set()
+    for doc in documentation:
+        doc_name = doc.get("doc_name") or ""
+        doc_name_lower = doc_name.lower()
+        url_lower = (doc.get("url") or "").lower()
+        found_in_trajectory = False
+        for step_str in step_strs:
+            # Guard both substrings on truthiness so a missing name/url (now "")
+            # does not spuriously match every step (``"" in s`` is always True).
+            if (doc_name_lower and doc_name_lower in step_str) or (
+                url_lower and url_lower in step_str
+            ):
+                found_in_trajectory = True
+                break
+        if found_in_trajectory:
+            accessed_docs.add(doc_name)
+
+    return len(accessed_docs) / len(documentation)
+
+
+def evaluate_documentation_grounding(
+    documentation: list[dict[str, Any]],
+    all_test_case: LLMTestCase,
+    judge_model: Any,
+    scores: dict[str, Any],
+) -> None:
+    """Score documentation constraints via GEval and derive GroundingAccuracy.
+
+    Each documented constraint becomes a GEval metric evaluated against
+    ``all_test_case``. Per-constraint results, an aggregate ``GroundingAccuracy``
+    (5.0/2.5/0.0 banded by critical-constraint coverage), and
+    ``ParameterRecallAccuracy`` are written into ``scores`` in place.
+
+    Args:
+        documentation: Guides, each with a ``constraints`` list of
+            ``{"text": str, "critical": bool}`` entries.
+        all_test_case: The combined test case (text output + trace) to judge.
+        judge_model: A ``DeepEvalBaseLLM`` judge model.
+        scores: Mutable scores dict updated in place.
+    """
+    # Deduplicate constraints by text first so two guides sharing the same
+    # constraint produce a single metric; otherwise total > unique and a
+    # perfect 5.0 (applied == total) becomes unreachable.
+    doc_constraints_map: dict[str, bool] = {}
+    for doc in documentation:
+        for constraint in doc.get("constraints", []):
+            doc_constraints_map[constraint["text"]] = constraint["critical"]
+
+    doc_metrics = [
+        GEval(
+            name=f"Doc Constraint: {c_text}",
+            criteria=(
+                "Verify that the actual output fulfills this specific"
+                f" documentation constraint/requirement: {c_text}"
+            ),
+            evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+            model=judge_model,
+        )
+        for c_text in doc_constraints_map
+    ]
+
+    if not doc_metrics:
+        return
+
+    _log.info(
+        "Evaluating %d documentation constraint metrics sequentially...",
+        len(doc_metrics),
+    )
+    for m in doc_metrics:
+        try:
+            _log.info("Evaluating doc metric: %s...", m.name)
+            for ms in run_geval(all_test_case, [m]):
+                scores[ms.name] = ms.to_entry()
+        except Exception as e:  # noqa: BLE001 - one bad metric must not abort scoring
+            _log.error("Error evaluating doc metric %s: %s", m.name, e)
+
+    total_constraints = len(doc_metrics)
+    applied_constraints = 0
+    critical_total = sum(1 for crit in doc_constraints_map.values() if crit)
+    critical_applied = 0
+
+    for c_text, c_crit in doc_constraints_map.items():
+        m_name = f"Doc Constraint: {c_text}"
+        entry = scores.get(m_name)
+        # ``entry`` is the judged-shape dict; bail safely on a missing/malformed
+        # entry (the per-constraint scoring above logged the failure).
+        if isinstance(entry, dict) and entry.get("success"):
+            applied_constraints += 1
+            if c_crit:
+                critical_applied += 1
+
+    # Banded grounding score: 5.0 (Success), 2.5 (Partial), 0.0 (Failure). The
+    # early return above guarantees ``total_constraints > 0`` and
+    # ``applied <= total``, and any unmet critical constraint takes the Partial
+    # branch before non-critical analysis runs, so ``non_critical_total`` is
+    # never zero in the final branch.
+    if applied_constraints == total_constraints:
+        grounding_score = 5.0
+    elif applied_constraints == 0:
+        grounding_score = 0.0
+    elif critical_applied < critical_total:
+        grounding_score = 2.5
+    else:
+        non_critical_total = total_constraints - critical_total
+        non_critical_applied = applied_constraints - critical_applied
+        grounding_score = 2.5 + 2.5 * (non_critical_applied / non_critical_total)
+
+    recall_accuracy = applied_constraints / total_constraints
+
+    scores["GroundingAccuracy"] = {
+        "score": grounding_score,
+        "success": grounding_score >= 4.0,
+        "reason": (
+            f"Applied {applied_constraints} out of {total_constraints} documented"
+            f" constraints (Critical: {critical_applied}/{critical_total})."
+        ),
+    }
+    scores["ParameterRecallAccuracy"] = recall_accuracy
+
+
+@METRICS.register("grounding")
+class GroundingMetric:
+    """Registered evaluator for documentation grounding + retrieval rate.
+
+    Runs only when the result carries mapped ``documentation``. Yields
+    per-constraint judged scores, the aggregate ``GroundingAccuracy``, plus the
+    bare-value ``ParameterRecallAccuracy`` and ``DocRetrievalRate`` passthroughs.
+
+    Attributes:
+        name: Identifier for logging; per-score keys come from each yielded
+            :class:`MetricScore`.
+    """
+
+    name = "grounding"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        """Run only when the harness recorded mapped documentation."""
+        return bool(ctx.result.get("documentation"))
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        """Score grounding constraints and derive the doc-retrieval rate."""
+        documentation = ctx.result.get("documentation", [])
+        scores: dict[str, Any] = {}
+        evaluate_documentation_grounding(
+            documentation, ctx.all_case, ctx.judge, scores
+        )
+        retrieval_rate = calculate_doc_retrieval_rate(
+            documentation, ctx.result.get("trajectory", [])
+        )
+
+        out: list[MetricScore] = []
+        for name, entry in scores.items():
+            if isinstance(entry, dict):
+                out.append(
+                    MetricScore(
+                        name=name,
+                        score=entry.get("score"),
+                        success=entry.get("success"),
+                        reason=entry.get("reason"),
+                    )
+                )
+            else:
+                # Bare-value entry (e.g. ParameterRecallAccuracy).
+                out.append(MetricScore(name=name, score=entry))
+        out.append(MetricScore(name="DocRetrievalRate", score=retrieval_rate))
+        return out

--- a/devops_bench/metrics/grounding.py
+++ b/devops_bench/metrics/grounding.py
@@ -25,6 +25,7 @@ from deepeval.test_case import LLMTestCase, SingleTurnParams
 
 from devops_bench.core import get_logger
 from devops_bench.metrics.base import (
+    GEVAL_PASS_THRESHOLD,
     METRICS,
     MetricContext,
     MetricScore,
@@ -118,6 +119,7 @@ def evaluate_documentation_grounding(
                 "Verify that the actual output fulfills this specific"
                 f" documentation constraint/requirement: {c_text}"
             ),
+            threshold=GEVAL_PASS_THRESHOLD,
             evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
             model=judge_model,
         )

--- a/devops_bench/metrics/outcome_validity.py
+++ b/devops_bench/metrics/outcome_validity.py
@@ -24,6 +24,7 @@ from deepeval.test_case import SingleTurnParams
 from devops_bench.core import get_logger
 from devops_bench.metrics._skills import load_skill_text
 from devops_bench.metrics.base import (
+    GEVAL_PASS_THRESHOLD,
     METRICS,
     MetricContext,
     MetricScore,
@@ -61,11 +62,13 @@ def build_outcome_validity_metric(model) -> GEval:
         model: A ``DeepEvalBaseLLM`` judge model.
 
     Returns:
-        A configured :class:`~deepeval.metrics.GEval` instance.
+        A configured :class:`~deepeval.metrics.GEval` instance with the shared
+        :data:`GEVAL_PASS_THRESHOLD` pass cutoff applied.
     """
     return GEval(
         name="OutcomeValidity",
         criteria=load_outcome_criteria(),
+        threshold=GEVAL_PASS_THRESHOLD,
         evaluation_params=[
             SingleTurnParams.INPUT,
             SingleTurnParams.ACTUAL_OUTPUT,

--- a/devops_bench/metrics/outcome_validity.py
+++ b/devops_bench/metrics/outcome_validity.py
@@ -1,0 +1,93 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OutcomeValidity GEval metric and its checklist skill loading."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from deepeval.metrics import GEval
+from deepeval.test_case import SingleTurnParams
+
+from devops_bench.core import get_logger
+from devops_bench.metrics._skills import load_skill_text
+from devops_bench.metrics.base import (
+    METRICS,
+    MetricContext,
+    MetricScore,
+    run_geval,
+)
+
+__all__ = [
+    "OUTCOME_SKILL_FILENAME",
+    "OutcomeValidityMetric",
+    "build_outcome_validity_metric",
+    "load_outcome_criteria",
+]
+
+OUTCOME_SKILL_FILENAME = "outcome-validity-checklist.md"
+
+_log = get_logger("metrics.outcome_validity")
+
+
+def load_outcome_criteria() -> str:
+    """Read the outcome-validity checklist skill packaged with the project.
+
+    Returns:
+        The full markdown text used as the GEval criteria.
+
+    Raises:
+        FileNotFoundError: If the packaged skill file is missing.
+    """
+    return load_skill_text(OUTCOME_SKILL_FILENAME)
+
+
+def build_outcome_validity_metric(model) -> GEval:
+    """Build the OutcomeValidity GEval metric.
+
+    Args:
+        model: A ``DeepEvalBaseLLM`` judge model.
+
+    Returns:
+        A configured :class:`~deepeval.metrics.GEval` instance.
+    """
+    return GEval(
+        name="OutcomeValidity",
+        criteria=load_outcome_criteria(),
+        evaluation_params=[
+            SingleTurnParams.INPUT,
+            SingleTurnParams.ACTUAL_OUTPUT,
+        ],
+        model=model,
+    )
+
+
+@METRICS.register("outcome_validity")
+class OutcomeValidityMetric:
+    """Registered evaluator that scores OutcomeValidity for every result.
+
+    Attributes:
+        name: Score key written into ``res["scores"]``.
+    """
+
+    name = "OutcomeValidity"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        """Always applies — every run is scored against outcome validity."""
+        return True
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        """Score the outcome-validity GEval against the outcome test case."""
+        return run_geval(ctx.outcome_case, [build_outcome_validity_metric(ctx.judge)])

--- a/devops_bench/metrics/pipeline.py
+++ b/devops_bench/metrics/pipeline.py
@@ -74,12 +74,17 @@ def _build_context(
     Returns:
         A populated :class:`MetricContext` with the three test cases built once.
     """
+    # ``input`` / ``output`` / ``expected_output`` are the minimum a judge needs
+    # and are always written by the harness. The trajectory / latency /
+    # retrieval-context fields default to empty so a slimmer external result dict
+    # degrades to an unscored case rather than raising an uncaught ``KeyError``
+    # here (before the per-metric ``try`` in the batch loop).
     prompt = res["input"]
     actual_output = res["output"]
-    trajectory = res["trajectory"]
     expected_output = res["expected_output"]
-    latency = res["latency"]
-    retrieval_context = res["retrieval_context"]
+    trajectory = res.get("trajectory", [])
+    latency = res.get("latency")
+    retrieval_context = res.get("retrieval_context")
 
     outcome_case = LLMTestCase(
         input=prompt,
@@ -136,10 +141,11 @@ def evaluate_metrics_batch(
     given result, and one failing metric never aborts the rest.
 
     Args:
-        detailed_results: Execution result dicts, each with ``input``,
-            ``output``, ``trajectory``, ``expected_output``, ``latency``,
-            ``name``, ``retrieval_context``, and optional ``documentation`` /
-            ``chaos_spec`` / ``chaos_report`` / ``perf_report`` / ``tools`` keys.
+        detailed_results: Execution result dicts. ``input``, ``output``, and
+            ``expected_output`` are required; ``trajectory``, ``latency``,
+            ``retrieval_context``, ``name``, ``documentation``, ``chaos_spec`` /
+            ``chaos_report`` / ``perf_report``, and ``tools`` are optional and
+            default to empty when absent.
         judge_model: A ``DeepEvalBaseLLM`` judge model.
         use_mcp: Whether the harness granted MCP tool capabilities. ``None``
             falls back to the ``BENCH_USE_MCP`` env var.

--- a/devops_bench/metrics/pipeline.py
+++ b/devops_bench/metrics/pipeline.py
@@ -1,0 +1,174 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Batch scoring loop that turns execution results into per-task scores."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from deepeval.test_case import LLMTestCase
+
+from devops_bench.core import get_bool, get_logger
+
+# Imported for their @METRICS.register side effects.
+from devops_bench.metrics import (
+    chaos_metrics,  # noqa: F401
+    grounding,  # noqa: F401
+    outcome_validity,  # noqa: F401
+    tool_invocation,  # noqa: F401
+)
+from devops_bench.metrics.base import (
+    METRICS,
+    MetricContext,
+)
+
+# Re-exported for callers importing from this module.
+from devops_bench.metrics.checklist import (
+    CHECKLIST_THRESHOLD,
+    ChecklistMetric,
+    extract_checklist_items,
+)
+
+__all__ = [
+    "CHECKLIST_THRESHOLD",
+    "ChecklistMetric",
+    "evaluate_metrics_batch",
+    "extract_checklist_items",
+]
+
+_log = get_logger("metrics.pipeline")
+
+# Order in which builtin metric keys appear in results.json.
+_BUILTIN_METRIC_KEYS: tuple[str, ...] = (
+    "outcome_validity",
+    "tool_invocation",
+    "checklist",
+    "grounding",
+    "chaos",
+)
+
+
+def _build_context(
+    res: dict[str, Any], judge_model: Any, use_mcp: bool
+) -> MetricContext:
+    """Build the per-result :class:`MetricContext`, sharing test cases.
+
+    Args:
+        res: One execution result dict.
+        judge_model: A ``DeepEvalBaseLLM`` judge.
+        use_mcp: Whether the run was granted MCP capabilities.
+
+    Returns:
+        A populated :class:`MetricContext` with the three test cases built once.
+    """
+    prompt = res["input"]
+    actual_output = res["output"]
+    trajectory = res["trajectory"]
+    expected_output = res["expected_output"]
+    latency = res["latency"]
+    retrieval_context = res["retrieval_context"]
+
+    outcome_case = LLMTestCase(
+        input=prompt,
+        actual_output=actual_output if actual_output else "No response generated",
+        expected_output=expected_output,
+        retrieval_context=retrieval_context,
+        latency=latency,
+    )
+
+    combined_actual = {
+        "tools_used": res.get("tools", []),
+        "execution_trace": trajectory,
+    }
+    tool_case = LLMTestCase(
+        input=prompt,
+        actual_output=json.dumps(combined_actual, indent=2),
+        expected_output=expected_output,
+        latency=latency,
+    )
+
+    all_context = {
+        "tools_used": res.get("tools", []),
+        "execution_trace": trajectory,
+        "text_output": actual_output if actual_output else "No response generated",
+    }
+    all_case = LLMTestCase(
+        input=prompt,
+        actual_output=json.dumps(all_context, indent=2),
+        expected_output=expected_output,
+        latency=latency,
+    )
+
+    return MetricContext(
+        result=res,
+        judge=judge_model,
+        use_mcp=use_mcp,
+        outcome_case=outcome_case,
+        tool_case=tool_case,
+        all_case=all_case,
+    )
+
+
+def evaluate_metrics_batch(
+    detailed_results: list[dict[str, Any]],
+    judge_model: Any,
+    *,
+    use_mcp: bool | None = None,
+) -> None:
+    """Score a batch of execution results in place via the metrics registry.
+
+    Adding a metric is a new ``@METRICS.register(...)`` class in any metric
+    module — there is no orchestration surgery required here. Each registered
+    evaluator's :meth:`MetricEvaluator.applies` gates whether it runs for a
+    given result, and one failing metric never aborts the rest.
+
+    Args:
+        detailed_results: Execution result dicts, each with ``input``,
+            ``output``, ``trajectory``, ``expected_output``, ``latency``,
+            ``name``, ``retrieval_context``, and optional ``documentation`` /
+            ``chaos_spec`` / ``chaos_report`` / ``perf_report`` / ``tools`` keys.
+        judge_model: A ``DeepEvalBaseLLM`` judge model.
+        use_mcp: Whether the harness granted MCP tool capabilities. ``None``
+            falls back to the ``BENCH_USE_MCP`` env var.
+    """
+    _log.info("Starting batch post-processing evaluation metrics...")
+    if use_mcp is None:
+        use_mcp = get_bool("BENCH_USE_MCP", True)
+
+    builtin_keys = list(_BUILTIN_METRIC_KEYS)
+    builtin_set = set(builtin_keys)
+    # Builtin metrics in the pinned (results.json) order, then any third-party
+    # registrations in registry insertion order.
+    ordered_keys = builtin_keys + [k for k in METRICS if k not in builtin_set]
+    evaluators = [METRICS[k]() for k in ordered_keys]
+
+    for res in detailed_results:
+        ctx = _build_context(res, judge_model, use_mcp)
+        scores: dict[str, Any] = {}
+        _log.info("Evaluating metrics for: %s...", res.get("name"))
+        for ev in evaluators:
+            try:
+                if not ev.applies(ctx):
+                    continue
+                for ms in ev.evaluate(ctx):
+                    scores[ms.name] = ms.to_entry()
+            except Exception:  # noqa: BLE001 - one metric must not abort the rest
+                _log.exception(
+                    "metric %r failed for %s",
+                    getattr(ev, "name", ev),
+                    res.get("name"),
+                )
+        res["scores"] = scores

--- a/devops_bench/metrics/tool_invocation.py
+++ b/devops_bench/metrics/tool_invocation.py
@@ -1,0 +1,97 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ToolInvocation GEval metric and its skill loading."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from deepeval.metrics import GEval
+from deepeval.test_case import SingleTurnParams
+
+from devops_bench.core import get_logger
+from devops_bench.metrics._skills import load_skill_text
+from devops_bench.metrics.base import (
+    METRICS,
+    MetricContext,
+    MetricScore,
+    run_geval,
+)
+
+__all__ = [
+    "TOOL_SKILL_FILENAME",
+    "TOOL_INVOCATION_THRESHOLD",
+    "ToolInvocationMetric",
+    "build_tool_invocation_metric",
+    "load_tool_criteria",
+]
+
+TOOL_SKILL_FILENAME = "tool-invocation-skill.md"
+TOOL_INVOCATION_THRESHOLD = 0.8
+
+_log = get_logger("metrics.tool_invocation")
+
+
+def load_tool_criteria() -> str:
+    """Read the tool-invocation skill packaged with the project.
+
+    Returns:
+        The full markdown text used as the GEval criteria.
+
+    Raises:
+        FileNotFoundError: If the packaged skill file is missing.
+    """
+    return load_skill_text(TOOL_SKILL_FILENAME)
+
+
+def build_tool_invocation_metric(model) -> GEval:
+    """Build the ToolInvocation GEval metric.
+
+    Args:
+        model: A ``DeepEvalBaseLLM`` judge model.
+
+    Returns:
+        A configured :class:`~deepeval.metrics.GEval` instance with the
+        tool-invocation pass threshold applied.
+    """
+    return GEval(
+        name="ToolInvocation",
+        criteria=load_tool_criteria(),
+        threshold=TOOL_INVOCATION_THRESHOLD,
+        evaluation_params=[
+            SingleTurnParams.INPUT,
+            SingleTurnParams.ACTUAL_OUTPUT,
+        ],
+        model=model,
+    )
+
+
+@METRICS.register("tool_invocation")
+class ToolInvocationMetric:
+    """Registered evaluator scoring ToolInvocation when MCP is enabled.
+
+    Attributes:
+        name: Score key written into ``res["scores"]``.
+    """
+
+    name = "ToolInvocation"
+
+    def applies(self, ctx: MetricContext) -> bool:
+        """Run only when the harness has granted MCP capabilities to the agent."""
+        return ctx.use_mcp
+
+    def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+        """Score the tool-invocation GEval against the tool-trace test case."""
+        return run_geval(ctx.tool_case, [build_tool_invocation_metric(ctx.judge)])

--- a/devops_bench/skills/__init__.py
+++ b/devops_bench/skills/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Judge skill markdown shipped as package data (see ``metrics._skills``)."""

--- a/devops_bench/skills/outcome-validity-checklist.md
+++ b/devops_bench/skills/outcome-validity-checklist.md
@@ -1,0 +1,38 @@
+---
+name: outcome-validity-checklist
+description: Evaluates the outcome of an agent's task based on user intent and production readiness.
+---
+
+# Instructions
+
+You are an expert Kubernetes Reliability Engineer evaluating the final outcome of an
+agent's task. Your goal is to determine if the agent achieved the user's
+requested outcome and if the resulting state is production-ready.
+
+Ensure that you compare the AI assistant's actual output against the user's input prompt, and verify it meets the architectural requirements and manifestations explicitly outlined in the test case Expected Output field.
+The final score should be calculated in the format 'Total Score: X/N', where X is the number of passed requirements and N is the total number of requirements in the 'Expected Output' list.
+
+## Evaluation Criteria
+
+1. **Intent-Based Outcome Achievement**: Did the agent reach the user's specific goal?
+    - **Deployment Intent**: If the user asked to **deploy**, **apply**, or
+     **fix/change** something in the cluster, providing a manifest or a list of
+     shell commands (e.g., `kubectl apply...`) is a **SIGNIFICANT FAILURE**. The
+     agent must have actually invoked the tools to perform the action.
+    - **Instructional Intent**: If the user ONLY asked to **produce/generate** a manifest or "Show me how to deploy", then providing instructions is acceptable.
+2. **Semantic Integrity (Manifests)**: Compare the results against the Golden Manifest. Ensure architectural intent (ports, images, etc.) is met.
+3. **Execution Confirmation**: Does the response explicitly state that the change was successfully applied to the cluster, or does it merely describe what should be done?
+4. **Critical Facts**: Does the response fulfill all critical facts and requirements listed in the 'Critical Facts/Requirements' section?
+5. **Checklist Grading**:
+    - If the 'Expected Output' field contains a bulleted list of specific requirements, you MUST evaluate each requirement individually.
+    - You MUST output the results in the following EXACT format at the beginning of your 'reason' field:
+        - [x] Requirement 1: Reason for pass
+        - [ ] Requirement 2: Reason for fail
+    - Replace `Requirement 1` with the actual text of the requirement.
+    - Use `[x]` for passed and `[ ]` for failed.
+    - After the list, you MUST include a summary line: **'Total Score: X/N'** where X is the count of passed items and N is the total number of items.
+
+## Scoring Guidance
+- Provide the final score in the format 'Total Score: X/N', where X is the count of passed requirements and N is the total number of requirements in the 'Expected Output' list.
+- Do not use the 1-5 scale.
+- You MUST also include a line 'Status: PASS' if X/N >= 0.8 (80%), otherwise 'Status: FAIL'.

--- a/devops_bench/skills/outcome-validity-checklist.md
+++ b/devops_bench/skills/outcome-validity-checklist.md
@@ -10,7 +10,6 @@ agent's task. Your goal is to determine if the agent achieved the user's
 requested outcome and if the resulting state is production-ready.
 
 Ensure that you compare the AI assistant's actual output against the user's input prompt, and verify it meets the architectural requirements and manifestations explicitly outlined in the test case Expected Output field.
-The final score should be calculated in the format 'Total Score: X/N', where X is the number of passed requirements and N is the total number of requirements in the 'Expected Output' list.
 
 ## Evaluation Criteria
 
@@ -30,9 +29,7 @@ The final score should be calculated in the format 'Total Score: X/N', where X i
         - [ ] Requirement 2: Reason for fail
     - Replace `Requirement 1` with the actual text of the requirement.
     - Use `[x]` for passed and `[ ]` for failed.
-    - After the list, you MUST include a summary line: **'Total Score: X/N'** where X is the count of passed items and N is the total number of items.
 
-## Scoring Guidance
-- Provide the final score in the format 'Total Score: X/N', where X is the count of passed requirements and N is the total number of requirements in the 'Expected Output' list.
-- Do not use the 1-5 scale.
-- You MUST also include a line 'Status: PASS' if X/N >= 0.8 (80%), otherwise 'Status: FAIL'.
+This checklist shapes the explanation you return; the numeric pass/fail score is
+derived by the evaluation harness, so do not emit a `Total Score` or `Status`
+line of your own.

--- a/devops_bench/skills/tool-invocation-skill.md
+++ b/devops_bench/skills/tool-invocation-skill.md
@@ -1,0 +1,31 @@
+---
+name: tool-invocation
+description: Evaluates tool usage efficiency and correctness for a Kubernetes assistant.
+---
+
+## Instructions
+
+You are an expert Kubernetes assistant evaluator focusing on tool usage efficiency
+and correctness. Your goal is to evaluate the sequence of actions and tool
+calls the agent made to fulfill the request.
+
+NOTE: The test actual output (provided in the test case context) contains the agent's execution trace (internal reasoning and tool calls). Use this execution trace to evaluate efficiency and correctness.
+
+Compare the execution trace tool calls against any required tool calls explicitly mentioned in the test case Expected Output field (e.g., look for 'Expected Tool Call' or similar guidance strings).
+
+## Evaluation Criteria
+
+1.  **Tool Correctness**: Did the agent use the appropriate tools for the task?
+    Did it hallucinate tool names or parameters?
+2.  **Execution Efficiency**: Was the sequence of tool calls logical and
+    efficient? Did the agent get stuck in "loops" (repeatedly calling the same
+    tool with similar parameters and failing)?
+3.  **Plan Follow-through**: Did the agent's actions match its stated reasoning
+    (if any)?
+
+## Scoring Guidance
+- **5 (Completely)**: Perfect tool selection, efficient execution, and logical flow. No redundant calls.
+- **4 (Mostly)**: Correct tools were used, but there might have been one or two slightly inefficient or redundant steps.
+- **3 (Moderately)**: The agent eventually succeeded but took a very convoluted path or had a minor tool-call hallucination that it recovered from.
+- **2 (Somewhat)**: Major inefficiencies, logical loops, or multiple failed/hallucinated tool calls.
+- **1 (Not at all)**: Complete failure in tool selection, got stuck in an infinite loop, or fundamentally misunderstood how to use the available tools.

--- a/docs/migration/component-design.md
+++ b/docs/migration/component-design.md
@@ -154,7 +154,7 @@ To prevent circular import dependencies, the repository relies on a strict **lay
                            v
 +--------------------------------------------------------+
 |                      4. Engine                         |
-|                     (devops_bench/harness/)            |
+|                     (devops_bench/evalharness/)            |
 +--------------------------------------------------------+
                            |
                            v

--- a/docs/migration/directory-structure.md
+++ b/docs/migration/directory-structure.md
@@ -18,8 +18,8 @@ To prevent ambiguity, the codebase adheres to strict definitions for key framewo
 |------|------------|------------------|
 | **Task** | A benchmark scenario defining an intent, infrastructure requirements, and success verifications. | `tasks/` (YAML definitions) |
 | **Agent** | The AI system being evaluated. Powered by an **Agent Harness** adapter over a communication transport. | `devops_bench/agents/` |
-| **Evaluation Harness** | The execution pipeline that orchestrates the lifecycle of a task (provisioning, scenario startup, running the agent, teardown, scoring). | `devops_bench/harness/` |
-| **Scenario Manager** | A component within the evaluation harness that concurrently manages background chaos injection and checks. | `devops_bench/harness/scenario.py` |
+| **Evaluation Harness** | The execution pipeline that orchestrates the lifecycle of a task (provisioning, scenario startup, running the agent, teardown, scoring). | `devops_bench/evalharness/` |
+| **Scenario Manager** | A component within the evaluation harness that concurrently manages background chaos injection and checks. | `devops_bench/evalharness/scenario.py` |
 | **Chaos** | Fault injection configured as a combination of a **Trigger** (when) and a **Fault** (what). | `devops_bench/chaos/` |
 | **Verification** | Outcome assertions evaluated during or at the end of a scenario. Supports complex nested lists/dicts. | `devops_bench/verification/` |
 | **Metric / Judge** | Rubrics used to grade the agent's run trajectory, usually LLM-as-judge. | `devops_bench/metrics/` |
@@ -80,10 +80,10 @@ This table maps every significant path in the legacy `gke-labs` repository to it
 
 | Legacy Path (gke-labs) | Restructured Path (devops_bench) | Notes |
 |-----------------------|---------------------------------|-------|
-| `pkg/evaluator/evaluate.py` (Main loop) | `devops_bench/harness/{base,default,artifacts}.py` | Decomposed into pipeline phases |
+| `pkg/evaluator/evaluate.py` (Main loop) | `devops_bench/evalharness/{base,default,artifacts}.py` | Decomposed into pipeline phases |
 | `pkg/evaluator/evaluate.py` (Metrics) | `devops_bench/metrics/{pipeline,geval,outcome_validity,tool_invocation,grounding,chaos_metrics}.py` | Split into discrete metric modules |
 | `pkg/evaluator/loader.py` | `devops_bench/tasks/loader.py` | |
-| `pkg/manager/manager.py` | `devops_bench/harness/scenario.py` | ScenarioManager is part of the harness |
+| `pkg/manager/manager.py` | `devops_bench/evalharness/scenario.py` | ScenarioManager is part of the harness |
 | `pkg/agents/chaos/chaos.py` | `devops_bench/chaos/agent.py` + `devops_bench/chaos/faults/generate_load.py` | Split into agent loop + fault action |
 | `pkg/agents/verifier/*` | `devops_bench/verification/*` | Extracted into verifier base and registries |
 | `pkg/agents/runner/gcli.py`, `openclaw.py` | `devops_bench/agents/cli/{gemini,openclaw}.py` | Relocated by transport |

--- a/docs/migration/migrated.bara.sky
+++ b/docs/migration/migrated.bara.sky
@@ -36,8 +36,8 @@ MIGRATED = [
     # "devops_bench/agents/api/**",
 
     # --- Stage 3: orchestrator ---
-    # "devops_bench/harness/**",
-    # "tests/unit/harness/**",
+    # "devops_bench/evalharness/**",
+    # "tests/unit/evalharness/**",
 
     # --- Stage 4: data + entrypoint, then the cross-cutting tests last ---
     # "infra/**",

--- a/docs/migration/pr-plan.md
+++ b/docs/migration/pr-plan.md
@@ -102,7 +102,7 @@ These components depend on Stage 1 leaves and form the primary building blocks o
 With all leaves and components in place, the core run loop can now migrate.
 
 - **3a. Run orchestration (`harness/`)**:
-  - **Paths**: `devops_bench/harness/` (base, default, scenario, artifacts), `tests/unit/harness/`.
+  - **Paths**: `devops_bench/evalharness/` (base, default, scenario, artifacts), `tests/unit/evalharness/`.
   - **Details**: Integrates the `ScenarioManager` (controlling chaos and verification) with the `DefaultHarness` (managing task loops, provisioning, execution, and teardown).
 
 ---

--- a/tests/unit/evalharness/test_default_harness.py
+++ b/tests/unit/evalharness/test_default_harness.py
@@ -1,0 +1,279 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Targeted unit tests for ``DefaultHarness`` internals not covered elsewhere.
+
+Tests in this file exercise the harness-level wiring beyond the agent /
+scenario / metrics seams (those have their own files): the scenario-drain
+timed-out path, the constructor-arg-driven deployment / namespace defaults,
+the cached granted-skill-paths snapshot, and the narrowed builtin-agent
+import behavior.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from devops_bench.agents.result import AgentResult
+from devops_bench.core import MissingDependencyError
+from devops_bench.evalharness import default as harness_default
+from devops_bench.evalharness.default import DefaultHarness
+from devops_bench.tasks import Task
+
+
+@pytest.fixture
+def isolated_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip BENCH_* / AGENT_* env so the harness reads predictable defaults."""
+    for var in (
+        "BENCH_USE_MCP",
+        "BENCH_AGENT_TYPE",
+        "AGENT_MCP_SERVER",
+        "AGENT_ALLOWED_TOOLS",
+        "AGENT_SKILLS_PATHS",
+        "AGENT_RULES_TEXT",
+        "AGENT_TARGET",
+        "AGENT_MODEL",
+        "AGENT_PROVIDER",
+        "TARGET_DEPLOYMENT_NAME",
+        "NAMESPACE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_drain_scenario_stamps_timed_out_when_thread_still_alive(
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A scenario thread that outlives the join budget is flagged on the report."""
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+
+    # Drive the join budget to ~0 so the thread is "still alive" on return
+    # without sleeping in the test. The harness reads the module global at
+    # call time, so patching the attribute on the module flexes the path.
+    monkeypatch.setattr(harness_default, "_SCENARIO_JOIN_SEC", 0.01)
+
+    class _StuckScenario:
+        """Stand-in scenario manager whose reports stay partial."""
+
+        def get_reports(self) -> tuple[dict[str, Any], dict[str, Any]]:
+            return ({"status": "initiated", "injected_fault": "x"}, {})
+
+    stop_event = threading.Event()
+
+    def _hang() -> None:
+        # Hold the thread alive past the join budget so ``is_alive`` is True
+        # on return; the event lets the test release the thread on cleanup.
+        stop_event.wait(timeout=2.0)
+
+    scenario_thread = threading.Thread(target=_hang, daemon=True)
+    scenario_thread.start()
+    try:
+        chaos_report, perf_report = harness._drain_scenario(  # noqa: SLF001
+            _StuckScenario(), scenario_thread
+        )
+        assert chaos_report["status"] == "timed_out"
+        # Partial fields from the underlying scenario carry through so the
+        # operator sees how far it got before the cutoff.
+        assert chaos_report["injected_fault"] == "x"
+        assert perf_report == {}
+    finally:
+        stop_event.set()
+        scenario_thread.join(timeout=2.0)
+
+
+def test_drain_scenario_returns_empty_when_no_scenario_scheduled(
+    isolated_env: None,
+) -> None:
+    """No chaos for the task → both reports are empty dicts (legacy contract)."""
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+    chaos_report, perf_report = harness._drain_scenario(None, None)  # noqa: SLF001
+    assert chaos_report == {} and perf_report == {}
+
+
+def test_default_target_deployment_and_namespace_are_ctor_args(
+    isolated_env: None,
+) -> None:
+    """A non-Hypercompute embedder can override the legacy defaults at ctor.
+
+    No env vars set; the harness's overrides flow through to
+    ``replace_placeholders`` so a task with
+    ``{{TARGET_DEPLOYMENT_NAME}}``/``{{NAMESPACE}}`` resolves to the
+    embedder's values rather than the legacy literals.
+    """
+    harness = DefaultHarness(
+        project_id="p",
+        cluster_name="c",
+        default_target_deployment="my-app",
+        default_namespace="custom-ns",
+    )
+    resolved = harness.replace_placeholders(
+        "deploy={{TARGET_DEPLOYMENT_NAME}} ns={{NAMESPACE}}",
+        cluster_name="cl",
+    )
+    assert resolved == "deploy=my-app ns=custom-ns"
+
+
+def test_granted_skill_paths_snapshot_captured_once(
+    isolated_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_granted_skill_paths`` snapshots once at __init__, not per record.
+
+    Removes the env-drift surface: a mid-run change to
+    ``AGENT_SKILLS_PATHS`` must NOT show up in record records, because
+    the harness is the single source of truth for what was granted.
+    """
+    monkeypatch.setenv("AGENT_SKILLS_PATHS", "/skills/a,/skills/b")
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+    assert harness._granted_skill_paths == ("/skills/a", "/skills/b")  # noqa: SLF001
+
+    # A later env mutation must not move the snapshot — the captured
+    # tuple is the authority for the rest of the run.
+    monkeypatch.setenv("AGENT_SKILLS_PATHS", "/skills/x")
+    assert harness._granted_skill_paths == ("/skills/a", "/skills/b")  # noqa: SLF001
+
+
+def test_build_agent_config_returns_identical_snapshot_across_calls(
+    isolated_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``build_agent_config`` is a pure accessor over the __init__ snapshot.
+
+    Two back-to-back calls must return the **same object identity** so the
+    agent the harness constructs cannot differ from the config the
+    record's ``capabilities_granted`` was derived from. A previous version
+    re-read ``AgentConfig.from_env()`` per call, opening a desync window
+    that mid-batch env mutation could exploit.
+    """
+    monkeypatch.setenv("AGENT_SKILLS_PATHS", "/skills/a")
+    monkeypatch.setenv("BENCH_USE_MCP", "true")
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+
+    a = harness.build_agent_config()
+    b = harness.build_agent_config()
+    # Identity — not just equality — pins the no-rebuild invariant.
+    assert a is b
+    assert a.capabilities.skills.paths == ("/skills/a",)
+
+
+def test_capabilities_granted_matches_agent_config_even_after_env_mutation(
+    isolated_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``capabilities_granted`` exactly mirrors the agent's actual config.
+
+    This is the consistency invariant the senior reviewer flagged: env
+    mutated AFTER ``DefaultHarness(...)`` construction must not desync
+    what the agent was built with from what the record claims it was
+    built with. Both come from the single ``__init__`` snapshot.
+    """
+    monkeypatch.setenv("AGENT_SKILLS_PATHS", "/skills/granted")
+    monkeypatch.setenv("AGENT_MCP_SERVER", "/path/to/mcp")
+    monkeypatch.setenv("AGENT_ALLOWED_TOOLS", "tool_a")
+    monkeypatch.setenv("BENCH_USE_MCP", "true")
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+
+    # Drift the env AFTER construction. The harness must still report
+    # what was granted at construction, not what the env now says.
+    monkeypatch.setenv("AGENT_SKILLS_PATHS", "/skills/leaked-after-init")
+    monkeypatch.setenv("BENCH_USE_MCP", "false")
+    monkeypatch.delenv("AGENT_MCP_SERVER", raising=False)
+
+    config = harness.build_agent_config()
+    task = Task.from_dict({"task_id": "t", "name": "demo", "prompt": "p"})
+    success = harness._build_success_record(  # noqa: SLF001
+        task=task,
+        prompt="p",
+        expected_output="e",
+        agent_res=AgentResult(output="ok", trajectory=[]),
+        chaos_report={},
+        perf_report={},
+    )
+    failed = harness._build_failed_record(  # noqa: SLF001
+        task, RuntimeError("boom")
+    )
+
+    # The record's ``skills`` and ``capabilities_granted.skills`` come
+    # from the same snapshot the agent was built from. The post-init env
+    # mutation must NOT leak through.
+    expected_skills = list(config.capabilities.skills.paths)
+    assert expected_skills == ["/skills/granted"]
+    for record in (success, failed):
+        assert record["skills"] == expected_skills
+        assert record["capabilities_granted"]["skills"] == expected_skills
+        # ``use_mcp`` was snapshotted True at __init__; the post-init
+        # mutation to "false" must not flip it on the record.
+        assert record["capabilities_granted"]["use_mcp"] is True
+    # And the agent's actual MCP binding agrees — the post-init delenv
+    # of AGENT_MCP_SERVER did NOT drop the binding the agent runs with.
+    assert config.capabilities.mcp is not None
+
+
+def test_run_one_returns_failed_record_when_get_deployer_raises(
+    isolated_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A deployer-factory failure becomes a failed record, not a batch crash.
+
+    ``get_deployer`` runs inside ``_run_one``'s try, so an unknown deployer
+    type fails just this task (status ``failed``) instead of aborting the whole
+    batch evaluation.
+    """
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+
+    def _boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise ValueError("unknown deployer type")
+
+    monkeypatch.setattr(harness_default, "get_deployer", _boom)
+    task = Task.from_dict({"task_id": "t", "name": "demo", "prompt": "p"})
+
+    record = harness._run_one(task, tmp_path)  # noqa: SLF001
+
+    assert record["status"] == "failed"
+    assert "unknown deployer type" in record["error"]
+    assert record["name"] == "demo"
+
+
+def test_ensure_builtin_agents_swallows_only_import_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Optional-SDK absence is swallowed; real bugs re-raise.
+
+    ``ImportError`` / ``MissingDependencyError`` are the narrow-catch
+    classes — anything else (``SyntaxError``, ``RuntimeError`` at module
+    top, etc.) must bubble out so the operator sees the real failure
+    instead of a silent ``debug`` log.
+    """
+    # Case 1: ImportError is swallowed — function returns normally.
+    def fake_import_missing_sdk(name: str) -> Any:
+        raise ImportError("anthropic SDK not installed")
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_missing_sdk)
+    harness_default._ensure_builtin_agents_registered()  # noqa: SLF001
+
+    # Case 2: a non-import bug must NOT be silently swallowed.
+    def fake_import_buggy_module(name: str) -> Any:
+        raise SyntaxError("agent module is broken")
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_buggy_module)
+    with pytest.raises(SyntaxError):
+        harness_default._ensure_builtin_agents_registered()  # noqa: SLF001
+
+    # Case 3: MissingDependencyError is also swallowed (its semantic class).
+    def fake_missing_dep(name: str) -> Any:
+        raise MissingDependencyError("optional-feature", "extras-marker")
+
+    monkeypatch.setattr(importlib, "import_module", fake_missing_dep)
+    harness_default._ensure_builtin_agents_registered()  # noqa: SLF001

--- a/tests/unit/evalharness/test_e2e_smoke.py
+++ b/tests/unit/evalharness/test_e2e_smoke.py
@@ -1,0 +1,360 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end smoke test (e2e plan §8 / harness handoff §10).
+
+Drives the real ``complextasks/optimize-scale`` task through
+:meth:`DefaultHarness.run` against the :class:`NoOpDeployer`, with the agent
+and the deepeval judge stubbed (no network, no provider SDK, no real
+``kubectl``), but exercising the **real** wiring: deployer → chaos
+trigger/action seam → verification mapping lookup → metrics registry loop →
+result reporter.
+
+Assertions pin:
+
+* exactly one ``results.json`` was written under the run directory,
+* the on-disk schema matches the preserved legacy shape (Decision D3),
+* a populated trajectory rode the typed :class:`AgentResult` boundary, and
+* both ``chaos_report`` and ``perf_report`` carry the typed values.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from devops_bench.agents import AGENTS, AgentHarness, AgentResult, ToolCall
+from devops_bench.chaos import ChaosResult
+from devops_bench.chaos.faults.generate_load import GenerateLoadFault
+from devops_bench.chaos.triggers.time_delay import TimeTrigger
+from devops_bench.evalharness import default as harness_default
+from devops_bench.evalharness.default import DefaultHarness
+from devops_bench.tasks import FileSystemTaskLoader
+from devops_bench.verification import VerificationResult, VerifierAgent
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_OPTIMIZE_SCALE_DIR = _REPO_ROOT / "complextasks" / "optimize-scale"
+
+
+class _StubAgent(AgentHarness):
+    """In-memory agent that records its prompt and returns a canned trajectory."""
+
+    last_prompt: str | None = None
+
+    def _execute(self, prompt: str) -> AgentResult:
+        _StubAgent.last_prompt = prompt
+        return AgentResult(
+            output="Tuned HPA, added requests/limits, observed load handled.",
+            trajectory=[
+                ToolCall(
+                    name="run_command",
+                    args={"command": "kubectl apply -f deploy.yaml"},
+                    result="deployment.apps/web-app configured",
+                    status="completed",
+                ).to_dict(),
+            ],
+            tokens={"input": 42, "output": 21},
+        )
+
+
+def _fake_inject(
+    self: GenerateLoadFault,
+    ctx: Any,
+    event: threading.Event | None,
+) -> ChaosResult:
+    """Fake fault that signals 'active' and returns a clean :class:`ChaosResult`."""
+    if event is not None:
+        event.set()
+    return ChaosResult(
+        success=True,
+        injected_fault=self.type,
+        output="fortio load completed at 300qps for 30s",
+        elapsed_time=30.5,
+    )
+
+
+def _fake_verification_result(
+    self: VerifierAgent,
+    spec: Any,
+    timeout_sec: float = 120,
+) -> VerificationResult:
+    """Fake verifier that mimics a successful end-to-end check."""
+    del spec, timeout_sec
+    return VerificationResult(
+        success=True,
+        elapsed_time=12.0,
+        reason="pods ready; scaling complete",
+        name="Planned Load Spike Verification",
+        children=[
+            VerificationResult(
+                success=True, elapsed_time=4.0, reason="pods ready", name="pod_spec"
+            ),
+            VerificationResult(
+                success=True, elapsed_time=8.0, reason="scaled", name="scaling_spec"
+            ),
+        ],
+    )
+
+
+def _fake_evaluate_metrics(
+    detailed_results: list[dict[str, Any]],
+    judge: Any,
+    *,
+    use_mcp: bool,
+) -> None:
+    """Score in place — mimics ``evaluate_metrics_batch`` without ``deepeval``."""
+    for res in detailed_results:
+        res["scores"] = {
+            "OutcomeValidity": {
+                "score": 0.85,
+                "success": True,
+                "reason": "captured the optimization intent",
+            },
+            "ChecklistScore": {
+                "score": 1.0,
+                "success": True,
+                "reason": "Passed 3 out of 3 checks.",
+            },
+            "DocRetrievalRate": 1.0,
+        }
+
+
+@pytest.fixture
+def stub_agent_registered():
+    """Register ``_StubAgent`` under the ``cli`` alias for the smoke run."""
+    AGENTS.register("gemini-stub")(_StubAgent)
+    try:
+        yield
+    finally:
+        AGENTS._items.pop("gemini-stub", None)  # noqa: SLF001 - test-only teardown
+        _StubAgent.last_prompt = None
+
+
+@pytest.fixture
+def smoke_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure the env so the harness picks NoOpDeployer + the stub agent."""
+    # Strip env vars that would otherwise leak from the dev shell and skew
+    # capabilities / agent selection.
+    for var in (
+        "BENCH_USE_MCP",
+        "BENCH_AGENT_TYPE",
+        "AGENT_MCP_SERVER",
+        "AGENT_ALLOWED_TOOLS",
+        "AGENT_SKILLS_PATHS",
+        "AGENT_RULES_TEXT",
+        "AGENT_MODEL",
+        "AGENT_PROVIDER",
+        "AGENT_TARGET",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("BENCH_USE_MCP", "true")
+    monkeypatch.setenv("BENCH_AGENT_TYPE", "gemini-stub")
+    monkeypatch.setenv("BENCH_NO_INFRA", "true")
+    # Pin placeholder targets so chaos / verification URLs are stable.
+    monkeypatch.setenv("TARGET_DEPLOYMENT_NAME", "web-app")
+    monkeypatch.setenv("NAMESPACE", "default")
+
+
+def test_optimize_scale_smoke_end_to_end(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    smoke_env: None,
+    stub_agent_registered: None,
+) -> None:
+    """A real ``optimize-scale`` task flows end-to-end through the harness."""
+    tasks = FileSystemTaskLoader().load_tasks(str(_OPTIMIZE_SCALE_DIR))
+    assert len(tasks) == 1
+
+    # Re-route results into the tmp dir so we leave no artifacts behind.
+    harness = DefaultHarness(
+        project_id="proj",
+        cluster_name="cluster",
+        judge_model=object(),
+        results_root=str(tmp_path),
+    )
+
+    # Shrink the chaos-active wait so the smoke completes quickly when the
+    # fake fault already signalled the event before the scenario thread
+    # started running. (The real harness uses 45s; tests don't need to.)
+    # The module global is what ``_run_one`` reads at call time, so we
+    # patch the live attribute on the module object — and assert against
+    # the same attribute, not a frozen ``from ... import`` alias (which
+    # would be a no-op assertion).
+    monkeypatch.setattr(harness_default, "_CHAOS_ACTIVE_WAIT_SEC", 1)
+    assert harness_default._CHAOS_ACTIVE_WAIT_SEC == 1
+
+    # The smoke run NEVER opens a kubectl port-forward — NoOpDeployer is the
+    # deployer, and the start_scenario call routes skip_port_forward=True.
+    real_start_scenario = harness.start_scenario
+
+    def patched_start_scenario(chaos_specs, mapping, ctx):
+        return real_start_scenario(
+            chaos_specs, mapping, ctx, skip_port_forward=True
+        )
+
+    monkeypatch.setattr(harness, "start_scenario", patched_start_scenario)
+
+    with (
+        # No real time-trigger sleep; the fake returns immediately.
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        # Inject without driving a real LLM / fortio binary.
+        patch.object(GenerateLoadFault, "inject", _fake_inject),
+        # Verification: typed result returned without touching k8s.
+        patch.object(
+            VerifierAgent, "wait_for_condition", _fake_verification_result
+        ),
+        # Metrics: registry-driven loop replaced with the fake scorer so the
+        # smoke does not pull deepeval / a real judge.
+        patch(
+            "devops_bench.metrics.evaluate_metrics_batch",
+            _fake_evaluate_metrics,
+            create=True,
+        ),
+        patch(
+            "devops_bench.metrics.get_judge_model", lambda: object(), create=True
+        ),
+    ):
+        results = harness.run(tasks)
+
+    # ----- run shape -----------------------------------------------------
+    run_dirs = [p for p in tmp_path.iterdir() if p.is_dir() and p.name.startswith("run_")]
+    assert len(run_dirs) == 1, f"expected one run dir, got {run_dirs}"
+    results_file = run_dirs[0] / "results.json"
+    assert results_file.exists()
+
+    on_disk = json.loads(results_file.read_text())
+    assert on_disk == results
+    assert len(on_disk) == 1
+    record = on_disk[0]
+
+    # ----- preserved schema (D3) -----------------------------------------
+    expected_keys = {
+        "input",
+        "output",
+        "latency",
+        "tokens",
+        "tools",
+        "trajectory",
+        "skills",
+        "name",
+        "status",
+        "expected_output",
+        "expected_output_raw",
+        "retrieval_context",
+        "chaos_spec",
+        "verification_spec",
+        "chaos_report",
+        "perf_report",
+        "documentation",
+        "capabilities_granted",
+        "scores",
+    }
+    assert expected_keys <= set(record.keys()), (
+        f"missing keys: {expected_keys - set(record.keys())}"
+    )
+    assert record["status"] == "success"
+    assert record["name"] == "optimize-scale"
+
+    # ----- trajectory rode the typed AgentResult boundary ---------------
+    assert isinstance(record["trajectory"], list) and record["trajectory"]
+    assert record["trajectory"][0]["name"] == "run_command"
+    assert record["trajectory"][0]["status"] == "completed"
+
+    # ----- chaos + verification reports present (typed flow) -------------
+    assert record["chaos_report"]["status"] == "success"
+    assert record["chaos_report"]["injected_fault"] == "generate_load"
+    assert record["chaos_report"]["verification"]["success"] is True
+    assert record["chaos_report"]["verification"]["name"] == (
+        "Planned Load Spike Verification"
+    )
+    assert record["perf_report"]["uptime_percentage"] == 100.0
+
+    # ----- scores wrote in place via the (stubbed) metrics registry ------
+    assert record["scores"]["OutcomeValidity"]["score"] == 0.85
+    # Bare-value scores keep the legacy raw-value shape (D3).
+    assert record["scores"]["DocRetrievalRate"] == 1.0
+
+    # ----- capabilities snapshot lives on the record ---------------------
+    assert record["capabilities_granted"] == {"use_mcp": True, "skills": []}
+
+    # ----- placeholder substitution happened on the prompt ---------------
+    assert "{{TARGET_DEPLOYMENT_NAME}}" not in record["input"]
+    assert "web-app" in record["input"]
+
+
+def test_smoke_uses_workspace_path_for_artifact_diff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    smoke_env: None,
+    stub_agent_registered: None,
+) -> None:
+    """Artifact diff is rooted at ``RunContext.workspace_path``, not literal cwd."""
+    tasks = FileSystemTaskLoader().load_tasks(str(_OPTIMIZE_SCALE_DIR))
+    harness = DefaultHarness(
+        project_id="proj",
+        cluster_name="cluster",
+        judge_model=object(),
+        results_root=str(tmp_path),
+    )
+
+    # Run the harness from a sandbox so an accidental ``snapshot_dir(".")``
+    # call would diff the empty sandbox — not the user's cwd. The smoke
+    # assertion is that ``run`` completes without writing into the user's
+    # source tree.
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    monkeypatch.chdir(sandbox)
+
+    real_start_scenario = harness.start_scenario
+
+    def patched_start_scenario(chaos_specs, mapping, ctx):
+        # Confirm the harness threaded the resolved workspace into the
+        # context, so the artifact diff cannot regress to ``"."`` hardcoded.
+        assert ctx.workspace_path is not None
+        assert os.fspath(ctx.workspace_path) == str(sandbox.resolve())
+        return real_start_scenario(
+            chaos_specs, mapping, ctx, skip_port_forward=True
+        )
+
+    monkeypatch.setattr(harness, "start_scenario", patched_start_scenario)
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", _fake_inject),
+        patch.object(
+            VerifierAgent, "wait_for_condition", _fake_verification_result
+        ),
+        patch(
+            "devops_bench.metrics.evaluate_metrics_batch",
+            _fake_evaluate_metrics,
+            create=True,
+        ),
+        patch(
+            "devops_bench.metrics.get_judge_model", lambda: object(), create=True
+        ),
+    ):
+        results = harness.run(tasks)
+
+    assert len(results) == 1
+    # Generated-files dir is only created when a new entry exists; the stub
+    # agent writes nothing, so the dir stays absent.
+    run_dirs = [p for p in tmp_path.iterdir() if p.is_dir() and p.name.startswith("run_")]
+    assert run_dirs
+    assert not (run_dirs[0] / "generated_files").exists()

--- a/tests/unit/evalharness/test_package_import.py
+++ b/tests/unit/evalharness/test_package_import.py
@@ -1,0 +1,81 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``import devops_bench.evalharness`` keeps the provider SDK chain lazy (§8 revised).
+
+The orchestrator is the only layer allowed to consume every component, so it
+sits structurally close to the heavy optional dependencies. Light init is now a
+guideline, not a rule: importing the package may pull ``deepeval`` / ``mcp``.
+What it must **never** pull is a provider model SDK: the metrics judge is
+imported lazily inside ``DefaultHarness._score``, the API agent's SDK loads at
+construction, and the chaos fault's agent + models chain loads only when the
+fault actually injects.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+import textwrap
+
+
+def _run_in_subprocess(snippet: str) -> str:
+    """Run ``snippet`` in a clean Python process and return stdout.
+
+    A fresh interpreter prevents leaks from earlier test imports (the wider
+    test session has often already pulled ``deepeval``).
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(snippet)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def test_importing_harness_pulls_no_provider_sdk() -> None:
+    """A bare ``import devops_bench.evalharness`` does not pull a provider SDK.
+
+    ``deepeval`` / ``mcp`` are permitted eagerly now; only the provider model
+    SDKs must stay out until the judge / agent actually run.
+    """
+    output = _run_in_subprocess(
+        """
+        import sys
+        import devops_bench.evalharness  # noqa: F401
+        forbidden = {
+            "anthropic",
+            "google.genai",
+            "google.generativeai",
+            "openai",
+            "ollama",
+        }
+        leaked = sorted(name for name in forbidden if name in sys.modules)
+        print(",".join(leaked))
+        """
+    )
+    leaked = [name for name in output.strip().split(",") if name]
+    assert leaked == [], f"importing devops_bench.evalharness pulled: {leaked}"
+
+
+def test_harness_exports_present() -> None:
+    """The eager package exposes every public harness symbol."""
+    pkg = importlib.import_module("devops_bench.evalharness")
+    # All four public symbols are eagerly imported now (no ``__getattr__``).
+    assert pkg.Harness.__name__ == "Harness"
+    assert pkg.ResultReporter.__name__ == "ResultReporter"
+    assert pkg.DefaultHarness.__name__ == "DefaultHarness"
+    assert pkg.ScenarioManager.__name__ == "ScenarioManager"

--- a/tests/unit/evalharness/test_registry_resolution.py
+++ b/tests/unit/evalharness/test_registry_resolution.py
@@ -1,0 +1,95 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry-only agent resolution (CONVENTIONS.md §2 / harness handoff §5).
+
+The harness must resolve agents purely through :data:`AGENTS` — there is no
+``_AGENT_MODULES`` / ``_AGENT_KEYS`` dispatch table to edit when a new agent
+is added. The acceptance bar is exactly: a dummy ``@AGENTS.register("dummy")``
+resolves with **no harness edit**.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from devops_bench.agents import AGENTS, AgentConfig, AgentHarness, AgentResult
+from devops_bench.core import NotRegisteredError
+from devops_bench.evalharness.default import DefaultHarness
+
+
+class _DummyAgent(AgentHarness):
+    """Trivial agent for the dropped-in-registration test.
+
+    Captures the config it was constructed with so the test can assert that
+    the harness threaded its resolved capabilities into the instance (rather
+    than handing the agent an env-only config).
+    """
+
+    last_config: AgentConfig | None = None
+
+    def __init__(self, config: AgentConfig | None = None) -> None:
+        super().__init__(config)
+        _DummyAgent.last_config = self.config
+
+    def _execute(self, prompt: str) -> AgentResult:  # pragma: no cover - never run
+        return AgentResult(output=f"echo: {prompt}", trajectory=[])
+
+
+@pytest.fixture
+def dummy_agent_registered() -> None:
+    """Register ``_DummyAgent`` under the canonical ``dummy`` key for one test."""
+    AGENTS.register("dummy")(_DummyAgent)
+    try:
+        yield
+    finally:
+        # ``Registry`` has no public deregister; drop the key directly so the
+        # fixture is hermetic across the suite.
+        AGENTS._items.pop("dummy", None)  # noqa: SLF001 - test-only teardown
+        _DummyAgent.last_config = None
+
+
+def test_dummy_agent_resolves_with_no_harness_edit(
+    dummy_agent_registered: None,
+) -> None:
+    """A third-party-registered agent flows through the orchestrator unchanged."""
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+    harness.agent_type = "dummy"
+
+    agent = harness.resolve_agent("dummy")
+
+    assert isinstance(agent, _DummyAgent)
+    # The harness threaded its built config (not a bare ``AgentConfig()``).
+    assert _DummyAgent.last_config is not None
+    assert isinstance(_DummyAgent.last_config, AgentConfig)
+
+
+def test_legacy_alias_normalizes_to_canonical_key() -> None:
+    """``cli`` / ``binary`` legacy types still resolve to the Gemini agent."""
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+
+    # ``cli`` is the legacy alias for the gemini agent; resolution must not
+    # require a path table — the alias map normalizes to ``gemini`` and the
+    # registry returns the registered class.
+    agent_cls = AGENTS.get("gemini")
+    agent = harness.resolve_agent("cli")
+    assert isinstance(agent, agent_cls)
+
+
+def test_unknown_agent_type_raises_not_registered() -> None:
+    """An agent key with no registration produces ``NotRegisteredError``."""
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+
+    with pytest.raises(NotRegisteredError):
+        harness.resolve_agent("not-a-real-agent-key")

--- a/tests/unit/evalharness/test_reporter.py
+++ b/tests/unit/evalharness/test_reporter.py
@@ -1,0 +1,295 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Golden tests for the preserved ``results.json`` schema (Decision D3).
+
+Two invariants are pinned here:
+
+1. **The ``ResultReporter`` writes the input list verbatim.** The reporter is
+   a thin sink the engine depends on (``harness-refactor-handoff.md`` §8);
+   it must not reshape the payload.
+2. **Success and failed records carry the *same* top-level key set.** A
+   downstream parser iterating one shape can never ``KeyError`` crossing
+   into the other. The tests drive the production code path by invoking
+   :meth:`DefaultHarness._build_success_record` /
+   :meth:`DefaultHarness._build_failed_record` on a stub
+   :class:`AgentResult` and asserting ``set(record.keys()) == required_keys``.
+   A hand-rolled dict would let the builders drift silently — these tests
+   intentionally exercise the real builders.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devops_bench.agents.result import AgentResult, ToolCall
+from devops_bench.evalharness.default import DefaultHarness
+from devops_bench.evalharness.reporter import ResultReporter
+from devops_bench.tasks import Task
+
+# Pinned legacy + symmetric-union key set. Every key listed here must be
+# present on *both* the success record and the failed record (Decision D3).
+# A reader iterating one shape may rely on every key being present on the
+# other — the previous schema asymmetry that motivated this fix is gone.
+_RESULTS_JSON_REQUIRED_KEYS: frozenset[str] = frozenset(
+    {
+        "input",
+        "output",
+        "latency",
+        "tokens",
+        "tools",
+        "trajectory",
+        "skills",
+        "name",
+        "status",
+        "error",
+        "errors",
+        "scores",
+        "expected_output",
+        "expected_output_raw",
+        "retrieval_context",
+        "chaos_spec",
+        "verification_spec",
+        "chaos_report",
+        "perf_report",
+        "documentation",
+        "capabilities_granted",
+        "verification_parse_errors",
+    }
+)
+
+
+@pytest.fixture
+def isolated_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every ``BENCH_*`` / ``AGENT_*`` knob the harness reads.
+
+    Keeps the test deterministic — without it the developer's shell env
+    could grant skills or MCP that the golden assertions don't expect.
+    """
+    for var in (
+        "BENCH_USE_MCP",
+        "BENCH_AGENT_TYPE",
+        "AGENT_MCP_SERVER",
+        "AGENT_ALLOWED_TOOLS",
+        "AGENT_SKILLS_PATHS",
+        "AGENT_RULES_TEXT",
+        "AGENT_TARGET",
+        "AGENT_MODEL",
+        "AGENT_PROVIDER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _stub_task() -> Task:
+    """Build a typed task with a few non-trivial fields the records carry."""
+    return Task.from_dict(
+        {
+            "task_id": "demo-1",
+            "name": "demo",
+            "prompt": "do the thing",
+            "expected_output": "exp",
+            "retrieval_context": ["doc-a"],
+            "chaos_spec": {"chaos": "yes"},
+            "verification_spec": {"verify": "yes"},
+        }
+    )
+
+
+def _stub_agent_result() -> AgentResult:
+    """Build an agent result with output, trajectory, tokens, latency populated."""
+    return AgentResult(
+        output="done",
+        trajectory=[
+            ToolCall(
+                name="run_command",
+                args={"command": "kubectl get pods"},
+                result="pod/web-app Running",
+                status="completed",
+            ).to_dict()
+        ],
+        tokens={"input": 10, "output": 5},
+        latency=1.5,
+    )
+
+
+def test_reporter_writes_results_json_with_indented_payload(tmp_path: Path) -> None:
+    """The reporter writes ``results.json`` under the run dir with the input list."""
+    reporter = ResultReporter(results_root=tmp_path)
+    run_dir = reporter.new_run_dir()
+    payload = [{"name": "demo", "status": "success"}]
+
+    written = reporter.write(run_dir, payload)
+
+    assert written == run_dir / "results.json"
+    on_disk = json.loads(written.read_text())
+    assert on_disk == payload
+
+
+def test_new_run_dir_returns_unique_path_under_root(tmp_path: Path) -> None:
+    """Two reporters sharing a root produce directories underneath it."""
+    reporter = ResultReporter(results_root=tmp_path)
+    a = reporter.new_run_dir()
+    assert a.parent == tmp_path
+    assert a.name.startswith("run_")
+
+
+def test_legacy_success_record_keys_are_emitted_verbatim(
+    isolated_env: None,
+) -> None:
+    """A real ``_build_success_record`` invocation matches the golden key set.
+
+    The test drives the production code path — earlier versions asserted a
+    hand-rolled dict, which let the builder drift away from the golden
+    schema undetected. Today the key set is asserted on the actual output.
+    """
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+    task = _stub_task()
+    agent_res = _stub_agent_result()
+
+    record = harness._build_success_record(  # noqa: SLF001 - testing internals
+        task=task,
+        prompt="resolved prompt",
+        expected_output="resolved expected",
+        agent_res=agent_res,
+        chaos_report={"status": "success"},
+        perf_report={"uptime_percentage": 100.0},
+    )
+
+    # Exact key equality — no drift in either direction.
+    assert set(record.keys()) == _RESULTS_JSON_REQUIRED_KEYS
+    # Spot-check the success-specific values.
+    assert record["status"] == "success"
+    assert record["output"] == "done"
+    assert record["trajectory"][0]["name"] == "run_command"
+    assert record["tokens"] == {"input": 10, "output": 5}
+    # The error/errors slots are present but empty on a clean success run.
+    assert record["error"] is None
+    assert record["errors"] == []
+    # Pre-scoring, ``scores`` is the empty dict; ``_score`` writes into it.
+    assert record["scores"] == {}
+    # Capabilities snapshot rides on every record (CONVENTIONS.md §7 closure).
+    assert record["capabilities_granted"]["use_mcp"] is True  # default get_bool
+    assert record["capabilities_granted"]["skills"] == []
+
+
+def test_legacy_failed_record_keys_are_emitted_verbatim(
+    isolated_env: None,
+) -> None:
+    """A real ``_build_failed_record`` invocation matches the SAME golden set.
+
+    This is the BLOCKING D3 fix: success and failed records used to carry
+    different key sets (success: ``errors`` + ``scores``; failed: ``error``
+    + ``score``), so a parser iterating one would ``KeyError`` on the
+    other. The symmetric union pinned here removes that asymmetry.
+    """
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+    task = _stub_task()
+    exc = RuntimeError("deployer.up() failed")
+
+    record = harness._build_failed_record(task, exc)  # noqa: SLF001
+
+    # Exact key equality — IDENTICAL to the success golden set.
+    assert set(record.keys()) == _RESULTS_JSON_REQUIRED_KEYS
+    # Failed-specific values.
+    assert record["status"] == "failed"
+    assert record["error"] == "deployer.up() failed"
+    assert record["errors"] == ["deployer.up() failed"]
+    assert record["scores"] == {}
+    assert record["output"] == ""
+    assert record["trajectory"] == []
+    # Capabilities snapshot rides on failed records too, so dashboards
+    # always see what the harness granted, even on a crash.
+    assert "use_mcp" in record["capabilities_granted"]
+
+
+def test_success_and_failed_records_have_identical_top_level_keys(
+    isolated_env: None,
+) -> None:
+    """Direct invariant: ``set(success.keys()) == set(failed.keys())``.
+
+    Reviewer-requested explicit assertion — the previous schema mismatch
+    (success had ``errors``+``scores``; failed had ``error``+``score``) is
+    pinned away here so a future change has to break this test to
+    re-introduce the asymmetry.
+    """
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+    task = _stub_task()
+
+    success = harness._build_success_record(  # noqa: SLF001
+        task=task,
+        prompt="p",
+        expected_output="e",
+        agent_res=_stub_agent_result(),
+        chaos_report={},
+        perf_report={},
+    )
+    failed = harness._build_failed_record(task, RuntimeError("boom"))  # noqa: SLF001
+
+    assert set(success.keys()) == set(failed.keys())
+    # And both equal the pinned golden union.
+    assert set(success.keys()) == _RESULTS_JSON_REQUIRED_KEYS
+
+
+def test_record_keys_class_constant_matches_golden(isolated_env: None) -> None:
+    """The harness's :attr:`_RECORD_KEYS` constant is the authoritative source.
+
+    Pinning it here means a future contributor who adds a record field
+    (and updates ``_RECORD_KEYS`` + both builders) must also update the
+    golden constant in this test file — a single coordinated edit catches
+    drift in either direction.
+    """
+    assert DefaultHarness._RECORD_KEYS == _RESULTS_JSON_REQUIRED_KEYS  # noqa: SLF001
+
+
+def test_verification_parse_errors_flow_into_success_record(
+    isolated_env: None,
+) -> None:
+    """Verification-spec parse failures land on ``verification_parse_errors``."""
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+    record = harness._build_success_record(  # noqa: SLF001
+        task=_stub_task(),
+        prompt="p",
+        expected_output="e",
+        agent_res=_stub_agent_result(),
+        chaos_report={},
+        perf_report={},
+        verification_parse_errors=[
+            {"name": "broken", "reason": "missing type discriminator"}
+        ],
+    )
+    assert record["verification_parse_errors"] == [
+        {"name": "broken", "reason": "missing type discriminator"}
+    ]
+
+
+def test_verification_parse_errors_flow_into_failed_record(
+    isolated_env: None,
+) -> None:
+    """The same plumbing exists on the failed path.
+
+    A verification authoring failure must never be lost to a deployer
+    crash — the operator should see both on the failed record.
+    """
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+    record = harness._build_failed_record(  # noqa: SLF001
+        _stub_task(),
+        RuntimeError("boom"),
+        verification_parse_errors=[{"name": "broken", "reason": "bad type"}],
+    )
+    assert record["verification_parse_errors"] == [
+        {"name": "broken", "reason": "bad type"}
+    ]

--- a/tests/unit/evalharness/test_scenario.py
+++ b/tests/unit/evalharness/test_scenario.py
@@ -1,0 +1,318 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scenario wiring tests (CONVENTIONS.md §4.2 / harness handoff §9.1/§9.2).
+
+The scenario manager runs the typed chaos seam (``trigger.wait`` then
+``action.inject``) and resolves the chaos ``verify`` key against a
+**mapping** (not a list scan) supplied by the orchestrator. Fakes stand in
+for both seams so the test exercises only the wiring — never a real cluster
+or a real LLM.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from devops_bench.chaos import ChaosResult, ChaosSpec
+from devops_bench.chaos.faults.generate_load import GenerateLoadFault
+from devops_bench.chaos.triggers.time_delay import TimeTrigger
+from devops_bench.core.context import RunContext
+from devops_bench.evalharness.scenario import ScenarioManager
+from devops_bench.verification import VerificationResult, VerifierAgent
+
+
+def _build_spec(*, verify_key: str | None) -> ChaosSpec:
+    """Build a typed :class:`ChaosSpec` mirroring the optimize-scale entry."""
+    return ChaosSpec.model_validate(
+        {
+            "name": "Test Disruption",
+            "trigger": {"type": "time", "delay_seconds": 0},
+            "action": {
+                "type": "generate_load",
+                "target": {
+                    "service_url": "http://example.svc.cluster.local",
+                    "qps": 50,
+                },
+            },
+            "verify": verify_key,
+        }
+    )
+
+
+def _build_ctx() -> RunContext:
+    return RunContext(task_id="t", task_name="t")
+
+
+def test_scenario_drives_trigger_wait_then_action_inject() -> None:
+    """The seam: trigger.wait runs first, then action.inject — no inline goal builder."""
+    spec = _build_spec(verify_key=None)
+    order: list[str] = []
+
+    def fake_wait(self: TimeTrigger, ctx: RunContext) -> None:
+        order.append("trigger.wait")
+
+    def fake_inject(
+        self: GenerateLoadFault,
+        ctx: RunContext,
+        event: threading.Event | None,
+    ) -> ChaosResult:
+        order.append("action.inject")
+        if event is not None:
+            event.set()
+        return ChaosResult(
+            success=True,
+            injected_fault=self.type,
+            output="ok",
+            elapsed_time=0.1,
+        )
+
+    with (
+        patch.object(TimeTrigger, "wait", fake_wait),
+        patch.object(GenerateLoadFault, "inject", fake_inject),
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            verification_mapping={},
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    assert order == ["trigger.wait", "action.inject"]
+    chaos_report, perf_report = manager.get_reports()
+    assert chaos_report["status"] == "success"
+    assert chaos_report["injected_fault"] == "generate_load"
+    assert chaos_report["name"] == "Test Disruption"
+    # No verification mapping resolution happened (verify_key was None).
+    assert "verification" not in chaos_report
+    assert perf_report == {}
+
+
+def test_scenario_threads_port_forward_target_onto_ctx_env() -> None:
+    """The manager threads the port-forward target onto ``ctx.env`` for the fault.
+
+    Connectivity moved into the load fault (#33): the manager no longer rewrites
+    the action URL or opens a port-forward itself — it hands the fault the
+    target deployment / namespace (and the skip flag) via the run context's
+    ``env`` so the fault can open its own tunnel.
+    """
+    from devops_bench.chaos.faults.generate_load import (
+        _ENV_SKIP_PORT_FORWARD,
+        _ENV_TARGET_DEPLOYMENT,
+        _ENV_TARGET_NAMESPACE,
+    )
+
+    spec = _build_spec(verify_key=None)
+    captured: dict[str, Any] = {}
+
+    def fake_inject(self: GenerateLoadFault, ctx: RunContext, event):
+        captured["env"] = dict(ctx.env)
+        # The in-cluster URL is untouched by the manager now; the fault is what
+        # would point it at the local tunnel (skipped here).
+        captured["service_url"] = self.target.service_url
+        return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", fake_inject),
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    assert captured["env"][_ENV_TARGET_DEPLOYMENT] == "dep"
+    assert captured["env"][_ENV_TARGET_NAMESPACE] == "ns"
+    # ``skip_port_forward=True`` flips the fault's opt-out flag on the env.
+    assert captured["env"][_ENV_SKIP_PORT_FORWARD] == "1"
+    # The manager leaves the action's in-cluster URL alone — no rewrite seam.
+    assert captured["service_url"] == "http://example.svc.cluster.local"
+
+
+def test_scenario_resolves_verify_against_mapping() -> None:
+    """The chaos ``verify`` key is looked up in the harness-supplied mapping."""
+    spec = _build_spec(verify_key="planned-verify")
+    verification_node = object()  # opaque stand-in; VerifierAgent is mocked
+
+    fake_result = VerificationResult(
+        success=True, elapsed_time=2.5, reason="all good"
+    )
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(
+            GenerateLoadFault,
+            "inject",
+            lambda self, ctx, event: ChaosResult(
+                success=True, injected_fault=self.type, elapsed_time=0.0
+            ),
+        ),
+        patch.object(
+            VerifierAgent, "wait_for_condition", return_value=fake_result
+        ) as mock_wait,
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            verification_mapping={"planned-verify": verification_node},
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    # The mapping value (not a list-scanned dict) flowed straight to the
+    # VerifierAgent — the lookup is O(1) and never imports verification on the
+    # chaos side.
+    mock_wait.assert_called_once_with(verification_node, timeout_sec=120)
+
+    chaos_report, perf_report = manager.get_reports()
+    assert chaos_report["verification"]["success"] is True
+    assert chaos_report["verification"]["reason"] == "all good"
+    # Perf report is derived from the typed VerificationResult.
+    assert perf_report == {
+        "deployment_time_seconds": 2.5,
+        "uptime_percentage": 100.0,
+        "resource_utilization_efficiency": 1.0,
+    }
+
+
+def test_scenario_unknown_verify_key_surfaces_failure_into_report() -> None:
+    """An unmapped ``verify:`` key writes a verification-failure entry, not silence.
+
+    The chaos seam never silently drops a verify reference — a typo'd key
+    must be visible on ``results.json``, not just in the log, so the
+    operator can spot a broken cross-reference without trawling stdout.
+    """
+    spec = _build_spec(verify_key="not-in-mapping")
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(
+            GenerateLoadFault,
+            "inject",
+            lambda self, ctx, event: ChaosResult(
+                success=True, injected_fault=self.type, elapsed_time=0.0
+            ),
+        ),
+        patch.object(VerifierAgent, "wait_for_condition") as mock_wait,
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            verification_mapping={"some-other-key": object()},
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    # Never called — the unknown key short-circuited before dispatch.
+    mock_wait.assert_not_called()
+    chaos_report, _ = manager.get_reports()
+    assert chaos_report["status"] == "success"
+    verification = chaos_report["verification"]
+    assert verification["success"] is False
+    assert verification["unresolved_reference"] == "not-in-mapping"
+    assert verification["known_references"] == ["some-other-key"]
+    assert "not found" in verification["reason"]
+
+
+def test_chaos_failure_lands_typed_error_into_report() -> None:
+    """A ``ChaosResult(success=False, error=...)`` flows into the chaos report."""
+    spec = _build_spec(verify_key=None)
+
+    def failing_inject(self, ctx, event):
+        return ChaosResult(
+            success=False,
+            injected_fault=self.type,
+            elapsed_time=0.0,
+            error="fortio not found",
+        )
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", failing_inject),
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    chaos_report, _ = manager.get_reports()
+    assert chaos_report["status"] == "failed"
+    assert chaos_report["error"] == "fortio not found"
+
+
+def test_injection_exception_sets_chaos_active_event() -> None:
+    """A raising injection still sets the event so the main thread unblocks.
+
+    The main thread waits on ``chaos_active_event`` to learn the disruption is
+    active; if injection raises and the event is never set, it stalls for the
+    full activation timeout. The failure path must signal the event.
+    """
+    spec = _build_spec(verify_key=None)
+
+    def raising_inject(self, ctx, event):
+        raise RuntimeError("port-forward refused")
+
+    with (
+        patch.object(TimeTrigger, "wait", lambda self, ctx: None),
+        patch.object(GenerateLoadFault, "inject", raising_inject),
+    ):
+        manager = ScenarioManager(
+            target_deployment="dep",
+            namespace="ns",
+            skip_port_forward=True,
+        )
+        manager.run_chaos_and_verification(spec, _build_ctx())
+
+    assert manager.chaos_active_event.is_set()
+    chaos_report, _ = manager.get_reports()
+    assert chaos_report["status"] == "failed"
+
+
+def test_stop_aborts_verification() -> None:
+    """``stop()`` is exception-safe and sets the abort flag once."""
+    manager = ScenarioManager(
+        target_deployment="dep",
+        namespace="ns",
+        skip_port_forward=True,
+    )
+    manager.stop()  # The fault owns the port-forward; stop only sets the flag.
+    assert manager._aborted.is_set()  # noqa: SLF001
+    # Idempotent — the second call must not raise.
+    manager.stop()
+
+
+@pytest.fixture(autouse=True)
+def _no_real_kubectl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guard against this file accidentally shelling out to ``kubectl``.
+
+    Every test sets ``skip_port_forward=True`` so the load fault never opens a
+    tunnel, but the guard pins the invariant explicitly: it patches the
+    ``subprocess.Popen`` the port-forward helper would use so a future refactor
+    that forgets the flag fails loudly instead of attempting a real
+    port-forward.
+    """
+
+    def _boom(*args, **kwargs):  # pragma: no cover - exercised only on regression
+        raise RuntimeError("test attempted to spawn a real kubectl process")
+
+    monkeypatch.setattr("devops_bench.k8s.kubectl.subprocess.Popen", _boom)

--- a/tests/unit/evalharness/test_single_env_read.py
+++ b/tests/unit/evalharness/test_single_env_read.py
@@ -1,0 +1,176 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single ``BENCH_USE_MCP`` read site (CONVENTIONS.md §7 / harness handoff §2.2).
+
+The harness owns the only read of ``BENCH_USE_MCP``; the resolved boolean is
+threaded into both the agent's :class:`AgentConfig` (gates the MCP binding)
+and the metrics scoring call (``MetricContext.use_mcp``). This file pins the
+invariant so a future change cannot silently re-introduce the agent-vs-judge
+disagreement that motivated §7.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from devops_bench.evalharness.default import DefaultHarness
+
+
+@pytest.fixture
+def isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every ``BENCH_*`` / ``AGENT_*`` knob the harness reads.
+
+    Keeps the test from picking up the developer's shell env (e.g. an
+    ``AGENT_MCP_SERVER`` left over from a manual run) which would muddle the
+    capability assertions.
+    """
+    for var in (
+        "BENCH_USE_MCP",
+        "BENCH_AGENT_TYPE",
+        "BENCH_NO_INFRA",
+        "AGENT_MCP_SERVER",
+        "AGENT_ALLOWED_TOOLS",
+        "AGENT_SKILLS_PATHS",
+        "AGENT_RULES_TEXT",
+        "AGENT_TARGET",
+        "AGENT_MODEL",
+        "AGENT_PROVIDER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_harness_reads_use_mcp_once_at_construction(
+    monkeypatch: pytest.MonkeyPatch, isolate_env: None
+) -> None:
+    """``BENCH_USE_MCP`` is read once during ``__init__``, not on every method."""
+    monkeypatch.setenv("BENCH_USE_MCP", "true")
+
+    with patch("devops_bench.evalharness.default.get_bool", wraps=__import__(
+        "devops_bench.core", fromlist=["get_bool"]
+    ).get_bool) as wrapped:
+        harness = DefaultHarness(project_id="p", cluster_name="c")
+
+        bench_use_mcp_reads = [
+            call for call in wrapped.call_args_list if call.args and call.args[0] == "BENCH_USE_MCP"
+        ]
+        # Exactly one harness-driven read of BENCH_USE_MCP at construction.
+        assert len(bench_use_mcp_reads) == 1
+        assert harness.use_mcp is True
+
+
+def test_use_mcp_flows_into_agent_capabilities_and_metrics(
+    monkeypatch: pytest.MonkeyPatch, isolate_env: None
+) -> None:
+    """The same resolved bool reaches the AgentConfig and the metrics call."""
+    monkeypatch.setenv("BENCH_USE_MCP", "false")
+    monkeypatch.setenv("AGENT_MCP_SERVER", "echo hi")
+    monkeypatch.setenv("AGENT_ALLOWED_TOOLS", "run_command")
+
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+
+    # Agent side: a False ``use_mcp`` gates off the MCP binding even when the
+    # env names a server — only the harness decides whether MCP runs.
+    config = harness.build_agent_config()
+    assert config.capabilities.mcp_servers == ()
+    assert config.capabilities.tools_enabled is False
+    assert harness.use_mcp is False
+
+    # Metrics side: the score path threads the same boolean as
+    # ``use_mcp=False`` into ``evaluate_metrics_batch``.
+    captured: dict = {}
+
+    def fake_batch(results, judge, *, use_mcp):
+        captured["use_mcp"] = use_mcp
+        captured["count"] = len(results)
+
+    monkeypatch.setattr(
+        "devops_bench.metrics.evaluate_metrics_batch",
+        fake_batch,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "devops_bench.metrics.get_judge_model",
+        lambda: object(),
+        raising=False,
+    )
+
+    harness._score([{"status": "success", "name": "t"}])  # noqa: SLF001
+    assert captured == {"use_mcp": False, "count": 1}
+
+
+def test_use_mcp_true_grants_mcp_binding(
+    monkeypatch: pytest.MonkeyPatch, isolate_env: None
+) -> None:
+    """A True ``use_mcp`` lets the env-declared MCP binding through."""
+    monkeypatch.setenv("BENCH_USE_MCP", "true")
+    monkeypatch.setenv("AGENT_MCP_SERVER", "/path/to/mcp")
+    monkeypatch.setenv("AGENT_ALLOWED_TOOLS", "tool_a,tool_b")
+
+    harness = DefaultHarness(project_id="p", cluster_name="c")
+    config = harness.build_agent_config()
+
+    assert config.capabilities.tools_enabled is True
+    assert config.capabilities.mcp is not None
+    assert config.capabilities.allowed_tools == ("tool_a", "tool_b")
+
+
+def test_only_one_executable_use_mcp_read_in_repo(
+    monkeypatch: pytest.MonkeyPatch, isolate_env: None, tmp_path: Path
+) -> None:
+    """Only one *executable* ``BENCH_USE_MCP`` read site exists in the package.
+
+    Pinned as a test rather than a comment so a refactor that re-introduces a
+    second read site fails CI rather than passes review. Plain docstring
+    mentions ("never reads ``BENCH_USE_MCP``") are intentionally allowed —
+    the assertion is on actual calls into ``get_bool`` / ``os.environ``.
+    """
+    import re
+
+    devops_bench_root = Path(__file__).resolve().parents[3] / "devops_bench"
+    # Match every realistic way a Python module reads BENCH_USE_MCP — the
+    # core helpers (``get_bool``, ``get_env``, ``first_env``), the stdlib
+    # ``os.getenv`` / ``os.environ.get`` / ``os.environ[...]`` paths, and
+    # bare ``environ["..."]`` (e.g. ``from os import environ``). A reviewer
+    # eyeballing §7 compliance would search for any of these; codify the
+    # search so a sneaked-in second read fails CI instead of passing review.
+    read_pattern = re.compile(
+        r"("
+        r"get_bool|get_env|first_env|os\.getenv|"
+        r"os\.environ\.get|os\.environ\[|"
+        r"\bgetenv|\benviron\["
+        r")\s*\(?\s*[\"']BENCH_USE_MCP[\"']"
+    )
+    reads: dict[Path, int] = {}
+    for path in devops_bench_root.rglob("*.py"):
+        text = path.read_text()
+        matches = read_pattern.findall(text)
+        if matches:
+            reads[path.relative_to(devops_bench_root)] = len(matches)
+
+    # Allowed read sites (CONVENTIONS.md §7):
+    # * ``evalharness/default.py`` — the canonical single read site.
+    # * ``metrics/pipeline.py`` — a documented *fallback* the harness never
+    #   triggers (it always passes ``use_mcp=`` explicitly), retained for
+    #   legacy CLI callers running ``evaluate_metrics_batch`` directly.
+    assert set(reads.keys()) <= {
+        Path("evalharness/default.py"),
+        Path("metrics/pipeline.py"),
+    }, f"unexpected BENCH_USE_MCP reads in: {sorted(reads)}"
+    # Pin the harness file to exactly one read so an accidental second read
+    # site (e.g. from a per-task refresh) is caught here.
+    assert reads.get(Path("evalharness/default.py")) == 1

--- a/tests/unit/evalharness/test_spec_parsing.py
+++ b/tests/unit/evalharness/test_spec_parsing.py
@@ -1,0 +1,186 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Harness parses opaque task blobs into typed component contracts.
+
+CONVENTIONS.md §3 / §4: every Layer-2 seam consumes a **typed** node, so the
+harness must convert the opaque ``chaos_spec`` / ``verification_spec`` blobs
+(``Any`` at the Layer-1 task boundary) into ``ChaosSpec`` / ``VerificationSpec``
+at its own boundary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from devops_bench.chaos import ChaosSpec
+from devops_bench.chaos.faults.generate_load import GenerateLoadFault
+from devops_bench.chaos.triggers.time_delay import TimeTrigger
+from devops_bench.evalharness.default import DefaultHarness
+from devops_bench.tasks import FileSystemTaskLoader
+from devops_bench.verification import (
+    ParallelSpec,
+    VerificationSpec,
+)
+from devops_bench.verification.verifiers import (
+    PodHealthyVerifier,
+    ScalingCompleteVerifier,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_TASK_DIR = _REPO_ROOT / "complextasks" / "optimize-scale"
+_TASK_YAML = _TASK_DIR / "task.yaml"
+
+
+def _harness() -> DefaultHarness:
+    return DefaultHarness(project_id="proj", cluster_name="cluster")
+
+
+def test_optimize_scale_chaos_parses_through_harness() -> None:
+    """The harness migrates the real optimize-scale chaos blob to typed nodes."""
+    raw = yaml.safe_load(_TASK_YAML.read_text())
+    specs = _harness()._parse_chaos_specs(raw["chaos_spec"], cluster_name="c")  # noqa: SLF001
+
+    assert len(specs) == 1
+    spec = specs[0]
+    assert isinstance(spec, ChaosSpec)
+    assert isinstance(spec.trigger, TimeTrigger)
+    assert spec.trigger.delay_seconds == 5
+    assert isinstance(spec.action, GenerateLoadFault)
+    assert spec.action.target.qps == 300
+    # Placeholders flow through the rewrite, even though chaos_spec is now
+    # native YAML (Decision D2 — values migrated, field name kept).
+    assert "{{" not in spec.action.target.service_url
+    assert spec.verify == "Planned Load Spike Verification"
+
+
+def test_optimize_scale_verification_mapping_keys_typed_specs() -> None:
+    """``_build_verification_mapping`` returns ``(mapping, errors)`` with typed specs.
+
+    The errors list is empty on the canonical optimize-scale shape; a
+    separate test exercises the loud-fail path.
+    """
+    raw = yaml.safe_load(_TASK_YAML.read_text())
+    mapping, errors = _harness()._build_verification_mapping(  # noqa: SLF001
+        raw["verification_spec"], cluster_name="c"
+    )
+
+    assert errors == []
+    assert set(mapping.keys()) == {"Planned Load Spike Verification"}
+    node = mapping["Planned Load Spike Verification"]
+    assert isinstance(node, VerificationSpec)
+    root = node.root
+    assert isinstance(root, ParallelSpec)
+    leaf_types = [type(leaf) for leaf in root.checks]
+    assert PodHealthyVerifier in leaf_types
+    assert ScalingCompleteVerifier in leaf_types
+
+
+def test_verification_mapping_canonical_wrapped_shape() -> None:
+    """The canonical ``[{name, spec: <typed-node>}]`` shape parses end-to-end."""
+    raw = [
+        {
+            "name": "all-healthy",
+            "spec": {
+                "type": "parallel",
+                "checks": [
+                    {
+                        "type": "pod_healthy",
+                        "selector": "app=demo",
+                        "namespace": "default",
+                    }
+                ],
+            },
+        }
+    ]
+    mapping, errors = _harness()._build_verification_mapping(  # noqa: SLF001
+        raw, cluster_name="c"
+    )
+    assert errors == []
+    assert set(mapping.keys()) == {"all-healthy"}
+    assert isinstance(mapping["all-healthy"], VerificationSpec)
+
+
+def test_verification_mapping_bare_node_compat_shape_still_parses() -> None:
+    """Legacy bare-node entries (no ``spec:`` wrapper) still parse.
+
+    Pins the back-compat branch — the entry mapping itself acts as the
+    typed verification node when no ``spec`` key is present. Documented
+    explicitly in :meth:`_build_verification_mapping` so reviewers can
+    spot the two-shape acceptance.
+    """
+    raw = [
+        {
+            "name": "pods",
+            "type": "pod_healthy",
+            "selector": "app=demo",
+            "namespace": "default",
+        }
+    ]
+    mapping, errors = _harness()._build_verification_mapping(  # noqa: SLF001
+        raw, cluster_name="c"
+    )
+    assert errors == []
+    assert set(mapping.keys()) == {"pods"}
+
+
+def test_verification_mapping_surfaces_validation_failures() -> None:
+    """A malformed entry never silently disappears — it lands on ``errors``."""
+    raw = [
+        {"name": "good", "spec": {"type": "pod_healthy", "selector": "app=x"}},
+        # Missing ``type`` discriminator — pydantic rejects.
+        {"name": "bad", "spec": {"selector": "app=y"}},
+        # Missing ``name`` — skipped + recorded as an authoring error.
+        {"spec": {"type": "pod_healthy", "selector": "app=z"}},
+        # Non-mapping entry — skipped + recorded.
+        "not a mapping",
+    ]
+    mapping, errors = _harness()._build_verification_mapping(  # noqa: SLF001
+        raw, cluster_name="c"
+    )
+    assert set(mapping.keys()) == {"good"}
+    # Every authoring failure shows up — operator sees the broken entries
+    # on the run record, not just a log line.
+    error_names = {e["name"] for e in errors}
+    assert "bad" in error_names
+    # Index-keyed labels for the unnamed / non-mapping entries.
+    assert any(name.startswith("<index ") for name in error_names)
+
+
+def test_legacy_json_in_yaml_chaos_spec_still_parses() -> None:
+    """A legacy JSON-in-YAML string round-trips through the harness parser.
+
+    Decision D2 keeps the *field name* stable; the harness accepts both the
+    legacy string-valued shape and the post-migration native-YAML shape so an
+    older fork can land the harness PR without touching its task files.
+    """
+    legacy_blob = (
+        '[{"name":"X","trigger":{"type":"time","delay_seconds":1},'
+        '"action":{"type":"generate_load","target":{"service_url":"http://h","qps":1}}}]'
+    )
+    specs = _harness()._parse_chaos_specs(legacy_blob, cluster_name="c")  # noqa: SLF001
+    assert len(specs) == 1
+    assert specs[0].name == "X"
+
+
+def test_task_loader_reads_native_yaml_specs_as_python_values() -> None:
+    """The Layer-1 task loader carries the native-YAML blob through unchanged."""
+    tasks = FileSystemTaskLoader().load_tasks(str(_TASK_DIR))
+    assert len(tasks) == 1
+    task = tasks[0]
+    # Opaque ``Any``: a list-of-mappings flows through verbatim, not as a string.
+    assert isinstance(task.chaos_spec, list)
+    assert isinstance(task.verification_spec, list)

--- a/tests/unit/metrics/test_metrics_base.py
+++ b/tests/unit/metrics/test_metrics_base.py
@@ -1,0 +1,157 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the metrics extension primitives: MetricScore, run_geval, registry."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from devops_bench.metrics.base import (
+    METRICS,
+    MetricContext,
+    MetricEvaluator,
+    MetricScore,
+    run_geval,
+)
+
+# --- MetricScore.to_entry() — D3 legacy-shape preservation -------------------
+
+
+def test_metric_score_to_entry_bare_value_for_rate_metrics():
+    # Rate / perf passthroughs: no success or reason → entry is the raw value.
+    ms = MetricScore(name="DocRetrievalRate", score=0.42)
+    assert ms.to_entry() == 0.42
+
+
+def test_metric_score_to_entry_dict_for_judged_metrics():
+    # Judged metrics: success + reason flip the entry to the legacy dict shape.
+    ms = MetricScore(
+        name="OutcomeValidity", score=0.9, success=True, reason="solid"
+    )
+    assert ms.to_entry() == {"score": 0.9, "success": True, "reason": "solid"}
+
+
+def test_metric_score_to_entry_round_trips_through_either_shape():
+    bare = MetricScore(name="X", score=0.5)
+    judged = MetricScore(name="Y", score=0.5, success=False, reason="meh")
+    assert isinstance(bare.to_entry(), float)
+    assert isinstance(judged.to_entry(), dict)
+
+
+def test_metric_score_to_entry_preserves_none_score():
+    ms = MetricScore(name="Workload_Uptime_Percentage", score=None)
+    assert ms.to_entry() is None
+
+
+# --- run_geval — single shared recorder, strips " [GEval]" --------------------
+
+
+def test_run_geval_strips_geval_suffix_exactly_once(mocker):
+    # DeepEval appends " [GEval]" to GEval metric names; run_geval must strip it
+    # and emit the bare name.
+    test_result = SimpleNamespace(
+        metrics_data=[
+            SimpleNamespace(
+                name="OutcomeValidity [GEval]", score=0.7, success=True, reason="ok"
+            )
+        ]
+    )
+    mocker.patch(
+        "deepeval.evaluate", return_value=SimpleNamespace(test_results=[test_result])
+    )
+
+    out = run_geval(MagicMock(), [MagicMock()])
+
+    assert len(out) == 1
+    assert out[0].name == "OutcomeValidity"
+    assert out[0].score == 0.7
+    assert out[0].success is True
+    assert out[0].reason == "ok"
+
+
+def test_run_geval_leaves_non_geval_names_alone(mocker):
+    # Metric data that does not carry the suffix passes through unchanged.
+    test_result = SimpleNamespace(
+        metrics_data=[
+            SimpleNamespace(
+                name="GracefulRecovery", score=4.0, success=True, reason="r"
+            )
+        ]
+    )
+    mocker.patch(
+        "deepeval.evaluate", return_value=SimpleNamespace(test_results=[test_result])
+    )
+
+    out = run_geval(MagicMock(), [MagicMock()])
+
+    assert out[0].name == "GracefulRecovery"
+
+
+# --- MetricContext + use_mcp flow --------------------------------------------
+
+
+def test_metric_context_carries_use_mcp_and_judge():
+    # use_mcp arrives via MetricContext (CONVENTIONS.md §7): metrics never
+    # self-read BENCH_USE_MCP.
+    judge = MagicMock()
+    ctx = MetricContext(
+        result={"name": "t"},
+        judge=judge,
+        use_mcp=False,
+        outcome_case=MagicMock(),
+        tool_case=MagicMock(),
+        all_case=MagicMock(),
+    )
+    assert ctx.use_mcp is False
+    assert ctx.judge is judge
+
+
+# --- METRICS registry — extension axis ---------------------------------------
+
+
+def test_metric_evaluator_protocol_is_runtime_checkable():
+    class Dummy:
+        name = "dummy"
+
+        def applies(self, ctx):
+            return True
+
+        def evaluate(self, ctx):
+            return []
+
+    assert isinstance(Dummy(), MetricEvaluator)
+
+
+def test_metrics_registry_records_decorated_class():
+    # A new metric is one decorator away — no orchestrator surgery. We register
+    # under a unique key, then deregister so the global registry stays clean.
+    @METRICS.register("test_metric_base_dummy")
+    class _Dummy:
+        name = "TestMetricBaseDummy"
+
+        def applies(self, ctx):
+            return True
+
+        def evaluate(self, ctx):
+            yield MetricScore(name="TestMetricBaseDummy", score=1.0)
+
+    try:
+        assert METRICS.get("test_metric_base_dummy") is _Dummy
+        assert "test_metric_base_dummy" in METRICS
+    finally:
+        # ``Registry`` exposes no delete; reach into the private dict so the
+        # cleanup does not leak into sibling tests.
+        METRICS._items.pop("test_metric_base_dummy", None)

--- a/tests/unit/metrics/test_metrics_chaos.py
+++ b/tests/unit/metrics/test_metrics_chaos.py
@@ -1,0 +1,91 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for chaos-mode scoring."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from devops_bench.metrics import chaos_metrics
+from devops_bench.metrics.chaos_metrics import evaluate_chaos_metrics
+
+
+def _chaos_result():
+    diag = SimpleNamespace(
+        name="DiagnosisAccuracy [GEval]", score=5.0, success=True, reason="r"
+    )
+    rec = SimpleNamespace(
+        name="GracefulRecovery", score=4.0, success=True, reason="r"
+    )
+    test_result = SimpleNamespace(metrics_data=[diag, rec])
+    return SimpleNamespace(test_results=[test_result])
+
+
+def test_chaos_records_geval_and_perf(mocker):
+    captured = {}
+
+    def _fake_geval(**kwargs):
+        captured.setdefault("names", []).append(kwargs["name"])
+        captured["criteria"] = captured.get("criteria", []) + [kwargs["criteria"]]
+        return MagicMock()
+
+    mocker.patch.object(chaos_metrics, "GEval", side_effect=_fake_geval)
+    mocker.patch("deepeval.evaluate", return_value=_chaos_result())
+    scores: dict = {}
+
+    evaluate_chaos_metrics(
+        MagicMock(),
+        MagicMock(),
+        {"injected_fault": "node drain"},
+        {
+            "deployment_time_seconds": 12.0,
+            "uptime_percentage": 99.5,
+            "resource_utilization_efficiency": 0.8,
+        },
+        scores,
+    )
+
+    # GEval name suffix stripped on record (via shared run_geval).
+    assert scores["DiagnosisAccuracy"]["score"] == 5.0
+    assert scores["GracefulRecovery"]["success"] is True
+    # Injected fault propagated into the diagnosis criteria.
+    assert any("node drain" in c for c in captured["criteria"])
+    # Performance numbers copied through verbatim.
+    assert scores["Workload_Deployment_Time_Seconds"] == 12.0
+    assert scores["Workload_Uptime_Percentage"] == 99.5
+    assert scores["Resource_Utilization_Efficiency"] == 0.8
+
+
+def test_chaos_defaults_fault_and_survives_eval_error(mocker):
+    captured = {}
+    mocker.patch.object(
+        chaos_metrics,
+        "GEval",
+        side_effect=lambda **kw: captured.setdefault("criteria", []).append(
+            kw["criteria"]
+        )
+        or MagicMock(),
+    )
+    mocker.patch("deepeval.evaluate", side_effect=RuntimeError("judge down"))
+    scores: dict = {}
+
+    evaluate_chaos_metrics(MagicMock(), MagicMock(), {}, {}, scores)
+
+    # Default fault used when none reported.
+    assert any("pod deletion" in c for c in captured["criteria"])
+    # Eval failure swallowed; perf keys still populated (as None here).
+    assert "Workload_Uptime_Percentage" in scores
+    assert scores["Workload_Uptime_Percentage"] is None

--- a/tests/unit/metrics/test_metrics_extension_axis.py
+++ b/tests/unit/metrics/test_metrics_extension_axis.py
@@ -1,0 +1,78 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extension-axis acceptance: a dummy metric appears with no orchestrator edit."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from unittest.mock import MagicMock
+
+from devops_bench.metrics import pipeline
+from devops_bench.metrics.base import (
+    METRICS,
+    MetricContext,
+    MetricScore,
+)
+from devops_bench.metrics.pipeline import evaluate_metrics_batch
+
+
+def _base_result(**overrides):
+    res = {
+        "input": "ping",
+        "output": "pong",
+        "trajectory": [],
+        "expected_output": "Expected pong",
+        "latency": 0.1,
+        "name": "case-dummy",
+        "retrieval_context": [],
+        "tools": [],
+    }
+    res.update(overrides)
+    return res
+
+
+def test_dummy_metric_appears_in_scores_with_no_orchestrator_edit(mocker):
+    # Stub out judge construction so the built-in metrics don't reach for
+    # ``deepeval.evaluate`` during the loop (they would normally call it via
+    # ``run_geval``); a no-op return means they record nothing while our dummy
+    # still emits its score, which is what we want to assert on.
+    from devops_bench.metrics import outcome_validity, tool_invocation
+
+    mocker.patch.object(outcome_validity, "build_outcome_validity_metric")
+    mocker.patch.object(tool_invocation, "build_tool_invocation_metric")
+    mocker.patch.object(pipeline, "LLMTestCase")
+    mocker.patch("deepeval.evaluate", return_value=MagicMock(test_results=[]))
+
+    @METRICS.register("acceptance_dummy")
+    class _DummyAcceptanceMetric:
+        name = "DummyAcceptanceMetric"
+
+        def applies(self, ctx: MetricContext) -> bool:
+            return True
+
+        def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
+            yield MetricScore(name="DummyAcceptanceMetric", score=0.99)
+
+    try:
+        results = [_base_result()]
+        evaluate_metrics_batch(results, MagicMock(), use_mcp=True)
+
+        # The dummy metric appears in ``res["scores"]`` without touching
+        # ``evaluate_metrics_batch`` — that is the whole point of the registry.
+        assert "DummyAcceptanceMetric" in results[0]["scores"]
+        # Bare-value entry round-trips through ``MetricScore.to_entry()`` (D3).
+        assert results[0]["scores"]["DummyAcceptanceMetric"] == 0.99
+    finally:
+        METRICS._items.pop("acceptance_dummy", None)

--- a/tests/unit/metrics/test_metrics_geval.py
+++ b/tests/unit/metrics/test_metrics_geval.py
@@ -1,0 +1,124 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the model-agnostic DeepEval judge."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+from devops_bench.metrics import geval
+from devops_bench.metrics.geval import ModelLayerJudge
+
+
+def _fake_client(text="judged", model_name="judge-model"):
+    client = MagicMock()
+    client.model_name = model_name
+    client.generate_content = AsyncMock(return_value="raw-response")
+    client.get_text_content = MagicMock(return_value=text)
+    return client
+
+
+def test_wraps_supplied_client_without_get_model(mocker):
+    get_model = mocker.patch.object(geval, "get_model")
+    client = _fake_client()
+
+    judge = ModelLayerJudge(client=client, model_name="explicit")
+
+    get_model.assert_not_called()
+    assert judge.load_model() is client
+    assert judge.get_model_name() == "explicit"
+
+
+def test_builds_client_from_config(mocker):
+    get_model = mocker.patch.object(geval, "get_model")
+    client = _fake_client(model_name="from-adapter")
+    get_model.return_value = client
+    mocker.patch.dict(
+        os.environ,
+        {"JUDGE_PROVIDER": "anthropic", "JUDGE_MODEL": "claude-test"},
+        clear=True,
+    )
+
+    judge = ModelLayerJudge()
+
+    get_model.assert_called_once_with(provider="anthropic", model_name="claude-test")
+    assert judge.get_model_name() == "claude-test"
+
+
+def test_model_name_falls_back_to_client(mocker):
+    mocker.patch.object(geval, "get_model")
+    client = _fake_client(model_name="adapter-default")
+
+    judge = ModelLayerJudge(client=client)
+
+    assert judge.get_model_name() == "adapter-default"
+
+
+def test_a_generate_uses_text_only_call():
+    client = _fake_client(text="the verdict")
+    judge = ModelLayerJudge(client=client)
+
+    import asyncio
+
+    out = asyncio.run(judge.a_generate("score this"))
+
+    assert out == "the verdict"
+    client.generate_content.assert_awaited_once_with(
+        contents=[{"role": "user", "content": "score this"}],
+        tools=None,
+        system_instruction=None,
+    )
+
+
+def test_a_generate_returns_empty_string_for_none():
+    client = _fake_client()
+    client.get_text_content.return_value = None
+    judge = ModelLayerJudge(client=client)
+
+    import asyncio
+
+    assert asyncio.run(judge.a_generate("x")) == ""
+
+
+def test_generate_runs_async():
+    client = _fake_client(text="sync result")
+    judge = ModelLayerJudge(client=client)
+
+    assert judge.generate("prompt") == "sync result"
+
+
+def test_generate_is_loop_aware():
+    # When a loop is already running, generate() must not call asyncio.run()
+    # re-entrantly; it offloads to a worker thread and still returns the text.
+    import asyncio
+
+    client = _fake_client(text="loop-safe result")
+    judge = ModelLayerJudge(client=client)
+
+    async def _call_from_running_loop():
+        return judge.generate("prompt")
+
+    assert asyncio.run(_call_from_running_loop()) == "loop-safe result"
+
+
+def test_get_judge_model_passes_through(mocker):
+    get_model = mocker.patch.object(geval, "get_model")
+    get_model.return_value = _fake_client(model_name="gm")
+
+    judge = geval.get_judge_model(provider="ollama", model_name="gemma")
+
+    get_model.assert_called_once_with(provider="ollama", model_name="gemma")
+    assert judge.get_model_name() == "gemma"

--- a/tests/unit/metrics/test_metrics_grounding.py
+++ b/tests/unit/metrics/test_metrics_grounding.py
@@ -1,0 +1,203 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for documentation grounding metrics."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from devops_bench.metrics import grounding
+from devops_bench.metrics.grounding import (
+    calculate_doc_retrieval_rate,
+    evaluate_documentation_grounding,
+)
+
+# --- calculate_doc_retrieval_rate (pure logic) --------------------------------
+
+
+def test_retrieval_rate_empty_docs():
+    assert calculate_doc_retrieval_rate([], [{"step": 1}]) == 0.0
+
+
+def test_retrieval_rate_matches_by_name():
+    docs = [{"doc_name": "GuideA", "url": "http://a"}]
+    trajectory = [{"action": "read guidea docs"}]
+    assert calculate_doc_retrieval_rate(docs, trajectory) == 1.0
+
+
+def test_retrieval_rate_matches_by_url():
+    docs = [{"doc_name": "GuideA", "url": "http://example.com/a"}]
+    trajectory = [{"href": "see http://example.com/a now"}]
+    assert calculate_doc_retrieval_rate(docs, trajectory) == 1.0
+
+
+def test_retrieval_rate_partial():
+    docs = [
+        {"doc_name": "GuideA", "url": "http://a"},
+        {"doc_name": "GuideB", "url": "http://b"},
+    ]
+    trajectory = [{"action": "read guidea"}]
+    assert calculate_doc_retrieval_rate(docs, trajectory) == 0.5
+
+
+def test_retrieval_rate_no_match():
+    docs = [{"doc_name": "GuideA", "url": "http://a"}]
+    assert calculate_doc_retrieval_rate(docs, [{"action": "nothing here"}]) == 0.0
+
+
+def test_retrieval_rate_tolerates_missing_name_and_url():
+    docs = [
+        {"url": "http://a"},  # no doc_name
+        {"doc_name": None, "url": None},  # both None
+        {"doc_name": "GuideC", "url": "http://c"},
+    ]
+    trajectory = [{"action": "read guidec via http://c"}]
+    assert calculate_doc_retrieval_rate(docs, trajectory) == pytest.approx(1 / 3)
+
+
+# --- evaluate_documentation_grounding (GEval mocked) --------------------------
+
+
+def _metric_result(name, score, success, reason="ok"):
+    metric_data = SimpleNamespace(name=name, score=score, success=success, reason=reason)
+    test_result = SimpleNamespace(metrics_data=[metric_data])
+    return SimpleNamespace(test_results=[test_result])
+
+
+def _named_geval(mocker):
+    """Patch grounding.GEval so each metric carries its real ``name``."""
+    return mocker.patch.object(
+        grounding, "GEval", side_effect=lambda **kw: SimpleNamespace(name=kw["name"])
+    )
+
+
+def _evaluate_by_outcome(mocker, outcomes):
+    """Order-agnostic ``deepeval.evaluate`` keyed off the metric name.
+
+    ``outcomes`` maps a metric name (as built by the grounding code, e.g.
+    ``"Doc Constraint: use TLS"``) to a ``(score, success)`` pair. The reported
+    name carries DeepEval's ``" [GEval]"`` suffix so the strip path is exercised.
+    """
+
+    def _side_effect(test_cases, metrics):
+        name = metrics[0].name
+        score, success = outcomes[name]
+        return _metric_result(f"{name} [GEval]", score, success)
+
+    return mocker.patch("deepeval.evaluate", side_effect=_side_effect)
+
+
+def test_grounding_no_constraints_returns_early(mocker):
+    evaluate = mocker.patch("deepeval.evaluate")
+    scores: dict = {}
+
+    evaluate_documentation_grounding(
+        [{"constraints": []}], MagicMock(), MagicMock(), scores
+    )
+
+    evaluate.assert_not_called()
+    assert scores == {}
+
+
+def test_grounding_all_applied_scores_full(mocker):
+    _named_geval(mocker)
+    docs = [
+        {
+            "constraints": [
+                {"text": "use TLS", "critical": True},
+                {"text": "set replicas", "critical": False},
+            ]
+        }
+    ]
+    scores: dict = {}
+    _evaluate_by_outcome(
+        mocker,
+        {
+            "Doc Constraint: use TLS": (5.0, True),
+            "Doc Constraint: set replicas": (5.0, True),
+        },
+    )
+
+    evaluate_documentation_grounding(docs, MagicMock(), MagicMock(), scores)
+
+    assert scores["GroundingAccuracy"]["score"] == 5.0
+    assert scores["GroundingAccuracy"]["success"] is True
+    assert scores["ParameterRecallAccuracy"] == 1.0
+    # Per-constraint keys recorded with the [GEval] suffix stripped.
+    assert scores["Doc Constraint: use TLS"]["success"] is True
+
+
+def test_grounding_critical_missing_scores_partial(mocker):
+    _named_geval(mocker)
+    docs = [
+        {
+            "constraints": [
+                {"text": "use TLS", "critical": True},
+                {"text": "set replicas", "critical": False},
+            ]
+        }
+    ]
+    scores: dict = {}
+    _evaluate_by_outcome(
+        mocker,
+        {
+            "Doc Constraint: use TLS": (0.0, False),
+            "Doc Constraint: set replicas": (5.0, True),
+        },
+    )
+
+    evaluate_documentation_grounding(docs, MagicMock(), MagicMock(), scores)
+
+    # Critical applied (0) < critical total (1) => partial 2.5.
+    assert scores["GroundingAccuracy"]["score"] == 2.5
+    assert scores["GroundingAccuracy"]["success"] is False
+    assert scores["ParameterRecallAccuracy"] == 0.5
+
+
+def test_grounding_none_applied_scores_zero(mocker):
+    _named_geval(mocker)
+    docs = [{"constraints": [{"text": "use TLS", "critical": True}]}]
+    scores: dict = {}
+    _evaluate_by_outcome(mocker, {"Doc Constraint: use TLS": (0.0, False)})
+
+    evaluate_documentation_grounding(docs, MagicMock(), MagicMock(), scores)
+
+    assert scores["GroundingAccuracy"]["score"] == 0.0
+    assert scores["ParameterRecallAccuracy"] == 0.0
+
+
+def test_grounding_dedups_shared_constraint_text(mocker):
+    # Two guides share the same constraint text; it must collapse to one metric
+    # so a perfect 5.0 (applied == unique total) is reachable.
+    _named_geval(mocker)
+    docs = [
+        {"constraints": [{"text": "use TLS", "critical": True}]},
+        {"constraints": [{"text": "use TLS", "critical": True}]},
+    ]
+    scores: dict = {}
+    evaluate = _evaluate_by_outcome(
+        mocker, {"Doc Constraint: use TLS": (5.0, True)}
+    )
+
+    evaluate_documentation_grounding(docs, MagicMock(), MagicMock(), scores)
+
+    # Deduped: a single metric evaluated once, and the perfect score is reachable.
+    assert evaluate.call_count == 1
+    assert scores["GroundingAccuracy"]["score"] == 5.0
+    assert scores["GroundingAccuracy"]["success"] is True
+    assert scores["ParameterRecallAccuracy"] == 1.0

--- a/tests/unit/metrics/test_metrics_grounding.py
+++ b/tests/unit/metrics/test_metrics_grounding.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from devops_bench.metrics import grounding
+from devops_bench.metrics.base import GEVAL_PASS_THRESHOLD
 from devops_bench.metrics.grounding import (
     calculate_doc_retrieval_rate,
     evaluate_documentation_grounding,
@@ -100,6 +101,19 @@ def _evaluate_by_outcome(mocker, outcomes):
         return _metric_result(f"{name} [GEval]", score, success)
 
     return mocker.patch("deepeval.evaluate", side_effect=_side_effect)
+
+
+def test_grounding_constraint_geval_uses_explicit_pass_threshold(mocker):
+    # Per-constraint GEvals must pass the explicit 0.8 cutoff rather than
+    # inheriting deepeval's looser 0.5 default, since their success flags drive
+    # GroundingAccuracy / ParameterRecallAccuracy.
+    geval_cls = _named_geval(mocker)
+    mocker.patch("deepeval.evaluate", return_value=SimpleNamespace(test_results=[]))
+    docs = [{"constraints": [{"text": "use TLS", "critical": True}]}]
+
+    evaluate_documentation_grounding(docs, MagicMock(), MagicMock(), {})
+
+    assert geval_cls.call_args.kwargs["threshold"] == GEVAL_PASS_THRESHOLD
 
 
 def test_grounding_no_constraints_returns_early(mocker):

--- a/tests/unit/metrics/test_metrics_pipeline.py
+++ b/tests/unit/metrics/test_metrics_pipeline.py
@@ -1,0 +1,309 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the registry-driven batch scoring pipeline."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from devops_bench.metrics import checklist, pipeline
+from devops_bench.metrics.pipeline import (
+    CHECKLIST_THRESHOLD,
+    evaluate_metrics_batch,
+    extract_checklist_items,
+)
+
+# --- extract_checklist_items (pure logic) -------------------------------------
+
+
+def test_checklist_extracts_critical_requirements_bullets():
+    expected = (
+        "Critical Requirements:\n"
+        "- Deployment must use 3 replicas\n"
+        "- Service exposes port 8080\n"
+    )
+    assert extract_checklist_items(expected, use_mcp=True) == [
+        "Deployment must use 3 replicas",
+        "Service exposes port 8080",
+    ]
+
+
+def test_checklist_stops_at_expected_manifest_marker():
+    expected = (
+        "Critical Requirements:\n"
+        "- Keep replicas at 3\n"
+        "Expected Manifest Generated:\n"
+        "- apiVersion: apps/v1\n"
+    )
+    assert extract_checklist_items(expected, use_mcp=True) == ["Keep replicas at 3"]
+
+
+def test_checklist_drops_tool_call_items_when_mcp_disabled():
+    expected = (
+        "Critical Requirements:\n"
+        "- Expected Tool Call: apply_manifest\n"
+        "- App is reachable\n"
+    )
+    assert extract_checklist_items(expected, use_mcp=False) == ["App is reachable"]
+    assert extract_checklist_items(expected, use_mcp=True) == [
+        "Expected Tool Call: apply_manifest",
+        "App is reachable",
+    ]
+
+
+def test_checklist_empty_when_no_bullets():
+    assert extract_checklist_items("Some prose without bullets", use_mcp=True) == []
+
+
+def test_checklist_preserves_trailing_hyphen():
+    # ``lstrip("- ")`` must not eat a trailing hyphen the way ``strip("- ")`` would.
+    expected = "Critical Requirements:\n- Deploy to namespace staging-\n"
+    assert extract_checklist_items(expected, use_mcp=True) == [
+        "Deploy to namespace staging-"
+    ]
+
+
+def test_checklist_threshold_is_value_independent_of_tool_invocation():
+    # Phase-0 fix #1: a dedicated constant so the checklist cutoff is not
+    # silently coupled to ``TOOL_INVOCATION_THRESHOLD``.
+    assert CHECKLIST_THRESHOLD == 0.8
+
+
+# --- evaluate_metrics_batch (deepeval mocked) ---------------------------------
+
+
+def _metric_result(name, score=1.0, success=True, reason="ok"):
+    metric_data = SimpleNamespace(
+        name=name, score=score, success=success, reason=reason
+    )
+    test_result = SimpleNamespace(metrics_data=[metric_data])
+    return SimpleNamespace(test_results=[test_result])
+
+
+def _evaluate_by_metric_name(successes=None):
+    """Build an order-agnostic ``evaluate`` side effect.
+
+    The pipeline always calls ``evaluate([tc], metrics=[m])`` with a single
+    metric, so the result is derived from that metric's real ``name`` rather
+    than call order. The reported name carries DeepEval's ``" [GEval]"`` suffix
+    so the test actually exercises the suffix stripping. ``successes`` optionally
+    maps a metric name (pre-suffix) to its success bool (default True).
+    """
+    successes = successes or {}
+
+    def _side_effect(test_cases, metrics):
+        metric = metrics[0]
+        name = metric.name
+        return _metric_result(f"{name} [GEval]", success=successes.get(name, True))
+
+    return _side_effect
+
+
+def _base_result(**overrides):
+    res = {
+        "input": "deploy the app",
+        "output": "done, applied to cluster",
+        "trajectory": [{"tool": "apply"}],
+        "expected_output": "App deployed",
+        "latency": 1.0,
+        "name": "case-1",
+        "retrieval_context": [],
+        "tools": ["apply"],
+    }
+    res.update(overrides)
+    return res
+
+
+def _patch_judges(mocker):
+    from devops_bench.metrics import outcome_validity, tool_invocation
+
+    mocker.patch.object(
+        outcome_validity,
+        "build_outcome_validity_metric",
+        return_value=SimpleNamespace(name="OutcomeValidity"),
+    )
+    mocker.patch.object(
+        tool_invocation,
+        "build_tool_invocation_metric",
+        return_value=SimpleNamespace(name="ToolInvocation"),
+    )
+
+
+def test_batch_scores_outcome_and_tool(mocker):
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    # Order-agnostic: result keyed off the metric name with the [GEval] suffix
+    # exercised through the strip path.
+    mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+    judge = MagicMock()
+    results = [_base_result(expected_output="App deployed")]  # no bullets
+
+    evaluate_metrics_batch(results, judge, use_mcp=True)
+
+    scores = results[0]["scores"]
+    assert "OutcomeValidity" in scores
+    assert "ToolInvocation" in scores
+    assert "OutcomeValidity [GEval]" not in scores
+    assert "ToolInvocation [GEval]" not in scores
+    assert "ChecklistScore" not in scores
+
+
+def test_batch_skips_tool_when_mcp_disabled(mocker):
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    evaluate = mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+    judge = MagicMock()
+    results = [_base_result()]
+
+    evaluate_metrics_batch(results, judge, use_mcp=False)
+
+    # Only the outcome evaluation runs (ToolInvocation gated by ctx.use_mcp).
+    assert evaluate.call_count == 1
+    assert "OutcomeValidity" in results[0]["scores"]
+    assert "ToolInvocation" not in results[0]["scores"]
+
+
+def test_batch_use_mcp_falls_back_to_env(mocker):
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+    mocker.patch.object(pipeline, "get_bool", return_value=False)
+    judge = MagicMock()
+    results = [_base_result()]
+
+    evaluate_metrics_batch(results, judge)  # use_mcp omitted → env fallback
+
+    assert "ToolInvocation" not in results[0]["scores"]
+
+
+def test_batch_computes_checklist_score(mocker):
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    # Give the dynamic GEval metric a stable name so success is matchable.
+    mocker.patch.object(
+        checklist, "GEval", side_effect=lambda **kw: SimpleNamespace(name=kw["name"])
+    )
+    mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+    judge = MagicMock()
+    results = [_base_result(expected_output="Critical Requirements:\n- replicas=3\n")]
+
+    evaluate_metrics_batch(results, judge, use_mcp=True)
+
+    scores = results[0]["scores"]
+    # The dynamic check key is also stripped of the [GEval] suffix.
+    assert "Check: replicas=3" in scores
+    assert scores["ChecklistScore"]["score"] == 1.0
+    assert scores["ChecklistScore"]["success"] is True
+
+
+def test_batch_invokes_grounding_and_chaos(mocker):
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+
+    from devops_bench.metrics import chaos_metrics, grounding
+
+    grounding_call = mocker.patch.object(grounding, "evaluate_documentation_grounding")
+    retrieval = mocker.patch.object(
+        grounding, "calculate_doc_retrieval_rate", return_value=0.5
+    )
+    chaos = mocker.patch.object(chaos_metrics, "evaluate_chaos_metrics")
+    judge = MagicMock()
+    results = [
+        _base_result(
+            documentation=[{"doc_name": "g", "url": "u", "constraints": []}],
+            chaos_spec=[{"fault": "kill"}],
+            chaos_report={"injected_fault": "kill"},
+            perf_report={"uptime_percentage": 99.9},
+        )
+    ]
+
+    evaluate_metrics_batch(results, judge, use_mcp=True)
+
+    grounding_call.assert_called_once()
+    retrieval.assert_called_once()
+    chaos.assert_called_once()
+    assert results[0]["scores"]["DocRetrievalRate"] == 0.5
+
+
+def test_batch_score_insertion_order_matches_legacy_results_json(mocker):
+    # D3: ``res["scores"]`` insertion order lands on disk; pin the legacy
+    # ordering (outcome -> tool -> checklist -> grounding -> chaos) so
+    # downstream results.json consumers do not see a reshuffle.
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    mocker.patch.object(
+        checklist, "GEval", side_effect=lambda **kw: SimpleNamespace(name=kw["name"])
+    )
+    mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+
+    from devops_bench.metrics import chaos_metrics, grounding
+
+    mocker.patch.object(
+        grounding,
+        "evaluate_documentation_grounding",
+        side_effect=lambda docs, tc, judge, scores: scores.update(
+            {
+                "Doc Constraint: x": {"score": 1.0, "success": True, "reason": "r"},
+                "GroundingAccuracy": {"score": 5.0, "success": True, "reason": "r"},
+                "ParameterRecallAccuracy": 1.0,
+            }
+        ),
+    )
+    mocker.patch.object(
+        grounding, "calculate_doc_retrieval_rate", return_value=0.5
+    )
+    mocker.patch.object(
+        chaos_metrics,
+        "evaluate_chaos_metrics",
+        side_effect=lambda tc, judge, cr, pr, scores: scores.update(
+            {
+                "DiagnosisAccuracy": {"score": 5.0, "success": True, "reason": "r"},
+                "GracefulRecovery": {"score": 4.0, "success": True, "reason": "r"},
+                "Workload_Deployment_Time_Seconds": 12.0,
+                "Workload_Uptime_Percentage": 99.5,
+                "Resource_Utilization_Efficiency": 0.8,
+            }
+        ),
+    )
+
+    results = [
+        _base_result(
+            expected_output="Critical Requirements:\n- replicas=3\n",
+            documentation=[{"doc_name": "g", "url": "u", "constraints": []}],
+            chaos_spec=[{"fault": "kill"}],
+            chaos_report={"injected_fault": "kill"},
+            perf_report={"uptime_percentage": 99.5},
+        )
+    ]
+    evaluate_metrics_batch(results, MagicMock(), use_mcp=True)
+
+    keys = list(results[0]["scores"].keys())
+    # Locate the section anchors and assert outcome -> tool -> checklist ->
+    # grounding -> chaos. We pin the first-occurrence index of one canonical
+    # key from each family so the assertion is robust to the per-family
+    # internal ordering (grounding emits multiple keys, chaos likewise).
+    def idx(name: str) -> int:
+        return keys.index(name)
+
+    assert (
+        idx("OutcomeValidity")
+        < idx("ToolInvocation")
+        < idx("Check: replicas=3")
+        < idx("ChecklistScore")
+        < idx("GroundingAccuracy")
+        < idx("DiagnosisAccuracy")
+    )

--- a/tests/unit/metrics/test_metrics_pipeline.py
+++ b/tests/unit/metrics/test_metrics_pipeline.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from devops_bench.metrics import checklist, pipeline
+from devops_bench.metrics.base import GEVAL_PASS_THRESHOLD
 from devops_bench.metrics.pipeline import (
     CHECKLIST_THRESHOLD,
     evaluate_metrics_batch,
@@ -207,6 +208,24 @@ def test_batch_computes_checklist_score(mocker):
     assert "Check: replicas=3" in scores
     assert scores["ChecklistScore"]["score"] == 1.0
     assert scores["ChecklistScore"]["success"] is True
+
+
+def test_checklist_per_item_geval_uses_explicit_pass_threshold(mocker):
+    # Per-item checklist GEvals must pass the explicit 0.8 cutoff rather than
+    # inheriting deepeval's looser 0.5 default, since their success flags feed
+    # the aggregate ChecklistScore.
+    geval_cls = mocker.patch.object(
+        checklist, "GEval", side_effect=lambda **kw: SimpleNamespace(name=kw["name"])
+    )
+    _patch_judges(mocker)
+    mocker.patch.object(pipeline, "LLMTestCase")
+    mocker.patch("deepeval.evaluate", side_effect=_evaluate_by_metric_name())
+    judge = MagicMock()
+    results = [_base_result(expected_output="Critical Requirements:\n- replicas=3\n")]
+
+    evaluate_metrics_batch(results, judge, use_mcp=True)
+
+    assert geval_cls.call_args.kwargs["threshold"] == GEVAL_PASS_THRESHOLD
 
 
 def test_batch_invokes_grounding_and_chaos(mocker):

--- a/tests/unit/metrics/test_metrics_skills.py
+++ b/tests/unit/metrics/test_metrics_skills.py
@@ -1,0 +1,102 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for skill loading and GEval metric construction (outcome + tool)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from devops_bench.metrics import _skills, outcome_validity, tool_invocation
+from devops_bench.metrics.tool_invocation import TOOL_INVOCATION_THRESHOLD
+
+
+def _patch_resources(mocker, files_by_name):
+    """Patch ``_skills.resources.files`` with a fake package traversable.
+
+    ``files_by_name`` maps a filename to its text content; any name absent from
+    the mapping is treated as a missing resource (``is_file()`` is False).
+    """
+
+    class _FakeResource:
+        def __init__(self, name):
+            self._name = name
+
+        def is_file(self):
+            return self._name in files_by_name
+
+        def read_text(self, encoding="utf-8"):
+            return files_by_name[self._name]
+
+    class _FakePackage:
+        def __truediv__(self, name):
+            return _FakeResource(name)
+
+    mocker.patch.object(_skills.resources, "files", return_value=_FakePackage())
+
+
+def test_load_skill_text_reads_packaged_resource(mocker):
+    _patch_resources(
+        mocker, {"outcome-validity-checklist.md": "## Evaluation Criteria"}
+    )
+    assert (
+        _skills.load_skill_text("outcome-validity-checklist.md")
+        == "## Evaluation Criteria"
+    )
+
+
+def test_load_outcome_criteria_uses_loader(mocker):
+    _patch_resources(
+        mocker, {outcome_validity.OUTCOME_SKILL_FILENAME: "OUTCOME-MD"}
+    )
+    assert outcome_validity.load_outcome_criteria() == "OUTCOME-MD"
+
+
+def test_load_tool_criteria_uses_loader(mocker):
+    _patch_resources(mocker, {tool_invocation.TOOL_SKILL_FILENAME: "TOOL-MD"})
+    assert tool_invocation.load_tool_criteria() == "TOOL-MD"
+
+
+def test_load_skill_text_missing_raises(mocker):
+    _patch_resources(mocker, {})  # nothing exists
+    with pytest.raises(FileNotFoundError):
+        _skills.load_skill_text("does-not-exist.md")
+
+
+def test_build_outcome_validity_metric(mocker):
+    geval_cls = mocker.patch.object(outcome_validity, "GEval")
+    mocker.patch.object(outcome_validity, "load_outcome_criteria", return_value="CRIT")
+    model = MagicMock()
+
+    outcome_validity.build_outcome_validity_metric(model)
+
+    kwargs = geval_cls.call_args.kwargs
+    assert kwargs["name"] == "OutcomeValidity"
+    assert kwargs["criteria"] == "CRIT"
+    assert kwargs["model"] is model
+
+
+def test_build_tool_invocation_metric_applies_threshold(mocker):
+    geval_cls = mocker.patch.object(tool_invocation, "GEval")
+    mocker.patch.object(tool_invocation, "load_tool_criteria", return_value="CRIT")
+    model = MagicMock()
+
+    tool_invocation.build_tool_invocation_metric(model)
+
+    kwargs = geval_cls.call_args.kwargs
+    assert kwargs["name"] == "ToolInvocation"
+    assert kwargs["threshold"] == TOOL_INVOCATION_THRESHOLD
+    assert kwargs["model"] is model

--- a/tests/unit/metrics/test_metrics_skills.py
+++ b/tests/unit/metrics/test_metrics_skills.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from devops_bench.metrics import _skills, outcome_validity, tool_invocation
+from devops_bench.metrics.base import GEVAL_PASS_THRESHOLD
 from devops_bench.metrics.tool_invocation import TOOL_INVOCATION_THRESHOLD
 
 
@@ -86,6 +87,7 @@ def test_build_outcome_validity_metric(mocker):
     kwargs = geval_cls.call_args.kwargs
     assert kwargs["name"] == "OutcomeValidity"
     assert kwargs["criteria"] == "CRIT"
+    assert kwargs["threshold"] == GEVAL_PASS_THRESHOLD
     assert kwargs["model"] is model
 
 

--- a/tests/unit/metrics/test_package_import.py
+++ b/tests/unit/metrics/test_package_import.py
@@ -1,0 +1,67 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Import policy for ``devops_bench.metrics`` and the provider-SDK guarantee.
+
+Under the current policy "light init is a guideline, not a rule": importing
+``devops_bench.metrics`` eagerly pulls ``deepeval`` (the single eval framework).
+``deepeval`` itself imports the provider SDKs (``anthropic``/``google.genai``/
+``openai``) at its own import time, so they ride along when metrics is imported
+— that is accepted.
+
+The provider-SDK *laziness* guarantee that still holds is in our own models
+layer: ``import devops_bench.models`` must not construct a provider client, so
+it pulls no SDK on its own (the SDK is imported only when a model is selected).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_SDKS = ("anthropic", "google.genai", "google.generativeai", "openai", "ollama")
+
+
+def _fresh_import(module: str) -> set[str]:
+    """Import ``module`` in a fresh interpreter; return which SDKs it pulled."""
+    code = (
+        "import sys\n"
+        f"import {module}  # noqa: F401\n"
+        f"print([s for s in {_SDKS!r} if s in sys.modules])\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, proc.stderr
+    return set(eval(proc.stdout.strip()))  # noqa: S307 - trusted child output
+
+
+def test_metrics_exposes_public_symbols():
+    code = (
+        "import devops_bench.metrics as m\n"
+        "assert hasattr(m, 'METRICS')\n"
+        "assert hasattr(m, 'MetricScore')\n"
+        "print('ok')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout
+
+
+def test_models_layer_stays_sdk_lazy():
+    # The real optional-dependency guarantee: our models layer constructs no
+    # provider client on import, so no SDK is pulled until a model is selected.
+    assert _fresh_import("devops_bench.models") == set()


### PR DESCRIPTION
The metrics suite used to be built inline in `pkg/evaluator/evaluate.py` (GEval construction, checklist parsing, scoring in `evaluate_metrics_batch`); this extracts it into `devops_bench/metrics/` as registry-driven evaluators (`METRICS`) over a typed `MetricContext`/`MetricScore`, with judges routed through the `models` layer and judge skills shipped as package data under `devops_bench/skills/`.

**Behavior changes**
- Each metric declares its own `applies()` and yields typed scores via the `METRICS` registry, replacing the monolithic batch function; downstream packages can add metrics without editing the pipeline.
- Judges are instantiated through the `models` layer instead of constructing provider SDK clients directly (provider-agnostic scoring).
- Judge skill markdown moves from a hard-coded `skills/` filesystem path to `devops_bench/skills/` package data, so it resolves under `pip install` / wheels.
- The tool-invocation checklist item is dropped when MCP is disabled, so non-MCP runs are not scored against an inapplicable check.

**Bugs fixed**
- Checklist parsing uses `lstrip("- ")` instead of `strip("- ")`, so trailing hyphens in requirement text are no longer truncated.
- Document-retrieval scoring guards empty `doc_name`/`url` fields, which previously matched all text and inflated the rate.