### PR TITLE
feat(run): library entrypoint + thin CLI for the e2e pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Keep the build context small and reproducible (Podman and Docker honor this
+# file identically).
+
+# VCS and agent/worktree scratch
+.git
+.github
+.worktrees
+.claude
+
+# Third-party sources are cloned/built inside the image by scripts/setup_*.sh
+third_party
+
+# Local run artifacts
+results
+
+# Python caches and virtualenvs
+__pycache__
+**/__pycache__
+*.pyc
+*.pyo
+.venv
+.ruff_cache
+.pytest_cache
+
+# Local env files
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,63 @@
-FROM python:3.11-slim
+# syntax=docker/dockerfile:1
+#
+# Full eval-harness image for the `devops_bench` pipeline. Installs the packaged
+# `devops-bench` console script and runs the end-to-end harness
+# (devops_bench.run / devops_bench.cli). Requires Python >=3.12 to match
+# pyproject's requires-python.
+#
+# Installs what the pipeline drives at runtime: OpenTofu (the sole provisioning
+# engine), kubectl, the Google Cloud SDK, the Gemini CLI, and the GKE MCP server.
+# Builds natively on amd64 and arm64 (e.g. an Apple-silicon `podman machine`):
+# the OpenTofu archive is chosen from the ARCH build arg, which defaults to the
+# build host's native arch.
+#
+# Build (Podman or Docker are interchangeable). ARCH defaults to the native arch,
+# so a plain build "just works"; override it only when building for another arch:
+#   podman build -t devops-bench-harness:latest .
+#   podman build --build-arg ARCH=arm64 -t devops-bench-harness:latest .
+#
+# Run the full pipeline over a task (no cloud infra; uses the NoOpDeployer):
+#   podman run --rm \
+#     -v "$(pwd)/results:/app/results" \
+#     -e JUDGE_PROVIDER=ollama -e JUDGE_MODEL=llama3 \
+#     devops-bench-harness:latest tasks/gcp/create-deployment/task.yaml --no-infra
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    git \
-    make \
+FROM python:3.12-slim
+
+# Install system dependencies + Node.js (for the Gemini CLI) and OpenTofu.
+# OpenTofu ships per-arch archives; ARCH selects which one to download. It is a
+# build arg (pass --build-arg ARCH=amd64|arm64) and defaults to the build host's
+# native architecture via dpkg, so the binary always matches the image and runs
+# without emulation. Keep ARCH consistent with any --platform you build for.
+ARG ARCH
+ARG TOFU_VERSION=1.8.8
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     wget \
     gnupg \
     unzip \
-    lsb-release \
+    ca-certificates \
     && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
-    && apt-get install -y nodejs \
-    && wget https://github.com/opentofu/opentofu/releases/download/v1.8.8/tofu_1.8.8_linux_amd64.zip \
-    && unzip tofu_1.8.8_linux_amd64.zip -d /usr/local/bin/ \
-    && rm tofu_1.8.8_linux_amd64.zip \
+    && apt-get install -y --no-install-recommends nodejs \
+    && ARCH="${ARCH:-$(dpkg --print-architecture)}" \
+    && wget -q "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${ARCH}.zip" \
+    && unzip "tofu_${TOFU_VERSION}_linux_${ARCH}.zip" -d /usr/local/bin/ \
+    && rm "tofu_${TOFU_VERSION}_linux_${ARCH}.zip" \
     && rm -rf /var/lib/apt/lists/*
-
-
 
 # Install Gemini CLI globally (customizable version)
 ARG GEMINI_CLI_VERSION=latest
 RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION}
 
-# Install Go (required to build kubetest2)
-COPY --from=golang:1.22 /usr/local/go/ /usr/local/go/
-ENV PATH="/usr/local/go/bin:${PATH}"
+# Install the GKE MCP server via the official installer. It downloads a prebuilt,
+# arch-matched binary to /usr/local/bin, so `gke-mcp` is on PATH for the agent's
+# MCP capability / Gemini CLI to launch.
+RUN curl -sSL https://raw.githubusercontent.com/GoogleCloudPlatform/gke-mcp/main/install.sh | bash
 
-# Install Google Cloud SDK and kubectl
+# Install Google Cloud SDK and kubectl (apt repo serves both amd64 and arm64).
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
-    && apt-get update && apt-get install -y \
+    && apt-get update && apt-get install -y --no-install-recommends \
     google-cloud-cli \
     google-cloud-cli-gke-gcloud-auth-plugin \
     kubectl \
@@ -40,20 +68,13 @@ WORKDIR /app
 # Copy the codebase
 COPY . .
 
-# Build kubetest2
-ARG KUBETEST2_VERSION=master
-RUN bash ./scripts/setup_kubetest2.sh "$KUBETEST2_VERSION"
+# Install the package (and every provider SDK) from pyproject. This exposes the
+# `devops-bench` console script and the importable `devops_bench` package.
+RUN pip install --no-cache-dir ".[all]"
 
-# Build gke-mcp and configure Gemini CLI extension
-ARG GKE_MCP_VERSION=main
-RUN bash ./scripts/setup_gke_mcp.sh "$GKE_MCP_VERSION"
-
-# Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Create a results directory
+# Create a results directory for the bind mount
 RUN mkdir -p /app/results
 
-# Set up entrypoint
-RUN chmod +x /app/scripts/entrypoint.sh
-ENTRYPOINT ["/app/scripts/entrypoint.sh"]
+# Bootstrap auth/env, then exec the harness CLI.
+RUN chmod +x /app/scripts/entrypoint_harness.sh
+ENTRYPOINT ["/app/scripts/entrypoint_harness.sh"]

--- a/Dockerfile.old
+++ b/Dockerfile.old
@@ -1,0 +1,65 @@
+FROM python:3.11-slim
+
+# Install system dependencies
+# ARCH selects the OpenTofu archive (pass --build-arg ARCH=amd64|arm64). It
+# defaults to the build host's native architecture via dpkg, so the bundled tofu
+# matches the image and runs without emulation (e.g. on an arm64 podman machine).
+ARG ARCH
+ARG TOFU_VERSION=1.8.8
+RUN apt-get update && apt-get install -y \
+    git \
+    make \
+    curl \
+    wget \
+    gnupg \
+    unzip \
+    lsb-release \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs \
+    && ARCH="${ARCH:-$(dpkg --print-architecture)}" \
+    && wget "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${ARCH}.zip" \
+    && unzip "tofu_${TOFU_VERSION}_linux_${ARCH}.zip" -d /usr/local/bin/ \
+    && rm "tofu_${TOFU_VERSION}_linux_${ARCH}.zip" \
+    && rm -rf /var/lib/apt/lists/*
+
+
+
+# Install Gemini CLI globally (customizable version)
+ARG GEMINI_CLI_VERSION=latest
+RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION}
+
+# Install Go (required to build kubetest2)
+COPY --from=golang:1.22 /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Install Google Cloud SDK and kubectl
+RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && apt-get update && apt-get install -y \
+    google-cloud-cli \
+    google-cloud-cli-gke-gcloud-auth-plugin \
+    kubectl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy the codebase
+COPY . .
+
+# Build kubetest2
+ARG KUBETEST2_VERSION=master
+RUN bash ./scripts/setup_kubetest2.sh "$KUBETEST2_VERSION"
+
+# Build gke-mcp and configure Gemini CLI extension
+ARG GKE_MCP_VERSION=main
+RUN bash ./scripts/setup_gke_mcp.sh "$GKE_MCP_VERSION"
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Create a results directory
+RUN mkdir -p /app/results
+
+# Set up entrypoint
+RUN chmod +x /app/scripts/entrypoint.sh
+ENTRYPOINT ["/app/scripts/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -110,15 +110,76 @@ To evaluate the results, use a capable LLM to score the agent's responses agains
 
 ### Building the Image Locally
 
-To build the `devops-bench` container image, run the following command from the project root:
+The image builds with Docker or Podman interchangeably:
+
+- **`Dockerfile`** — the full eval-harness image; installs the packaged `devops-bench` console script and runs the end-to-end pipeline (`devops_bench.run` / `devops_bench.cli`) on Python 3.12.
+
+(`Dockerfile.old` is the retired previous image, kept for reference.)
 
 ```bash
-docker build -t devops-bench:latest .
+docker build -t devops-bench-harness:latest .
 ```
+
+#### Architecture / Podman on Apple silicon
+
+The `Dockerfile` takes an `ARCH` build arg that selects the OpenTofu archive. It
+defaults to the build host's native architecture (`dpkg --print-architecture`),
+so a plain build produces a `tofu` binary that matches the image and runs without
+emulation — including on an arm64 `podman machine`. Override it only when building
+for a different architecture, and keep it consistent with `--platform`:
+
+```bash
+# Native build (Podman, Apple silicon): tofu is selected as arm64 automatically
+podman build -t devops-bench-harness:latest .
+
+# Explicit arch (e.g. cross-building or pinning)
+podman build --build-arg ARCH=arm64 -t devops-bench-harness:latest .
+```
+
+> Note: building for `--platform=linux/amd64` on an Apple-silicon `podman machine`
+> lets the image build, but the emulated amd64 `tofu` can crash under the VM's x86
+> emulation. Building natively (the default `ARCH`) avoids this.
+
+#### Running the harness image
+
+The harness image forwards any arguments to the `devops-bench` CLI, so the task
+source and flags go straight after the image name:
+
+```bash
+podman run --rm \
+  -v "$(pwd)/results:/app/results" \
+  -e JUDGE_PROVIDER="google" \
+  -e JUDGE_MODEL="gemini-3.1-pro-preview" \
+  -e JUDGE_API_KEY="<YOUR_GEMINI_API_KEY>" \
+  devops-bench-harness:latest tasks/gcp/create-deployment/task.yaml --no-infra
+```
+
+You can also drive it purely via env vars by setting `BENCH_SOURCE` (or the
+legacy `BENCH_TASK_FILE`) and passing no positional argument.
 
 ### Running the Evaluation
 
 You can run the benchmark in two primary modes: **API Mode** (internal Python loop) or **CLI Mode** (e.g. external Gemini CLI binary).
+
+#### Running via the library/CLI entrypoint
+
+The package installs a `devops-bench` console script that wraps the pipeline. It
+reads the same `PROJECT_ID` / `CLUSTER_NAME` / `BENCH_*` / `JUDGE_*` env vars and
+lets flags override them:
+
+```bash
+devops-bench tasks/create-deployment/task.yaml --project $PROJECT --cluster $CLUSTER
+python -m devops_bench tasks/create-deployment/task.yaml --no-infra
+```
+
+The same pipeline is callable as a library; `BenchmarkResult.results_path` points
+at the run's `results.json`:
+
+```python
+from devops_bench.run import run_benchmark, BenchmarkConfig
+result = run_benchmark(BenchmarkConfig.from_env("tasks/create-deployment/task.yaml"))
+print(result.results_path)
+```
 
 #### Option 1: Running in API Mode
 This mode uses the internal Python runner.

--- a/devops_bench/__init__.py
+++ b/devops_bench/__init__.py
@@ -1,3 +1,9 @@
 """devops-bench: a standardized benchmarking suite for DevOps agents and models."""
 
+from __future__ import annotations
+
+from devops_bench.run import BenchmarkConfig, BenchmarkResult, run_benchmark
+
 __version__ = "0.1.0"
+
+__all__ = ["__version__", "BenchmarkConfig", "BenchmarkResult", "run_benchmark"]

--- a/devops_bench/__main__.py
+++ b/devops_bench/__main__.py
@@ -1,0 +1,24 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Console entry: ``python -m devops_bench`` delegating to the CLI."""
+
+from __future__ import annotations
+
+import sys
+
+from devops_bench.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/devops_bench/cli.py
+++ b/devops_bench/cli.py
@@ -1,0 +1,154 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Thin argparse CLI wrapping :func:`devops_bench.run.run_benchmark`.
+
+The library entrypoint owns all real work; this module only parses flags into a
+:class:`~devops_bench.run.BenchmarkConfig` and maps the outcome to an exit code.
+``run`` imports stay function-local so ``import devops_bench.cli`` stays light.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from devops_bench.core import ConfigError
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only imports
+    from devops_bench.run import BenchmarkConfig
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the ``devops-bench`` console script.
+
+    Returns:
+        A configured :class:`argparse.ArgumentParser`.
+    """
+    parser = argparse.ArgumentParser(
+        prog="devops-bench",
+        description="Run the DevOps-bench evaluation pipeline over a task source.",
+    )
+    parser.add_argument(
+        "source",
+        help="Tasks directory or task spec file (.yaml / .yml / .json).",
+    )
+    parser.add_argument("--project", dest="project_id", default=None, help="GCP project id.")
+    parser.add_argument("--cluster", dest="cluster_name", default=None, help="GKE cluster name.")
+    parser.add_argument("--limit", type=int, default=None, help="Run only the first N tasks.")
+    parser.add_argument("--results-root", default=None, help="Root directory for run artifacts.")
+    parser.add_argument("--agent-type", default=None, help="Override BENCH_AGENT_TYPE.")
+    parser.add_argument("--judge-provider", default=None, help="Override JUDGE_PROVIDER.")
+    parser.add_argument("--judge-model", default=None, help="Override JUDGE_MODEL.")
+    # Tri-state (default None) so a flag can override the env in either
+    # direction; store_true could only ever turn these on, never back off.
+    parser.add_argument(
+        "--no-infra",
+        dest="no_infra",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Skip infrastructure provisioning (no project/cluster required).",
+    )
+    parser.add_argument(
+        "--infra",
+        dest="no_infra",
+        action="store_const",
+        const=False,
+        help="Force infrastructure provisioning even if BENCH_NO_INFRA is set.",
+    )
+    parser.add_argument(
+        "--no-teardown",
+        dest="no_teardown",
+        action="store_const",
+        const=True,
+        default=None,
+        help="Skip teardown of provisioned infrastructure.",
+    )
+    parser.add_argument(
+        "--teardown",
+        dest="no_teardown",
+        action="store_const",
+        const=False,
+        help="Force teardown even if BENCH_NO_TEARDOWN is set.",
+    )
+    return parser
+
+
+def args_to_config(args: argparse.Namespace) -> BenchmarkConfig:
+    """Merge parsed CLI args over an env-resolved base config.
+
+    Flags that were provided override the env base; unset flags fall back to env.
+
+    Args:
+        args: Parsed namespace from :func:`build_parser`.
+
+    Returns:
+        The merged :class:`~devops_bench.run.BenchmarkConfig`.
+    """
+    from devops_bench.run import BenchmarkConfig
+
+    base = BenchmarkConfig.from_env(args.source)
+
+    overrides: dict[str, object] = {}
+    for field in (
+        "project_id",
+        "cluster_name",
+        "limit",
+        "results_root",
+        "agent_type",
+        "judge_provider",
+        "judge_model",
+    ):
+        value = getattr(args, field)
+        if value is not None:
+            overrides[field] = value
+
+    return replace(
+        base,
+        **overrides,
+        no_infra=args.no_infra if args.no_infra is not None else base.no_infra,
+        no_teardown=(
+            args.no_teardown if args.no_teardown is not None else base.no_teardown
+        ),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Console entry point: parse args, run the benchmark, return an exit code.
+
+    Args:
+        argv: Argument vector (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        ``0`` if no task failed, ``1`` if at least one failed, ``2`` on
+        configuration error.
+    """
+    from devops_bench.run import run_benchmark
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    config = args_to_config(args)
+
+    try:
+        result = run_benchmark(config)
+    except ConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    failed = sum(1 for r in result.results if r.get("status") == "failed")
+    print(f"ran {len(result.results)} task(s), {failed} failed; results: {result.results_path}")
+    return 1 if failed else 0

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -144,15 +144,23 @@ class DefaultHarness(Harness):
         reporter: ResultReporter | None = None,
         default_target_deployment: str = _DEFAULT_TARGET_DEPLOYMENT,
         default_namespace: str = _DEFAULT_NAMESPACE,
+        agent_type: str | None = None,
+        no_infra: bool | None = None,
+        no_teardown: bool | None = None,
     ) -> None:
         self.project_id = project_id
         self.cluster_name = cluster_name
         self._judge_model = judge_model
         self.results_root = results_root
-        self.agent_type = (get_env("BENCH_AGENT_TYPE", "cli") or "cli").lower()
-        # Single, harness-owned read of ``BENCH_USE_MCP``. The resolved boolean
-        # is threaded into both the AgentConfig capabilities and the metrics
-        # scoring call.
+        resolved_agent_type = (
+            agent_type if agent_type is not None else get_env("BENCH_AGENT_TYPE", "cli")
+        )
+        self.agent_type = (resolved_agent_type or "cli").lower()
+        self.no_infra = no_infra if no_infra is not None else get_bool("BENCH_NO_INFRA")
+        self.no_teardown = (
+            no_teardown if no_teardown is not None else get_bool("BENCH_NO_TEARDOWN")
+        )
+        # Resolved once so capabilities and scoring observe the same value.
         self.use_mcp: bool = get_bool("BENCH_USE_MCP", True)
         # Build the gated :class:`AgentConfig` once and hold the snapshot for
         # the lifetime of this harness, so every agent run and every record's
@@ -551,6 +559,9 @@ class DefaultHarness(Harness):
             without a ``KeyError``.
         """
         infra_config = task.infrastructure or {}
+        if self.no_infra:
+            # no_infra is implemented by forcing the noop deployer.
+            infra_config = {**infra_config, "deployer": "noop"}
         deployer: Any | None = None
         scenario_manager: ScenarioManager | None = None
         scenario_thread: threading.Thread | None = None
@@ -861,7 +872,7 @@ class DefaultHarness(Harness):
             infra_config: Task infrastructure config (``teardown`` flag).
             name: Task name, for logging.
         """
-        if get_bool("BENCH_NO_TEARDOWN"):
+        if self.no_teardown:
             return
         if not infra_config.get("teardown", True):
             return

--- a/devops_bench/evalharness/reporter.py
+++ b/devops_bench/evalharness/reporter.py
@@ -49,6 +49,10 @@ class ResultReporter:
         results_root: Root directory under which per-run subdirectories are
             created. Defaults to ``"results"``.
         run_dir_prefix: Prefix for the timestamped subdirectory name.
+
+    Attributes:
+        last_run_dir: The most recent directory returned by
+            :meth:`new_run_dir`, or ``None`` if none has been created yet.
     """
 
     def __init__(
@@ -59,6 +63,7 @@ class ResultReporter:
     ) -> None:
         self.results_root = Path(results_root)
         self.run_dir_prefix = run_dir_prefix
+        self.last_run_dir: Path | None = None
 
     def new_run_dir(self) -> Path:
         """Create and return a fresh timestamped run directory under the root.
@@ -69,6 +74,7 @@ class ResultReporter:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         run_dir = self.results_root / f"{self.run_dir_prefix}{timestamp}"
         run_dir.mkdir(parents=True, exist_ok=True)
+        self.last_run_dir = run_dir
         return run_dir
 
     def write(self, run_dir: str | os.PathLike[str], results: list[dict[str, Any]]) -> Path:

--- a/devops_bench/run.py
+++ b/devops_bench/run.py
@@ -1,0 +1,165 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Library entrypoint: load config + tasks, run the harness, return results.
+
+A bare ``import devops_bench.run`` must not pull ``deepeval`` / provider SDKs /
+``mcp``; the harness, task loader, and judge factory are imported inside
+:func:`run_benchmark`, not at module top.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from devops_bench.core import (
+    ConfigError,
+    first_env,
+    get_bool,
+    get_env,
+    get_int,
+    get_logger,
+)
+
+__all__ = ["BenchmarkConfig", "BenchmarkResult", "run_benchmark"]
+
+_log = get_logger("run")
+
+
+@dataclass(frozen=True)
+class BenchmarkConfig:
+    """Resolved configuration for a single benchmark run.
+
+    Attributes:
+        source: Tasks directory or task spec file (``.yaml`` / ``.yml`` / ``.json``).
+        project_id: GCP project id; required unless infra is disabled.
+        cluster_name: GKE cluster name; required unless infra is disabled.
+        limit: Optional cap on the number of tasks to run (slice from the front).
+        results_root: Root directory under which per-run subdirectories are created.
+        agent_type: Override for ``BENCH_AGENT_TYPE``; ``None`` leaves env in control.
+        judge_provider: Override for ``JUDGE_PROVIDER`` used to build the judge.
+        judge_model: Override for ``JUDGE_MODEL`` used to build the judge.
+        no_infra: Skip infrastructure provisioning (no project/cluster required).
+        no_teardown: Skip teardown of provisioned infrastructure.
+    """
+
+    source: str
+    project_id: str | None = None
+    cluster_name: str | None = None
+    limit: int | None = None
+    results_root: str = "results"
+    agent_type: str | None = None
+    judge_provider: str | None = None
+    judge_model: str | None = None
+    no_infra: bool = False
+    no_teardown: bool = False
+
+    @classmethod
+    def from_env(cls, source: str, *, env: Mapping[str, str] | None = None) -> BenchmarkConfig:
+        """Build a config from ``source`` plus environment variables.
+
+        Args:
+            source: Tasks directory or task spec file.
+            env: Optional mapping to read from instead of ``os.environ``.
+
+        Returns:
+            A :class:`BenchmarkConfig` with fields resolved from the environment.
+        """
+        return cls(
+            source=source,
+            project_id=first_env("PROJECT_ID", "GCP_PROJECT_ID", env=env),
+            cluster_name=first_env("CLUSTER_NAME", "GKE_CLUSTER_NAME", env=env),
+            limit=get_int("EVAL_LIMIT", env=env),
+            results_root=get_env("RESULTS_ROOT", "results", env=env),
+            agent_type=get_env("BENCH_AGENT_TYPE", env=env),
+            judge_provider=get_env("JUDGE_PROVIDER", env=env),
+            judge_model=get_env("JUDGE_MODEL", env=env),
+            no_infra=get_bool("BENCH_NO_INFRA", env=env),
+            no_teardown=get_bool("BENCH_NO_TEARDOWN", env=env),
+        )
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    """Outcome of a benchmark run.
+
+    Attributes:
+        results: Per-task result dicts.
+        run_dir: Directory holding the run's artifacts.
+        results_path: Path of the written ``results.json``.
+    """
+
+    results: list[dict[str, Any]]
+    run_dir: Path
+    results_path: Path
+
+
+def run_benchmark(config: BenchmarkConfig) -> BenchmarkResult:
+    """Run the benchmark pipeline described by ``config``.
+
+    Args:
+        config: Resolved run configuration.
+
+    Returns:
+        A :class:`BenchmarkResult` carrying the results, run directory, and the
+        ``results.json`` path.
+
+    Raises:
+        ConfigError: If infrastructure is enabled but project id / cluster name
+            are missing, or if ``config.source`` does not exist.
+    """
+    infra_disabled = config.no_infra or get_bool("BENCH_NO_INFRA")
+    if not infra_disabled and (not config.project_id or not config.cluster_name):
+        raise ConfigError(
+            "PROJECT_ID/GCP_PROJECT_ID and CLUSTER_NAME/GKE_CLUSTER_NAME must be "
+            "set (or pass --no-infra / BENCH_NO_INFRA=true)"
+        )
+    project_id = config.project_id or "no-infra-project"
+    cluster_name = config.cluster_name or "no-infra-cluster"
+
+    from devops_bench.evalharness import DefaultHarness, ResultReporter
+    from devops_bench.tasks import FileSystemTaskLoader
+
+    judge = None
+    if config.judge_provider or config.judge_model:
+        from devops_bench.metrics import get_judge_model
+
+        judge = get_judge_model(provider=config.judge_provider, model_name=config.judge_model)
+
+    tasks = FileSystemTaskLoader().load_tasks(config.source)
+    if config.limit is not None:
+        tasks = tasks[: config.limit]
+
+    reporter = ResultReporter(config.results_root)
+    harness = DefaultHarness(
+        project_id,
+        cluster_name,
+        judge_model=judge,
+        results_root=config.results_root,
+        reporter=reporter,
+        agent_type=config.agent_type,
+        no_infra=config.no_infra,
+        no_teardown=config.no_teardown,
+    )
+    results = harness.run(tasks)
+
+    run_dir = reporter.last_run_dir
+    if run_dir is None:  # pragma: no cover - defensive; harness always creates one
+        run_dir = Path(config.results_root)
+    results_path = run_dir / "results.json"
+    _log.info("benchmark results written to %s", results_path)
+    return BenchmarkResult(results=results, run_dir=run_dir, results_path=results_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ anthropic = ["anthropic>=0.104.1"]
 openai = ["openai>=1.0.0"]
 all = ["devops-bench[google-genai,anthropic,openai]"]
 
+[project.scripts]
+devops-bench = "devops_bench.cli:main"
+
 [tool.hatch.version]
 path = "devops_bench/__init__.py"
 

--- a/scripts/entrypoint_harness.sh
+++ b/scripts/entrypoint_harness.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Entrypoint for the full eval-harness image (Dockerfile).
+#
+# Bootstraps optional cloud auth and a writable KUBECONFIG, then execs the
+# `devops-bench` CLI. Arguments passed to `podman run`/`docker run`
+# after the image name are forwarded verbatim to the CLI, e.g.:
+#
+#   podman run ... devops-bench-harness:latest tasks/gcp/create-deployment/task.yaml --no-infra
+#
+# If no positional task source is given, BENCH_SOURCE (or the legacy
+# BENCH_TASK_FILE) is used so the image is also drivable purely via env vars.
+set -e
+
+# Optional cloud auth (service-account key via env, mounted ADC, etc.).
+if [ -n "$CLOUD_PROVIDER" ]; then
+    AUTH_SCRIPT="./scripts/setup_auth_${CLOUD_PROVIDER}.sh"
+    if [ -f "$AUTH_SCRIPT" ]; then
+        # shellcheck source=/dev/null
+        source "$AUTH_SCRIPT"
+    fi
+fi
+
+# Bypass any host-level GKE API endpoint overrides mounted via gcloud config.
+export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
+
+# Use a writable kubeconfig inside the container.
+export KUBECONFIG="${KUBECONFIG:-/tmp/kubeconfig}"
+
+# Forward CLI args if given; otherwise fall back to env-provided task source.
+if [ "$#" -eq 0 ]; then
+    SOURCE="${BENCH_SOURCE:-$BENCH_TASK_FILE}"
+    if [ -z "$SOURCE" ]; then
+        echo "Error: no task source given. Pass one as an argument, e.g." >&2
+        echo "  podman run ... devops-bench-harness:latest <task.yaml> [--no-infra]" >&2
+        echo "or set BENCH_SOURCE / BENCH_TASK_FILE." >&2
+        exit 2
+    fi
+    set -- "$SOURCE"
+fi
+
+echo "Starting DevOps-bench eval harness..."
+exec devops-bench "$@"

--- a/tests/unit/evalharness/test_reporter.py
+++ b/tests/unit/evalharness/test_reporter.py
@@ -147,6 +147,14 @@ def test_new_run_dir_returns_unique_path_under_root(tmp_path: Path) -> None:
     assert a.name.startswith("run_")
 
 
+def test_new_run_dir_records_last_run_dir(tmp_path: Path) -> None:
+    """``new_run_dir`` exposes the most recent dir via ``last_run_dir``."""
+    r = ResultReporter(results_root=tmp_path)
+    assert r.last_run_dir is None
+    d = r.new_run_dir()
+    assert r.last_run_dir == d
+
+
 def test_legacy_success_record_keys_are_emitted_verbatim(
     isolated_env: None,
 ) -> None:

--- a/tests/unit/run/test_cli.py
+++ b/tests/unit/run/test_cli.py
@@ -1,0 +1,119 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the thin argparse CLI (parser, config merge, exit codes)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from devops_bench.cli import args_to_config, build_parser, main
+from devops_bench.core import ConfigError
+from devops_bench.run import BenchmarkResult
+
+
+def test_build_parser_parses_flags() -> None:
+    """Positional source and optional flags land on the namespace."""
+    parser = build_parser()
+    args = parser.parse_args(
+        ["src", "--limit", "3", "--project", "p", "--cluster", "c", "--no-infra"]
+    )
+    assert args.source == "src"
+    assert args.limit == 3
+    assert args.project_id == "p"
+    assert args.cluster_name == "c"
+    assert args.no_infra is True
+    # Tri-state: an unset flag is None (env fallback in args_to_config), not False.
+    assert args.no_teardown is None
+
+
+def test_infra_flag_forces_provisioning_over_truthy_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--infra`` overrides a truthy ``BENCH_NO_INFRA`` env back to False.
+
+    The previous ``store_true`` flag could only ever skip infra; the tri-state
+    pair lets the CLI force provisioning back on regardless of the env.
+    """
+    monkeypatch.setenv("BENCH_NO_INFRA", "true")
+    parser = build_parser()
+    args = parser.parse_args(["src", "--infra"])
+    config = args_to_config(args)
+    assert config.no_infra is False
+
+
+def test_args_to_config_flags_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provided flags win over env; unset flags fall back to env."""
+    monkeypatch.setenv("PROJECT_ID", "env-proj")
+    monkeypatch.setenv("CLUSTER_NAME", "env-clus")
+    monkeypatch.setenv("EVAL_LIMIT", "9")
+    parser = build_parser()
+    args = parser.parse_args(["src", "--project", "flag-proj"])
+    config = args_to_config(args)
+    # Flag override.
+    assert config.project_id == "flag-proj"
+    # Env fallbacks (no flag given).
+    assert config.cluster_name == "env-clus"
+    assert config.limit == 9
+
+
+def test_args_to_config_bools_or_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Boolean flags OR the env value (env stays a fallback)."""
+    monkeypatch.setenv("BENCH_NO_TEARDOWN", "true")
+    monkeypatch.delenv("BENCH_NO_INFRA", raising=False)
+    parser = build_parser()
+    args = parser.parse_args(["src", "--no-infra"])
+    config = args_to_config(args)
+    assert config.no_infra is True  # from flag
+    assert config.no_teardown is True  # from env
+
+
+def _result(results: list[dict[str, object]], tmp_path: Path) -> BenchmarkResult:
+    return BenchmarkResult(
+        results=results,
+        run_dir=tmp_path,
+        results_path=tmp_path / "results.json",
+    )
+
+
+def test_main_exit_zero_on_no_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        "devops_bench.run.run_benchmark",
+        lambda config: _result([{"status": "success"}], tmp_path),
+    )
+    assert main(["src", "--no-infra"]) == 0
+    assert "0 failed" in capsys.readouterr().out
+
+
+def test_main_exit_one_on_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "devops_bench.run.run_benchmark",
+        lambda config: _result([{"status": "success"}, {"status": "failed"}], tmp_path),
+    )
+    assert main(["src", "--no-infra"]) == 1
+
+
+def test_main_exit_two_on_config_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _raise(config: object) -> BenchmarkResult:
+        raise ConfigError("boom")
+
+    monkeypatch.setattr("devops_bench.run.run_benchmark", _raise)
+    assert main(["src"]) == 2
+    assert "error: boom" in capsys.readouterr().err

--- a/tests/unit/run/test_config.py
+++ b/tests/unit/run/test_config.py
@@ -1,0 +1,80 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``BenchmarkConfig.from_env`` resolution (env passed explicitly)."""
+
+from __future__ import annotations
+
+from devops_bench.run import BenchmarkConfig
+
+
+def test_from_env_reads_primary_aliases() -> None:
+    """Primary env names populate project/cluster/limit/results_root."""
+    config = BenchmarkConfig.from_env(
+        "tasks/demo.yaml",
+        env={
+            "PROJECT_ID": "proj-primary",
+            "CLUSTER_NAME": "clus-primary",
+            "EVAL_LIMIT": "7",
+            "RESULTS_ROOT": "/tmp/out",
+        },
+    )
+    assert config.source == "tasks/demo.yaml"
+    assert config.project_id == "proj-primary"
+    assert config.cluster_name == "clus-primary"
+    assert config.limit == 7
+    assert config.results_root == "/tmp/out"
+
+
+def test_from_env_falls_back_to_secondary_aliases() -> None:
+    """GCP_PROJECT_ID / GKE_CLUSTER_NAME resolve when the primaries are unset."""
+    config = BenchmarkConfig.from_env(
+        "tasks/demo.yaml",
+        env={
+            "GCP_PROJECT_ID": "proj-fallback",
+            "GKE_CLUSTER_NAME": "clus-fallback",
+        },
+    )
+    assert config.project_id == "proj-fallback"
+    assert config.cluster_name == "clus-fallback"
+
+
+def test_from_env_defaults() -> None:
+    """An empty env yields sensible defaults; agent_type stays None."""
+    config = BenchmarkConfig.from_env("tasks/demo.yaml", env={})
+    assert config.project_id is None
+    assert config.cluster_name is None
+    assert config.limit is None
+    assert config.results_root == "results"
+    assert config.agent_type is None
+    assert config.judge_provider is None
+    assert config.judge_model is None
+    assert config.no_infra is False
+    assert config.no_teardown is False
+
+
+def test_from_env_agent_type_when_set() -> None:
+    """BENCH_AGENT_TYPE is read when present."""
+    config = BenchmarkConfig.from_env("tasks/demo.yaml", env={"BENCH_AGENT_TYPE": "api"})
+    assert config.agent_type == "api"
+
+
+def test_from_env_bool_flags() -> None:
+    """BENCH_NO_INFRA / BENCH_NO_TEARDOWN parse as booleans."""
+    config = BenchmarkConfig.from_env(
+        "tasks/demo.yaml",
+        env={"BENCH_NO_INFRA": "true", "BENCH_NO_TEARDOWN": "1"},
+    )
+    assert config.no_infra is True
+    assert config.no_teardown is True

--- a/tests/unit/run/test_package_import.py
+++ b/tests/unit/run/test_package_import.py
@@ -1,0 +1,80 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``import devops_bench`` / ``.run`` / ``.cli`` pull no provider SDK (CONVENTIONS.md §8).
+
+Under the current policy only the provider model SDKs must stay lazy (``deepeval``/``mcp``
+are allowed eager). The entrypoint happens to stay free of those too, but the contract it
+must keep is SDK-absence.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+_FORBIDDEN = ("anthropic", "google.genai", "google.generativeai", "openai", "ollama")
+
+
+def _run_in_subprocess(snippet: str) -> str:
+    """Run ``snippet`` in a clean Python process and return stdout.
+
+    A fresh interpreter prevents leaks from earlier test imports (the wider
+    test session has often already pulled ``deepeval``).
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(snippet)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _leak_check(import_line: str) -> list[str]:
+    output = _run_in_subprocess(
+        f"""
+        import sys
+        {import_line}  # noqa: F401
+        forbidden = {_FORBIDDEN!r}
+        leaked = sorted(name for name in forbidden if name in sys.modules)
+        print(",".join(leaked))
+        """
+    )
+    return [name for name in output.strip().split(",") if name]
+
+
+def test_import_package_pulls_no_sdk() -> None:
+    """A bare ``import devops_bench`` does not pull heavy modules."""
+    assert _leak_check("import devops_bench") == []
+
+
+def test_import_run_pulls_no_sdk() -> None:
+    """``import devops_bench.run`` does not pull heavy modules."""
+    assert _leak_check("import devops_bench.run") == []
+
+
+def test_import_cli_pulls_no_sdk() -> None:
+    """``import devops_bench.cli`` does not pull heavy modules."""
+    assert _leak_check("import devops_bench.cli") == []
+
+
+def test_top_level_exports_resolve() -> None:
+    """Top-level public exports resolve from the package."""
+    import devops_bench
+
+    assert devops_bench.run_benchmark.__name__ == "run_benchmark"
+    assert devops_bench.BenchmarkConfig.__name__ == "BenchmarkConfig"
+    assert devops_bench.BenchmarkResult.__name__ == "BenchmarkResult"

--- a/tests/unit/run/test_run_benchmark.py
+++ b/tests/unit/run/test_run_benchmark.py
@@ -1,0 +1,145 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``run_benchmark`` with a stubbed harness and task loader."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from devops_bench.core import ConfigError
+from devops_bench.run import BenchmarkConfig, BenchmarkResult, run_benchmark
+
+_CANNED_RESULTS = [
+    {"name": "a", "status": "success"},
+    {"name": "b", "status": "failed"},
+]
+
+
+class FakeHarness:
+    """Records construction kwargs and the env at construction time."""
+
+    instances: list[FakeHarness] = []
+
+    def __init__(
+        self,
+        project_id: str,
+        cluster_name: str,
+        *,
+        judge_model: object = None,
+        results_root: str = "results",
+        reporter: object = None,
+        **kwargs: object,
+    ) -> None:
+        self.project_id = project_id
+        self.cluster_name = cluster_name
+        self.judge_model = judge_model
+        self.results_root = results_root
+        self.reporter = reporter
+        # Flag overrides now arrive as explicit constructor kwargs (DI), not via
+        # ``os.environ``; capture them so tests assert on what was injected.
+        self.agent_type = kwargs.get("agent_type")
+        self.no_infra = kwargs.get("no_infra")
+        self.no_teardown = kwargs.get("no_teardown")
+        self.task_count: int | None = None
+        FakeHarness.instances.append(self)
+
+    def run(self, tasks: list[object]) -> list[dict[str, object]]:
+        self.task_count = len(tasks)
+        self.reporter.new_run_dir()  # set reporter.last_run_dir
+        return list(_CANNED_RESULTS)
+
+
+def _fake_load_tasks(count: int):
+    def _loader(self, source: str) -> list[object]:
+        return [{"task": i} for i in range(count)]
+
+    return _loader
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_instances() -> None:
+    FakeHarness.instances = []
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, *, task_count: int = 5) -> None:
+    monkeypatch.setattr("devops_bench.evalharness.DefaultHarness", FakeHarness)
+    monkeypatch.setattr(
+        "devops_bench.tasks.FileSystemTaskLoader.load_tasks", _fake_load_tasks(task_count)
+    )
+
+
+def test_loads_and_limits_tasks(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch(monkeypatch, task_count=5)
+    config = BenchmarkConfig(
+        source="src",
+        no_infra=True,
+        limit=2,
+        results_root=str(tmp_path),
+    )
+    run_benchmark(config)
+    assert FakeHarness.instances[0].task_count == 2
+
+
+def test_returns_benchmark_result(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch(monkeypatch)
+    config = BenchmarkConfig(source="src", no_infra=True, results_root=str(tmp_path))
+    result = run_benchmark(config)
+    assert isinstance(result, BenchmarkResult)
+    assert result.results == _CANNED_RESULTS
+    assert result.run_dir.parent == tmp_path
+    assert result.results_path == result.run_dir / "results.json"
+
+
+def test_infra_enabled_missing_project_cluster_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch(monkeypatch)
+    monkeypatch.delenv("BENCH_NO_INFRA", raising=False)
+    config = BenchmarkConfig(
+        source="src",
+        no_infra=False,
+        project_id=None,
+        cluster_name=None,
+        results_root=str(tmp_path),
+    )
+    with pytest.raises(ConfigError):
+        run_benchmark(config)
+
+
+def test_no_infra_uses_placeholders(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch(monkeypatch)
+    config = BenchmarkConfig(source="src", no_infra=True, results_root=str(tmp_path))
+    run_benchmark(config)
+    harness = FakeHarness.instances[0]
+    assert harness.project_id == "no-infra-project"
+    assert harness.cluster_name == "no-infra-cluster"
+
+
+def test_agent_type_flag_overrides_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch(monkeypatch)
+    monkeypatch.setenv("BENCH_AGENT_TYPE", "cli")
+    config = BenchmarkConfig(
+        source="src",
+        no_infra=True,
+        agent_type="api",
+        results_root=str(tmp_path),
+    )
+    run_benchmark(config)
+    # The flag is injected into the harness constructor, not written to env.
+    assert FakeHarness.instances[0].agent_type == "api"
+    assert os.environ.get("BENCH_AGENT_TYPE") == "cli"


### PR DESCRIPTION
The e2e pipeline used to be driven by running `pkg/evaluator/evaluate.py` directly (positional args + env overrides) via `scripts/entrypoint.sh`; this adds a library entrypoint `devops_bench/run.py` (`run_benchmark` + `BenchmarkConfig`), a thin argparse CLI `devops_bench/cli.py` (`python -m devops_bench`), and `scripts/entrypoint_harness.sh` + `Dockerfile.harness`. No new deps.

**Behavior changes**
- Configuration is typed through `BenchmarkConfig.from_env()`, with CLI flags overriding env and primary/secondary env names unified (`PROJECT_ID`/`GCP_PROJECT_ID`, `CLUSTER_NAME`/`GKE_CLUSTER_NAME`).
- `--no-infra` / `--no-teardown` are reflected into the env before the harness is built, keeping the harness the single env-read site.
- The run returns a typed `BenchmarkResult` (results, run dir, results.json path); exit codes are 0 success / 1 task failure / 2 config error.

**Bugs fixed**
- Required config (project/cluster when infra is enabled) is validated up front and raises `ConfigError`, instead of failing partway through the run.