### PR TITLE
feat(agents): wire MCP servers + skills into the Gemini and OpenClaw CLI agents

### DIFF
--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -18,60 +18,116 @@ Trajectory extraction reads the official ``--output-format stream-json`` event
 stream from stdout (see :mod:`~devops_bench.agents.cli.gemini_cli.parsing`) — no
 ``~/.gemini/tmp/...`` disk reads, no session-id glob, no internal-schema parsing.
 
-Capability wiring: the allowed-tools list comes from the aggregated
-``config.capabilities.allowed_tools`` (across every bound MCP server) and the
-operator brief from ``config.capabilities.rules.text`` (written to a
-``GEMINI.md`` file in the run working directory before invocation, the CLI's
-native context-file mechanism).
+Capability wiring is delivered through the Gemini CLI's native workspace
+mechanisms, written into the per-run working directory before invocation:
+
+* **Tools** — ``config.capabilities.allowed_tools`` become ``--allowed-tools``
+  arguments, pre-approving them in headless mode.
+* **MCP servers** — command-bearing bindings become ``mcpServers`` entries in
+  ``<cwd>/.gemini/settings.json``.
+* **Skills** — ``config.capabilities.skills.paths`` are materialized under
+  ``<cwd>/.gemini/skills/<name>/SKILL.md``.
+* **Rules** — ``config.capabilities.rules.text`` is written to ``GEMINI.md``,
+  auto-loaded as the startup context.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from devops_bench.agents.base import AGENTS, AgentHarness
 from devops_bench.agents.cli.gemini_cli.parsing import parse_stream_json
 from devops_bench.agents.config import AgentConfig
 from devops_bench.agents.result import AgentResult
+from devops_bench.agents.shared.cli_capabilities import (
+    build_mcp_servers,
+    materialize_skills,
+)
 from devops_bench.core import SubprocessError, get_logger
 from devops_bench.core.subprocess import run
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from devops_bench.agents.capabilities import McpBinding
 
 __all__ = ["GeminiCliAgent"]
 
 # Filename the Gemini CLI auto-loads from its working directory as the
 # operator brief / startup context (its native equivalent of a system prompt).
 _GEMINI_RULES_FILE = "GEMINI.md"
+# Workspace config dir/files the CLI reads from its cwd. ``settings.json`` here
+# overrides the user-level ``~/.gemini/settings.json``; ``skills/`` is the
+# workspace skill-discovery root.
+_GEMINI_CONFIG_DIR = ".gemini"
+_GEMINI_SETTINGS_FILE = "settings.json"
+_GEMINI_SKILLS_DIR = "skills"
 
 _log = get_logger("agents.cli.gemini_cli")
+
+
+def _build_settings(mcp_servers: tuple[McpBinding, ...], *, skills_enabled: bool) -> dict:
+    """Assemble the Gemini ``settings.json`` payload for a run.
+
+    Args:
+        mcp_servers: Bindings to render into ``mcpServers`` (empty-command
+            bindings are skipped by :func:`build_mcp_servers`).
+        skills_enabled: Whether any workspace skill was materialized; gates the
+            explicit ``skills.enabled`` flag so the benchmark does not depend on
+            the user-level default.
+
+    Returns:
+        A settings mapping, possibly empty (caller skips the write when empty).
+    """
+    settings: dict = {}
+    servers = build_mcp_servers(mcp_servers)
+    if servers:
+        settings["mcpServers"] = servers
+    if skills_enabled:
+        settings["skills"] = {"enabled": True}
+    return settings
 
 
 def _build_argv(target: str, prompt: str, allowed_tools: tuple[str, ...]) -> list[str]:
     """Build the ``gemini`` invocation for ``prompt``.
 
-    When ``allowed_tools`` is empty, extensions are disabled via ``-e=""`` —
-    the documented switch for the headless "no tools" arm; ``-e none`` does
-    *not* disable extensions despite reading like it should.
+    ``--approval-mode yolo`` is always passed so the CLI auto-approves every tool
+    call (built-in *and* MCP) instead of blocking on interactive confirmation —
+    without it, MCP tool calls hang until the run hits its timeout.
+
+    When ``allowed_tools`` is empty, gemini *extensions* are disabled via
+    ``--extensions=`` — this is orthogonal to MCP (servers come from
+    ``settings.json`` and stay available). The short ``-e=`` / ``-e=""`` forms
+    print help and exit non-zero on gemini >= 0.47 (the literal value, quotes
+    included, reaches the parser since argv bypasses the shell), and ``-e none``
+    loads an extension literally named "none" rather than disabling.
+
+    Note: MCP servers only load when the workspace is *trusted*. The per-run temp
+    cwd is untrusted by default, so the bastion sets
+    ``security.folderTrust.enabled = false`` in the user-level
+    ``~/.gemini/settings.json`` (``--skip-trust`` alone does not lift the MCP
+    gate). See ``scripts/bastion/vm-setup.sh``.
 
     Args:
         target: Path to the ``gemini`` binary (already user-expanded).
         prompt: Task prompt.
         allowed_tools: Pre-approved tool names; each yields a separate
-            ``--allowed-tools <name>`` pair so the CLI never blocks on
-            interactive confirmation in headless mode.
+            ``--allowed-tools <name>`` pair (redundant under yolo).
 
     Returns:
         The argv list ready to hand to ``core.subprocess.run``.
     """
     argv = [target, "--output-format", "stream-json", "--skip-trust"]
+    argv.extend(["--approval-mode", "yolo"])
     if allowed_tools:
         for tool in allowed_tools:
             argv.extend(["--allowed-tools", tool])
     else:
-        # `-e=""` disables extensions; `-e none` does not (it loads the
-        # extension literally named "none" and silently no-ops).
-        argv.append('-e=""')
+        # `--extensions=` disables extensions; `-e=`/`-e=""` print help + exit 1
+        # on gemini >= 0.47, and `-e none` loads an extension named "none".
+        argv.append("--extensions=")
     argv.extend(["-p", prompt])
     return argv
 
@@ -117,12 +173,13 @@ class GeminiCliAgent(AgentHarness):
     ``config.model`` / ``config.api_key`` via the env overlay — never
     hardcoded. ``config.capabilities.allowed_tools`` (aggregated across every
     bound MCP server) selects between the ``--allowed-tools`` overlay and the
-    ``-e=""`` extensions-disabled path.
+    ``--extensions=`` extensions-disabled path.
 
-    ``__init__`` assigns ``self.mcp_servers`` and ``self.rules`` from the
-    granted config bindings, which is what makes
-    ``isinstance(agent, SupportsMcp / SupportsRules)`` return ``True`` for
-    orchestrator-side capability negotiation (the Protocols are structural).
+    ``__init__`` assigns ``self.mcp_servers``, ``self.skills`` and ``self.rules``
+    from the granted config bindings, which is what makes
+    ``isinstance(agent, SupportsMcp / SupportsSkills / SupportsRules)`` return
+    ``True`` for orchestrator-side capability negotiation (the Protocols are
+    structural).
 
     The full canonical trajectory is parsed from the official
     ``--output-format stream-json`` event stream; no session files are read
@@ -133,28 +190,47 @@ class GeminiCliAgent(AgentHarness):
         AgentHarness.__init__(self, config)
         caps = self.config.capabilities
         self.mcp_servers = caps.mcp_servers
+        self.skills = caps.skills
         self.rules = caps.rules
 
     def _execute(self, prompt: str) -> AgentResult:
         """Build argv, run the CLI, and parse the stream-json output.
 
-        When ``capabilities.rules.text`` is non-empty, the agent runs the
-        binary inside a per-run temp working directory and writes the rules
-        text to ``GEMINI.md`` there before invocation — the CLI auto-loads
-        that file as its startup context, which is the binary's native
-        delivery mechanism for an operator brief. The temp dir is cleaned up
-        when ``_execute`` returns.
+        The agent always runs the binary inside a per-run temp working
+        directory and lays down the granted capabilities there before
+        invocation, using the CLI's native workspace channels (all auto-loaded
+        from the cwd, so the user's ``~/.gemini`` stays untouched and concurrent
+        runs never race):
+
+        * ``GEMINI.md`` — the operator brief, when ``rules.text`` is set.
+        * ``.gemini/settings.json`` — ``mcpServers`` for each command-bearing
+          MCP binding, plus ``skills.enabled`` when skills were materialized.
+        * ``.gemini/skills/<name>/SKILL.md`` — one per discovered skill.
+
+        The temp dir is cleaned up when ``_execute`` returns.
         """
+        caps = self.config.capabilities
         target = os.path.expanduser(self.config.target or "gemini")
-        allowed_tools = self.config.capabilities.allowed_tools
-        argv = _build_argv(target, prompt, allowed_tools)
+        argv = _build_argv(target, prompt, caps.allowed_tools)
         env_overlay = _build_env(self.config)
-        rules_text = self.config.capabilities.rules.text
+        rules_text = caps.rules.text
 
         with tempfile.TemporaryDirectory(prefix="gemini-run-") as tmpdir:
+            workdir = Path(tmpdir)
             if rules_text:
-                (Path(tmpdir) / _GEMINI_RULES_FILE).write_text(
+                (workdir / _GEMINI_RULES_FILE).write_text(
                     rules_text, encoding="utf-8"
+                )
+
+            gemini_dir = workdir / _GEMINI_CONFIG_DIR
+            skill_names = materialize_skills(
+                gemini_dir / _GEMINI_SKILLS_DIR, caps.skills.paths
+            )
+            settings = _build_settings(caps.mcp_servers, skills_enabled=bool(skill_names))
+            if settings:
+                gemini_dir.mkdir(parents=True, exist_ok=True)
+                (gemini_dir / _GEMINI_SETTINGS_FILE).write_text(
+                    json.dumps(settings, indent=2), encoding="utf-8"
                 )
             try:
                 completed = run(

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -14,39 +14,43 @@
 
 """OpenClaw CLI agent harness driving the ``oc`` binary (local-only).
 
+Capability wiring is delivered through openclaw's native channels, laid down in
+a per-run temp dir:
+
+* **State isolation** — ``OPENCLAW_STATE_DIR`` points at ``<run>/state`` so
+  sessions and the skills root live in the per-run dir.
+* **MCP servers** — command-bearing bindings become ``mcp.servers`` entries in
+  ``<run>/openclaw.json``, selected via ``OPENCLAW_CONFIG_PATH``.
+* **Skills** — ``config.capabilities.skills.paths`` are materialized under
+  ``<OPENCLAW_STATE_DIR>/skills/<name>/SKILL.md``.
+* **Rules** — ``config.capabilities.rules.text`` is prepended to the prompt
+  (the ``oc`` build has no dedicated system-prompt flag).
+* **Model auth** — ``config.api_key`` is threaded into the provider env var
+  (``GEMINI_API_KEY``/``ANTHROPIC_API_KEY``/...) that ``oc agent --local`` reads.
+
 Trajectory extraction uses the official session commands documented in
-``docs/openclaw/sessions.md`` — *not* the debug-log ``sessionFile=`` scrape,
-and *not* ``sessions tail`` (which redacts tool args / result bodies):
+``docs/openclaw/sessions.md``: run ``oc agent --local``, locate the single
+session with ``oc sessions --json``, export it with
+``oc sessions export-trajectory``, and parse the bundle. On any extraction miss
+the failure is recorded on ``AgentResult.errors`` rather than returning a
+silent-empty trajectory.
 
-1. Wipe ``~/.openclaw/agents/<name>/sessions/*`` before the run so exactly
-   one fresh session exists afterward.
-2. Run ``oc agent --local --agent <name> -m <prompt>``.
-3. Locate the session: ``oc sessions --agent <name> --json`` (single row).
-4. Export the bundle: ``oc sessions export-trajectory --session-key <key>
-   --workspace <tmpdir> --json``.
-5. Parse the bundle (see :mod:`~devops_bench.agents.cli.openclaw.parsing`) into
-   canonical :class:`ToolCall` entries plus the final answer and token usage.
+The bundle parsing lives in :mod:`~devops_bench.agents.cli.openclaw.parsing`.
 
-The ``oc`` binary is a custom alias on the user's host; on any extraction
-miss the failure is recorded on ``AgentResult.errors`` rather than returning
-a silent-empty trajectory.
-
-Capability wiring: ``capabilities.rules.text`` is **prepended to the prompt**
-(separated by a blank line) before invocation. The installed ``oc`` build has
-no dedicated rules / system-prompt flag, so prompt-prepending is the reliable,
-binary-agnostic delivery channel. The agent assigns only ``self.rules`` in
-``__init__`` (satisfying :class:`SupportsRules`) and leaves ``mcp_servers`` /
-``skills`` unset — granting MCP or skills bindings would silently no-op against
-the ``oc`` build.
+``__init__`` assigns ``self.rules``, ``self.mcp_servers`` and ``self.skills``
+from the granted bindings, so the agent structurally satisfies
+``SupportsRules`` / ``SupportsMcp`` / ``SupportsSkills``.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import shlex
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from devops_bench.agents.base import AGENTS, AgentHarness
 from devops_bench.agents.cli.openclaw.parsing import (
@@ -57,12 +61,26 @@ from devops_bench.agents.cli.openclaw.parsing import (
 )
 from devops_bench.agents.config import AgentConfig
 from devops_bench.agents.result import AgentResult
+from devops_bench.agents.shared.cli_capabilities import (
+    build_mcp_servers,
+    materialize_skills,
+)
 from devops_bench.core import SubprocessError, get_logger
 from devops_bench.core.subprocess import run
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from devops_bench.agents.capabilities import McpBinding
 
 __all__ = ["OpenClawAgent"]
 
 _log = get_logger("agents.cli.openclaw.agent")
+
+# Per-run layout under the temp working dir. ``state`` is openclaw's state root
+# (sessions + the managed skills tree); ``openclaw.json`` is the isolated config
+# carrying ``mcp.servers``.
+_OPENCLAW_STATE_DIRNAME = "state"
+_OPENCLAW_SKILLS_DIRNAME = "skills"
+_OPENCLAW_CONFIG_FILE = "openclaw.json"
 
 
 def _oc_model_id(config: AgentConfig) -> str:
@@ -93,13 +111,75 @@ def _oc_model_id(config: AgentConfig) -> str:
     return f"{provider}/{model}"
 
 
+def _build_openclaw_config(mcp_servers: tuple[McpBinding, ...]) -> dict:
+    """Assemble the isolated ``openclaw.json`` payload for a run.
+
+    Args:
+        mcp_servers: Bindings to render into ``mcp.servers`` (empty-command
+            bindings are skipped by :func:`build_mcp_servers`).
+
+    Returns:
+        A config mapping with an ``mcp.servers`` section, or an empty dict when
+        no binding carries a launch command (caller then skips the config write
+        and leaves ``OPENCLAW_CONFIG_PATH`` unset).
+    """
+    servers = build_mcp_servers(mcp_servers)
+    if not servers:
+        return {}
+    return {"mcp": {"servers": servers}}
+
+
+def _build_env(config: AgentConfig) -> dict[str, str]:
+    """Build the env overlay that gives ``oc agent --local`` its model API key.
+
+    ``oc agent --local`` reads the model provider's API key from the shell. The
+    benchmark's neutral ``config.api_key`` is mapped onto the provider-specific
+    variable(s) openclaw expects; the model itself is never hardcoded (it flows
+    from ``config.model`` via ``oc models set``).
+
+    Args:
+        config: Resolved :class:`AgentConfig` for this run.
+
+    Returns:
+        A mapping suitable for the subprocess environment overlay. The caller
+        adds ``OPENCLAW_STATE_DIR`` / ``OPENCLAW_CONFIG_PATH`` on top.
+    """
+    overlay: dict[str, str] = {}
+    if config.api_key:
+        provider = (config.provider or "google").strip().lower()
+        if provider in ("google", "gemini"):
+            overlay["GEMINI_API_KEY"] = config.api_key
+            overlay["GOOGLE_API_KEY"] = config.api_key
+        elif provider == "anthropic":
+            overlay["ANTHROPIC_API_KEY"] = config.api_key
+        elif provider == "openai":
+            overlay["OPENAI_API_KEY"] = config.api_key
+        else:
+            overlay["GEMINI_API_KEY"] = config.api_key
+    if config.extra_env:
+        overlay.update(config.extra_env)
+    return overlay
+
+
+def _oc_set_model_cmd(config: AgentConfig, oc_bin: str) -> str:
+    """Shell fragment that points oc at the configured model, or ``""``.
+
+    Chained with ``&&`` so a failed ``models set`` aborts the run (the non-zero
+    exit then surfaces on ``AgentResult.errors``) instead of silently falling
+    through to oc's stored default and invalidating the benchmark arm.
+    """
+    model_id = _oc_model_id(config)
+    if not model_id:
+        return ""
+    return f"{oc_bin} models set {shlex.quote(model_id)} && "
+
+
 def _prepend_rules(rules_text: str, prompt: str) -> str:
     """Return ``prompt`` with ``rules_text`` prepended as an operator brief.
 
-    Empty / whitespace-only rules pass the prompt through unchanged so a
-    default :class:`AgentRules` is indistinguishable from "no preamble". A
-    non-empty brief is separated from the prompt by a blank line so the
-    model sees two distinct sections.
+    Empty / whitespace-only rules pass the prompt through unchanged so a default
+    :class:`AgentRules` is indistinguishable from "no preamble". A non-empty
+    brief is separated from the prompt by a blank line.
 
     Args:
         rules_text: The bound rules text (``capabilities.rules.text``).
@@ -116,16 +196,18 @@ def _prepend_rules(rules_text: str, prompt: str) -> str:
 def _build_local_command(
     config: AgentConfig, prompt: str, agent_name: str, oc_bin: str
 ) -> str:
-    """Build the bash command that wipes sessions, sets the model, and runs ``oc``.
+    """Build the bash command that sets the model and runs ``oc agent --local``.
 
     Every interpolated value is ``shlex.quote``d so prompts/agent names
     containing single quotes, spaces, or newlines neither break parsing nor
     inject commands. ``bash -c`` is required so ``nvm.sh`` can be sourced to
-    expose the right Node toolchain before invoking ``oc``.
+    expose the right Node toolchain before invoking ``oc`` (a no-op when Node is
+    installed system-wide). Session state is isolated via ``OPENCLAW_STATE_DIR``
+    (set by the caller's env overlay).
 
     Args:
         config: Resolved :class:`AgentConfig`.
-        prompt: Task prompt for the agent.
+        prompt: Task prompt for the agent (rules already prepended).
         agent_name: ``oc`` agent profile (e.g. ``"operator"``).
         oc_bin: Path to the ``oc`` binary.
 
@@ -133,22 +215,11 @@ def _build_local_command(
         A single bash command string ready for ``subprocess.run(shell=True)``.
     """
     quoted_oc = shlex.quote(oc_bin)
-    sessions_dir = os.path.expanduser(f"~/.openclaw/agents/{agent_name}/sessions")
-    model_id = _oc_model_id(config)
-    # Chain `models set` with `&&` so a failed model-set aborts the run; the
-    # bash non-zero exit then surfaces via `completed.returncode` and lands on
-    # `AgentResult.errors` rather than silently falling through to oc's stored
-    # default (which would invalidate the benchmark arm).
-    set_model = (
-        f"{quoted_oc} models set {shlex.quote(model_id)} && " if model_id else ""
-    )
     return (
-        # Wipe prior sessions so exactly one fresh session exists afterward.
-        f"rm -rf {shlex.quote(sessions_dir)}/* 2>/dev/null; "
         # Source nvm so the Node-based oc binary's runtime is available.
         'export NVM_DIR="$HOME/.nvm"; '
         '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"; '
-        f"{set_model}"
+        f"{_oc_set_model_cmd(config, quoted_oc)}"
         f"{quoted_oc} --log-level debug agent --local "
         f"--agent {shlex.quote(agent_name)} -m {shlex.quote(prompt)}"
     )
@@ -161,29 +232,31 @@ class OpenClawAgent(AgentHarness):
     The binary path is resolved from ``config.target``, falling back to
     ``~/bin/oc`` and then ``"oc"`` on ``$PATH``. Model /
     provider flow from ``config.model`` / ``config.provider`` via an
-    ``oc models set <id>`` fragment prepended to the bash command — never
-    hardcoded. Trajectory is exported through the official
-    ``oc sessions export-trajectory`` command into a per-run temp workspace
-    and parsed into the canonical :class:`ToolCall` list.
+    ``oc models set <id>`` fragment — never hardcoded.
 
-    ``__init__`` assigns ``self.rules`` (satisfying :class:`SupportsRules`) so
-    the orchestrator can grant operator-brief text uniformly. The installed
-    ``oc`` build exposes no in-agent MCP or skills wiring, so
-    ``mcp_servers`` / ``skills`` are deliberately *not* assigned —
-    ``isinstance(agent, SupportsMcp / SupportsSkills)`` stays ``False`` rather
-    than granting a binding the agent silently ignores.
+    Capabilities are delivered through openclaw's native channels: MCP servers
+    via an isolated ``OPENCLAW_CONFIG_PATH`` (``mcp.servers``), skills via
+    ``<OPENCLAW_STATE_DIR>/skills``, and rules prepended to the prompt.
+    ``__init__`` assigns ``self.rules``, ``self.mcp_servers`` and
+    ``self.skills``, so the agent structurally satisfies ``SupportsRules`` /
+    ``SupportsMcp`` / ``SupportsSkills``.
 
     Args:
         config: Typed :class:`AgentConfig`; defaults are used when omitted.
-        agent_name: ``oc`` agent profile (defaults to ``"operator"``).
+        agent_name: ``oc`` agent profile (defaults to ``"main"``, openclaw's
+            built-in default agent, which exists in every config — including the
+            per-run isolated one written for MCP).
     """
 
     def __init__(
-        self, config: AgentConfig | None = None, *, agent_name: str = "operator"
+        self, config: AgentConfig | None = None, *, agent_name: str = "main"
     ) -> None:
         AgentHarness.__init__(self, config)
         self.agent_name = agent_name
-        self.rules = self.config.capabilities.rules
+        caps = self.config.capabilities
+        self.rules = caps.rules
+        self.mcp_servers = caps.mcp_servers
+        self.skills = caps.skills
 
     def _resolve_oc_bin(self) -> str:
         """Pick the ``oc`` binary path from config or fall back."""
@@ -193,43 +266,73 @@ class OpenClawAgent(AgentHarness):
         return candidate if os.path.exists(candidate) else "oc"
 
     def _execute(self, prompt: str) -> AgentResult:
-        """Run ``oc agent --local`` and extract the canonical trajectory.
+        """Run ``oc agent --local`` with the granted capabilities and extract the trajectory.
 
-        When ``capabilities.rules.text`` is non-empty, the rules are
-        **prepended to the prompt** (separated by a blank line) before being
-        passed to ``oc agent -m`` — the ``oc`` build exposes no dedicated rules
-        / system-prompt flag.
+        The granted capabilities are laid down in a per-run temp dir before
+        invocation:
+
+        * ``<run>/state`` — ``OPENCLAW_STATE_DIR`` (sessions + skills root).
+        * ``<run>/state/skills/<name>/SKILL.md`` — one per discovered skill.
+        * ``<run>/openclaw.json`` — ``mcp.servers`` for each command-bearing MCP
+          binding, selected via ``OPENCLAW_CONFIG_PATH``.
+
+        ``rules.text`` is prepended to the prompt; the model API key is threaded
+        into the provider env var.
         """
+        caps = self.config.capabilities
         oc_bin = self._resolve_oc_bin()
-        final_prompt = _prepend_rules(self.config.capabilities.rules.text, prompt)
-        command = _build_local_command(self.config, final_prompt, self.agent_name, oc_bin)
+        final_prompt = _prepend_rules(caps.rules.text, prompt)
 
-        try:
-            completed = subprocess.run(
-                command,
-                shell=True,  # noqa: S602 - bash needed for nvm; all values shlex.quoted
-                executable="/bin/bash",
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=self.config.timeout_sec,
+        with tempfile.TemporaryDirectory(prefix="oc-run-") as rundir:
+            workdir = Path(rundir)
+            state_dir = workdir / _OPENCLAW_STATE_DIRNAME
+            state_dir.mkdir(parents=True, exist_ok=True)
+
+            materialize_skills(state_dir / _OPENCLAW_SKILLS_DIRNAME, caps.skills.paths)
+
+            env_overlay = _build_env(self.config)
+            env_overlay["OPENCLAW_STATE_DIR"] = str(state_dir)
+
+            config_payload = _build_openclaw_config(caps.mcp_servers)
+            if config_payload:
+                config_path = workdir / _OPENCLAW_CONFIG_FILE
+                config_path.write_text(json.dumps(config_payload, indent=2))
+                env_overlay["OPENCLAW_CONFIG_PATH"] = str(config_path)
+
+            command = _build_local_command(self.config, final_prompt, self.agent_name, oc_bin)
+
+            try:
+                completed = subprocess.run(
+                    command,
+                    shell=True,  # noqa: S602 - bash needed for nvm; all values shlex.quoted
+                    executable="/bin/bash",
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=self.config.timeout_sec,
+                    cwd=str(workdir),
+                    env={**os.environ, **env_overlay},
+                )
+            except subprocess.TimeoutExpired as exc:
+                return AgentResult.errored(f"oc agent timed out after {exc.timeout}s")
+            except OSError as exc:
+                return AgentResult.errored(f"oc binary unavailable: {exc}")
+
+            stdout_text = _strip_ansi(completed.stdout or "")
+            errors: list[str] = []
+            metadata: dict = {}
+
+            if completed.returncode != 0:
+                stderr = (completed.stderr or "").strip()
+                errors.append(
+                    f"oc agent exited {completed.returncode}: {stderr or '<no stderr>'}"
+                )
+                metadata["returncode"] = completed.returncode
+
+            trajectory, tokens, bundle_output, export_errors = self._extract_trajectory(
+                oc_bin, env_overlay
             )
-        except subprocess.TimeoutExpired as exc:
-            return AgentResult.errored(f"oc agent timed out after {exc.timeout}s")
-        except OSError as exc:
-            return AgentResult.errored(f"oc binary unavailable: {exc}")
-
-        stdout_text = _strip_ansi(completed.stdout or "")
-        errors: list[str] = []
-        metadata: dict = {}
-
-        if completed.returncode != 0:
-            stderr = (completed.stderr or "").strip()
-            errors.append(f"oc agent exited {completed.returncode}: {stderr or '<no stderr>'}")
-            metadata["returncode"] = completed.returncode
-
-        trajectory, tokens, bundle_output, export_errors = self._extract_trajectory(oc_bin)
-        errors.extend(export_errors)
+            errors.extend(export_errors)
 
         # Bundle text is clean; bash stdout carries debug noise — fall back only if empty.
         output = bundle_output if bundle_output else stdout_text
@@ -243,9 +346,13 @@ class OpenClawAgent(AgentHarness):
         )
 
     def _extract_trajectory(
-        self, oc_bin: str
+        self, oc_bin: str, env_overlay: dict[str, str]
     ) -> tuple[list[dict], dict, str, list[str]]:
         """Run ``oc sessions`` + ``export-trajectory`` and parse the bundle.
+
+        ``env_overlay`` carries ``OPENCLAW_STATE_DIR`` (and ``OPENCLAW_CONFIG_PATH``
+        when MCP is configured) so the session commands read from the same
+        isolated state the agent turn wrote to.
 
         Returns:
             A ``(trajectory, tokens, output_text, errors)`` tuple. ``output_text``
@@ -259,6 +366,7 @@ class OpenClawAgent(AgentHarness):
                 [oc_bin, "sessions", "--agent", self.agent_name, "--json"],
                 check=False,
                 timeout=self.config.timeout_sec,
+                extra_env=env_overlay,
             )
         except SubprocessError as exc:
             errors.append(f"oc sessions failed: {exc}")
@@ -295,6 +403,7 @@ class OpenClawAgent(AgentHarness):
                     ],
                     check=False,
                     timeout=self.config.timeout_sec,
+                    extra_env=env_overlay,
                 )
             except SubprocessError as exc:
                 errors.append(f"oc export-trajectory failed: {exc}")

--- a/devops_bench/agents/cli/openclaw/parsing.py
+++ b/devops_bench/agents/cli/openclaw/parsing.py
@@ -208,9 +208,9 @@ def _pick_session_key(sessions_json: str) -> str | None:
     """Return the single session key from ``oc sessions --json`` output, or ``None``.
 
     The output may be a list of rows or a wrapper dict with a ``sessions``
-    list (per ``docs/openclaw/sessions.md``). Because the run wiped the
-    sessions dir first, exactly one row is expected; if more than one is
-    present the first is taken (with a debug log).
+    list (per ``docs/openclaw/sessions.md``). Because each run uses fresh
+    isolated state, exactly one row is expected; if more than one is present
+    the first is taken (with a debug log).
 
     Args:
         sessions_json: Raw stdout from ``oc sessions --agent <name> --json``.

--- a/devops_bench/agents/shared/cli_capabilities.py
+++ b/devops_bench/agents/shared/cli_capabilities.py
@@ -1,0 +1,100 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Capability materialization shared by the CLI agents (Gemini, openclaw).
+
+Both CLI agents render granted MCP bindings into a ``{name: {command, args}}``
+launch map and copy discovered ``SKILL.md`` files into the binary's workspace
+skills tree. Importing this module pulls no provider SDK.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from devops_bench.agents.shared.skills import parse_skill_md
+from devops_bench.core import get_logger
+
+if TYPE_CHECKING:
+    from devops_bench.agents.capabilities import McpBinding
+
+__all__ = ["build_mcp_servers", "materialize_skills"]
+
+_log = get_logger("agents.shared.cli_capabilities")
+
+_SKILL_FILE = "SKILL.md"
+
+
+def build_mcp_servers(mcp_servers: tuple[McpBinding, ...]) -> dict[str, dict]:
+    """Map MCP bindings with a launch command to a CLI ``servers`` mapping.
+
+    Bindings with an empty ``command`` are skipped: a CLI needs a command to
+    spawn a stdio MCP server, and an empty-command binding denotes a server the
+    binary already hosts itself.
+
+    Args:
+        mcp_servers: Bindings granted for the run.
+
+    Returns:
+        A ``{name: {"command": ..., "args": [...]}}`` mapping suitable for the
+        agent's MCP-servers config section. Empty when no binding carries a
+        command.
+    """
+    servers: dict[str, dict] = {}
+    for index, binding in enumerate(mcp_servers):
+        if not binding.command:
+            continue
+        name = binding.name or f"mcp{index}"
+        entry: dict = {"command": binding.command[0]}
+        if len(binding.command) > 1:
+            entry["args"] = list(binding.command[1:])
+        servers[name] = entry
+    return servers
+
+
+def materialize_skills(skills_root: Path, paths: tuple[str, ...]) -> list[str]:
+    """Copy discovered ``SKILL.md`` files into a CLI's workspace skills tree.
+
+    For each ``SKILL.md`` found beneath ``paths`` (the same discovery the API
+    agent performs), the file is written to ``skills_root/<name>/SKILL.md`` using
+    the ``name`` from its frontmatter.
+
+    Args:
+        skills_root: The destination skills directory to populate.
+        paths: Skill source directories to walk recursively. Missing paths are
+            warned and skipped (matching the API agent's discovery semantic).
+
+    Returns:
+        The names of the skills materialized, in discovery order.
+    """
+    written: list[str] = []
+    for raw_path in paths:
+        if not raw_path:
+            continue
+        source = Path(os.path.expanduser(raw_path))
+        if not source.exists():
+            _log.warning("Skills directory not found: %s", source)
+            continue
+        for skill_file in sorted(source.rglob(_SKILL_FILE)):
+            name, _description, content = parse_skill_md(str(skill_file))
+            if not name or content is None:
+                continue
+            dest_dir = skills_root / name
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            (dest_dir / _SKILL_FILE).write_text(content, encoding="utf-8")
+            written.append(name)
+            _log.info("Linked skill %s -> %s", name, dest_dir)
+    return written

--- a/tests/unit/agents/shared/test_cli_capabilities.py
+++ b/tests/unit/agents/shared/test_cli_capabilities.py
@@ -1,0 +1,73 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the CLI capability helpers shared by the Gemini/openclaw agents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from devops_bench.agents.capabilities import McpBinding
+from devops_bench.agents.shared.cli_capabilities import (
+    build_mcp_servers,
+    materialize_skills,
+)
+
+
+def test_build_mcp_servers_maps_command_to_command_and_args():
+    """``command[0]`` → ``command``; the remainder → ``args``."""
+    servers = build_mcp_servers(
+        (McpBinding(name="gke", command=("gke-mcp", "--flag", "v"), tools=("t",)),)
+    )
+    assert servers == {"gke": {"command": "gke-mcp", "args": ["--flag", "v"]}}
+
+
+def test_build_mcp_servers_omits_args_for_bare_command():
+    """A single-element command yields no ``args`` key."""
+    servers = build_mcp_servers((McpBinding(name="gke", command=("gke-mcp",)),))
+    assert servers == {"gke": {"command": "gke-mcp"}}
+
+
+def test_build_mcp_servers_skips_command_less_bindings():
+    """Empty-command bindings (in-process/built-in servers) are not launched."""
+    servers = build_mcp_servers((McpBinding(name="builtin", command=(), tools=("t",)),))
+    assert servers == {}
+
+
+def test_build_mcp_servers_names_unnamed_bindings_by_index():
+    """A binding with no name falls back to a positional ``mcp<index>`` key."""
+    servers = build_mcp_servers((McpBinding(name="", command=("srv",)),))
+    assert servers == {"mcp0": {"command": "srv"}}
+
+
+def test_materialize_skills_writes_named_skill_files(tmp_path: Path):
+    """Each discovered ``SKILL.md`` is copied under ``<root>/<name>/SKILL.md``."""
+    src = tmp_path / "src"
+    (src / "rotate").mkdir(parents=True)
+    (src / "rotate" / "SKILL.md").write_text(
+        "---\nname: rotate-secret\ndescription: rotate\n---\nbody\n",
+        encoding="utf-8",
+    )
+    dest = tmp_path / "dest"
+
+    written = materialize_skills(dest, (str(src),))
+
+    assert written == ["rotate-secret"]
+    copied = dest / "rotate-secret" / "SKILL.md"
+    assert "body" in copied.read_text(encoding="utf-8")
+
+
+def test_materialize_skills_skips_missing_paths(tmp_path: Path):
+    """A non-existent source path is warned and skipped, not fatal."""
+    assert materialize_skills(tmp_path / "dest", (str(tmp_path / "nope"),)) == []

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -26,12 +26,18 @@ from devops_bench.agents.capabilities import (
     AgentRules,
     AllCapabilities,
     McpBinding,
+    SkillBinding,
     SupportsMcp,
     SupportsRules,
+    SupportsSkills,
 )
 from devops_bench.agents.cli.gemini_cli import GeminiCliAgent, parse_stream_json
 from devops_bench.agents.cli.gemini_cli import agent as gemini_mod
-from devops_bench.agents.cli.gemini_cli.agent import _build_argv, _build_env
+from devops_bench.agents.cli.gemini_cli.agent import (
+    _build_argv,
+    _build_env,
+    _build_settings,
+)
 from devops_bench.core.errors import SubprocessError
 
 
@@ -133,8 +139,10 @@ def test_parse_stream_json_empty_input_returns_empty():
 def test_build_argv_disables_extensions_when_no_allowed_tools():
     argv = _build_argv("/bin/gemini", "hi", ())
     assert "--output-format" in argv and "stream-json" in argv
-    assert '-e=""' in argv
+    assert "--extensions=" in argv
     assert "--allowed-tools" not in argv
+    # Headless auto-approve so MCP/built-in tool calls never block on a prompt.
+    assert argv[argv.index("--approval-mode") + 1] == "yolo"
     assert argv[-2:] == ["-p", "hi"]
 
 
@@ -142,7 +150,8 @@ def test_build_argv_emits_one_allowed_tools_pair_per_tool():
     argv = _build_argv("/bin/gemini", "hi", ("a", "b"))
     pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1) if argv[i] == "--allowed-tools"]
     assert pairs == [("--allowed-tools", "a"), ("--allowed-tools", "b")]
-    assert '-e=""' not in argv
+    assert "--extensions=" not in argv
+    assert argv[argv.index("--approval-mode") + 1] == "yolo"
 
 
 def test_build_env_threads_api_key_and_model_into_gemini_vars():
@@ -353,12 +362,13 @@ def test_legacy_session_glob_is_gone():
 # ---------------------------------------------------------------------------
 
 
-def test_gemini_agent_satisfies_mcp_and_rules_protocols():
-    """Gemini declares MCP + Rules (its binary launches MCP in-process and
-    auto-loads ``GEMINI.md``); skills are not declared because oc-style local
-    skills are not how Gemini loads context."""
+def test_gemini_agent_satisfies_mcp_skills_and_rules_protocols():
+    """Gemini declares MCP, Skills and Rules: it writes ``mcpServers`` into a
+    workspace ``settings.json``, materializes workspace skills under
+    ``.gemini/skills``, and auto-loads ``GEMINI.md``."""
     agent = GeminiCliAgent(AgentConfig())
     assert isinstance(agent, SupportsMcp)
+    assert isinstance(agent, SupportsSkills)
     assert isinstance(agent, SupportsRules)
 
 
@@ -378,11 +388,11 @@ def test_execute_pulls_allowed_tools_from_capabilities(monkeypatch):
     argv = captured["argv"]
     pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1) if argv[i] == "--allowed-tools"]
     assert pairs == [("--allowed-tools", "alpha"), ("--allowed-tools", "beta")]
-    assert '-e=""' not in argv  # tools present → extensions enabled
+    assert "--extensions=" not in argv  # tools present → extensions enabled
 
 
 def test_execute_disables_extensions_when_capabilities_have_no_mcp(monkeypatch):
-    """No MCP binding (no allowed tools) → ``-e=""`` argv (extensions off)."""
+    """No MCP binding (no allowed tools) → ``--extensions=`` argv (extensions off)."""
     captured: dict = {}
 
     def fake_run(argv, **kwargs):
@@ -391,19 +401,22 @@ def test_execute_disables_extensions_when_capabilities_have_no_mcp(monkeypatch):
 
     monkeypatch.setattr(gemini_mod, "run", fake_run)
     GeminiCliAgent(AgentConfig(target="gemini")).run("p")
-    assert '-e=""' in captured["argv"]
+    assert "--extensions=" in captured["argv"]
     assert "--allowed-tools" not in captured["argv"]
 
 
 def test_gemini_agent_mirrors_capability_bindings_onto_mixin_attributes():
     """The structural-Protocol attributes track the granted bindings."""
     binding = McpBinding(name="x", command=(), tools=("t",))
+    skills = SkillBinding(paths=("/some/skills",))
     caps = AllCapabilities(
         mcp_servers=(binding,),
+        skills=skills,
         rules=AgentRules(text="be a sre"),
     )
     agent = GeminiCliAgent(AgentConfig(capabilities=caps))
     assert agent.mcp_servers == (binding,)
+    assert agent.skills == skills
     assert agent.rules == AgentRules(text="be a sre")
 
 
@@ -478,3 +491,160 @@ def test_execute_cleans_up_temp_working_dir_after_run(monkeypatch):
     # cwd was a real path during the run; after _execute returns it is gone.
     assert captured["cwd"] is not None
     assert not os.path.exists(captured["cwd"])
+
+
+# ---------------------------------------------------------------------------
+# MCP server wiring: settings.json mcpServers reach the binary's cwd.
+# ---------------------------------------------------------------------------
+
+
+def test_build_settings_combines_mcp_servers_and_skills_flag():
+    """Both knobs render; skills flag is gated on ``skills_enabled``."""
+    binding = McpBinding(name="gke", command=("gke-mcp",))
+    assert _build_settings((binding,), skills_enabled=True) == {
+        "mcpServers": {"gke": {"command": "gke-mcp"}},
+        "skills": {"enabled": True},
+    }
+    assert _build_settings((), skills_enabled=False) == {}
+
+
+def test_execute_writes_mcp_servers_into_workspace_settings(monkeypatch):
+    """A command-bearing MCP binding lands in ``<cwd>/.gemini/settings.json``."""
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        settings_path = os.path.join(kwargs["cwd"], ".gemini", "settings.json")
+        captured["exists"] = os.path.exists(settings_path)
+        if captured["exists"]:
+            with open(settings_path) as f:
+                captured["settings"] = json.load(f)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="gke", command=("gke-mcp",), tools=("mcp_gke_x",)),),
+    )
+    GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+
+    assert captured["exists"], "settings.json must exist in cwd before subprocess"
+    assert captured["settings"]["mcpServers"] == {"gke": {"command": "gke-mcp"}}
+
+
+def test_execute_writes_no_settings_when_no_command_and_no_skills(monkeypatch):
+    """No launchable MCP server and no skills → no settings.json is written."""
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        settings_path = os.path.join(kwargs["cwd"], ".gemini", "settings.json")
+        captured["exists"] = os.path.exists(settings_path)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    # Binding carries tools (→ --allowed-tools) but no launch command.
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="builtin", command=(), tools=("alpha",)),),
+    )
+    GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+    assert captured["exists"] is False
+
+
+def test_execute_materializes_skills_into_workspace(monkeypatch, tmp_path):
+    """Bound skill paths are copied to ``<cwd>/.gemini/skills/<name>/SKILL.md``
+    and ``skills.enabled`` is set in settings.json."""
+    src = tmp_path / "skills" / "my-skill"
+    src.mkdir(parents=True)
+    skill_text = "---\nname: my-skill\ndescription: do things\n---\nbody\n"
+    (src / "SKILL.md").write_text(skill_text)
+
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        skill_path = os.path.join(kwargs["cwd"], ".gemini", "skills", "my-skill", "SKILL.md")
+        captured["skill_exists"] = os.path.exists(skill_path)
+        if captured["skill_exists"]:
+            with open(skill_path) as f:
+                captured["skill_text"] = f.read()
+        else:
+            captured["skill_text"] = None
+        settings_path = os.path.join(kwargs["cwd"], ".gemini", "settings.json")
+        with open(settings_path) as f:
+            captured["settings"] = json.load(f)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(skills=SkillBinding(paths=(str(tmp_path / "skills"),)))
+    GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+
+    assert captured["skill_exists"], "skill must be materialized before subprocess"
+    assert captured["skill_text"] == skill_text
+    assert captured["settings"]["skills"] == {"enabled": True}
+
+
+def test_execute_warns_and_skips_missing_skill_paths(monkeypatch):
+    """A non-existent skill path is skipped (no settings.json, no crash)."""
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        settings_path = os.path.join(kwargs["cwd"], ".gemini", "settings.json")
+        captured["exists"] = os.path.exists(settings_path)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    caps = AllCapabilities(skills=SkillBinding(paths=("/no/such/skills/dir",)))
+    GeminiCliAgent(AgentConfig(target="gemini", capabilities=caps)).run("p")
+    assert captured["exists"] is False
+
+
+# ---------------------------------------------------------------------------
+# Parallel isolation: each run gets its own throwaway cwd, never a shared one.
+# This is what makes concurrent gemini runs safe on a single host — the binary
+# reads/writes its workspace `.gemini` from cwd, so two runs sharing a cwd would
+# clobber each other's settings/skills. The refactored arm also parses the
+# trajectory from stdout (see parse_stream_json tests), so it never touches the
+# shared `~/.gemini/tmp/.../chats` dir the legacy arm relies on.
+# ---------------------------------------------------------------------------
+
+
+def test_execute_runs_in_isolated_temp_cwd_not_user_home(monkeypatch):
+    """The cwd is a fresh temp dir (prefix ``gemini-run-``), not the process cwd
+    and not under the user's ``~/.gemini``."""
+    import tempfile
+
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+
+    cwd = captured["cwd"]
+    assert cwd is not None
+    assert os.path.basename(cwd).startswith("gemini-run-")
+    # Sandboxed under the OS temp root, and distinct from the process cwd.
+    assert os.path.realpath(cwd).startswith(os.path.realpath(tempfile.gettempdir()))
+    assert os.path.realpath(cwd) != os.path.realpath(os.getcwd())
+    # The user-level gemini config dir must never be used as the workspace.
+    assert os.path.expanduser("~/.gemini") not in os.path.realpath(cwd)
+
+
+def test_execute_uses_distinct_cwd_per_run(monkeypatch):
+    """Two runs never share a working directory — the core parallel-safety
+    invariant. Each ``_execute`` mints its own ``TemporaryDirectory``."""
+    cwds: list[str] = []
+
+    def fake_run(argv, **kwargs):
+        cwds.append(kwargs.get("cwd"))
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(gemini_mod, "run", fake_run)
+    # Two separate agents and a re-run of one — all must get unique cwds.
+    GeminiCliAgent(AgentConfig(target="gemini")).run("p")
+    agent = GeminiCliAgent(AgentConfig(target="gemini"))
+    agent.run("p")
+    agent.run("p")
+
+    assert len(cwds) == 3
+    assert all(c is not None for c in cwds)
+    assert len(set(cwds)) == 3, f"cwds must be unique per run, got {cwds}"

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -25,13 +26,20 @@ from devops_bench.agents import AGENTS, AgentConfig
 from devops_bench.agents.capabilities import (
     AgentRules,
     AllCapabilities,
+    McpBinding,
+    SkillBinding,
     SupportsMcp,
     SupportsRules,
     SupportsSkills,
 )
 from devops_bench.agents.cli.openclaw import OpenClawAgent, parse_trajectory_export
 from devops_bench.agents.cli.openclaw import agent as oc_mod
-from devops_bench.agents.cli.openclaw.agent import _build_local_command, _oc_model_id
+from devops_bench.agents.cli.openclaw.agent import (
+    _build_env,
+    _build_local_command,
+    _build_openclaw_config,
+    _oc_model_id,
+)
 from devops_bench.agents.cli.openclaw.parsing import _pick_session_key, _strip_ansi
 from devops_bench.core.errors import SubprocessError
 
@@ -174,7 +182,6 @@ def test_build_local_command_quotes_inputs_and_includes_model_set():
     cmd = _build_local_command(cfg, "hi 'world'", "operator", "/usr/local/bin/oc")
     # Prompt single-quote must be escaped, not break the shell line.
     assert "hi '\\''world'\\''" in cmd or "hi 'world'" not in cmd
-    assert "rm -rf" in cmd  # sessions wipe
     assert "NVM_DIR" in cmd  # nvm sourced for the node runtime
     # shlex.quote leaves alnum/`/`/`-`/`.` un-quoted; just match the canonical id.
     assert "models set google/gemini-2.5-pro" in cmd
@@ -385,19 +392,34 @@ def test_legacy_local_runner_is_gone():
 
 
 # ---------------------------------------------------------------------------
-# PR3 — capability negotiation: OpenClaw declares only what oc supports
+# Capability negotiation: OpenClaw wires MCP + skills via oc's native channels
 # ---------------------------------------------------------------------------
 
 
-def test_openclaw_satisfies_only_rules_protocol():
-    """The installed ``oc`` build exposes no in-agent MCP / skills wiring; the
-    agent therefore declares **only** :class:`SupportsRules`. Granting MCP or
-    skills to it would silently no-op — capability negotiation must refuse the
-    binding rather than waste it."""
+def test_openclaw_satisfies_mcp_skills_and_rules_protocols():
+    """OpenClaw declares MCP, Skills and Rules: it writes ``mcp.servers`` into an
+    isolated ``OPENCLAW_CONFIG_PATH``, materializes managed skills under
+    ``<OPENCLAW_STATE_DIR>/skills``, and prepends the operator brief to the
+    prompt."""
     agent = OpenClawAgent(AgentConfig())
     assert isinstance(agent, SupportsRules)
-    assert not isinstance(agent, SupportsMcp)
-    assert not isinstance(agent, SupportsSkills)
+    assert isinstance(agent, SupportsMcp)
+    assert isinstance(agent, SupportsSkills)
+
+
+def test_openclaw_agent_mirrors_capability_bindings_onto_mixin_attributes():
+    """The structural-Protocol attributes track the granted bindings."""
+    binding = McpBinding(name="gke", command=("gke-mcp",), tools=("t",))
+    skills = SkillBinding(paths=("/some/skills",))
+    caps = AllCapabilities(
+        mcp_servers=(binding,),
+        skills=skills,
+        rules=AgentRules(text="be a sre"),
+    )
+    agent = OpenClawAgent(AgentConfig(capabilities=caps))
+    assert agent.mcp_servers == (binding,)
+    assert agent.skills == skills
+    assert agent.rules == AgentRules(text="be a sre")
 
 
 def test_openclaw_agent_mirrors_rules_binding_onto_mixin_attribute():
@@ -473,3 +495,172 @@ def test_execute_does_not_prepend_rules_when_empty(monkeypatch, tmp_path):
     # inside single quotes in the `-m` segment — and no extra blank-line
     # prefix surrounds it.
     assert "-m 'just the prompt'" in cmd
+
+
+# ---------------------------------------------------------------------------
+# MCP server wiring: mcp.servers reach an isolated OPENCLAW_CONFIG_PATH.
+# ---------------------------------------------------------------------------
+
+
+def test_build_openclaw_config_wraps_servers_under_mcp():
+    """A launchable binding renders under the ``mcp.servers`` config path."""
+    cfg = _build_openclaw_config((McpBinding(name="gke", command=("gke-mcp",)),))
+    assert cfg == {"mcp": {"servers": {"gke": {"command": "gke-mcp"}}}}
+
+
+def test_build_openclaw_config_empty_without_launchable_server():
+    """No command-bearing binding → empty config (caller skips the write)."""
+    assert _build_openclaw_config(()) == {}
+    assert _build_openclaw_config((McpBinding(name="b", command=(), tools=("t",)),)) == {}
+
+
+def test_build_env_threads_api_key_by_provider():
+    """``config.api_key`` lands on the provider-specific env var(s)."""
+    google = _build_env(AgentConfig(api_key="k", provider="google"))
+    assert google["GEMINI_API_KEY"] == "k" and google["GOOGLE_API_KEY"] == "k"
+    anthropic = _build_env(AgentConfig(api_key="k", provider="anthropic"))
+    assert anthropic == {"ANTHROPIC_API_KEY": "k"}
+    assert _build_env(AgentConfig()) == {}
+
+
+def _empty_sessions_run(argv, **kwargs):
+    """Core-subprocess.run stub: ``oc sessions`` returns no rows."""
+    return _make_subprocess_result(stdout=json.dumps([]), returncode=0)
+
+
+def test_execute_writes_mcp_servers_into_isolated_config(monkeypatch, tmp_path):
+    """A command-bearing MCP binding lands in ``<cwd>/openclaw.json`` and
+    ``OPENCLAW_CONFIG_PATH`` is pointed at it (read inside the fake to beat
+    temp-dir cleanup)."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        env = kwargs.get("env") or {}
+        cfg_path = env.get("OPENCLAW_CONFIG_PATH")
+        captured["cfg_path"] = cfg_path
+        captured["config"] = (
+            json.loads(Path(cfg_path).read_text())
+            if cfg_path and Path(cfg_path).exists()
+            else None
+        )
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_bash)
+    monkeypatch.setattr(oc_mod, "run", _empty_sessions_run)
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="gke", command=("gke-mcp",), tools=("mcp_gke_x",)),),
+    )
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), capabilities=caps)).run("p")
+    assert captured["cfg_path"], "OPENCLAW_CONFIG_PATH must be set when MCP is bound"
+    assert captured["config"] == {"mcp": {"servers": {"gke": {"command": "gke-mcp"}}}}
+
+
+def test_execute_writes_no_config_when_no_launchable_server(monkeypatch, tmp_path):
+    """No command-bearing MCP binding → no isolated config, env var unset."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        env = kwargs.get("env") or {}
+        captured["has_cfg"] = "OPENCLAW_CONFIG_PATH" in env
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_bash)
+    monkeypatch.setattr(oc_mod, "run", _empty_sessions_run)
+    caps = AllCapabilities(
+        mcp_servers=(McpBinding(name="builtin", command=(), tools=("alpha",)),),
+    )
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), capabilities=caps)).run("p")
+    assert captured["has_cfg"] is False
+
+
+def test_execute_isolates_state_dir_and_drops_global_session_wipe(monkeypatch, tmp_path):
+    """``OPENCLAW_STATE_DIR`` points under the per-run cwd and the old global
+    ``rm -rf ~/.openclaw/.../sessions`` wipe is gone (state is fresh per run)."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        env = kwargs.get("env") or {}
+        captured["state_dir"] = env.get("OPENCLAW_STATE_DIR")
+        captured["cwd"] = kwargs.get("cwd")
+        captured["cmd"] = cmd
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_bash)
+    monkeypatch.setattr(oc_mod, "run", _empty_sessions_run)
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"))).run("p")
+    assert captured["state_dir"] == os.path.join(captured["cwd"], "state")
+    assert "rm -rf" not in captured["cmd"]
+
+
+def test_execute_threads_api_key_into_subprocess_env(monkeypatch, tmp_path):
+    """The model API key reaches the spawned ``oc`` process env."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        captured["env"] = kwargs.get("env") or {}
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_bash)
+    monkeypatch.setattr(oc_mod, "run", _empty_sessions_run)
+    cfg = AgentConfig(target=str(tmp_path / "oc"), api_key="secret", provider="google")
+    OpenClawAgent(cfg).run("p")
+    assert captured["env"]["GEMINI_API_KEY"] == "secret"
+    assert captured["env"]["GOOGLE_API_KEY"] == "secret"
+
+
+def test_execute_materializes_skills_into_state_skills_dir(monkeypatch, tmp_path):
+    """Bound skill paths are copied to ``<cwd>/state/skills/<name>/SKILL.md``."""
+    src = tmp_path / "skills" / "my-skill"
+    src.mkdir(parents=True)
+    skill_text = "---\nname: my-skill\ndescription: do things\n---\nbody\n"
+    (src / "SKILL.md").write_text(skill_text)
+
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        cwd = kwargs.get("cwd")
+        skill_path = os.path.join(cwd, "state", "skills", "my-skill", "SKILL.md")
+        captured["exists"] = os.path.exists(skill_path)
+        captured["text"] = Path(skill_path).read_text() if captured["exists"] else None
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_bash)
+    monkeypatch.setattr(oc_mod, "run", _empty_sessions_run)
+    caps = AllCapabilities(skills=SkillBinding(paths=(str(tmp_path / "skills"),)))
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), capabilities=caps)).run("p")
+    assert captured["exists"], "skill must be materialized before subprocess"
+    assert captured["text"] == skill_text
+
+
+def test_execute_warns_and_skips_missing_skill_paths(monkeypatch, tmp_path):
+    """A non-existent skill path is skipped (no crash, empty skills root)."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        cwd = kwargs.get("cwd")
+        skills_root = os.path.join(cwd, "state", "skills")
+        captured["entries"] = (
+            sorted(os.listdir(skills_root)) if os.path.isdir(skills_root) else []
+        )
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_bash)
+    monkeypatch.setattr(oc_mod, "run", _empty_sessions_run)
+    caps = AllCapabilities(skills=SkillBinding(paths=("/no/such/skills/dir",)))
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), capabilities=caps)).run("p")
+    assert captured["entries"] == []
+
+
+def test_execute_cleans_up_temp_working_dir_after_run(monkeypatch, tmp_path):
+    """The per-run temp dir (state, config, skills) is removed after _execute."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_bash)
+    monkeypatch.setattr(oc_mod, "run", _empty_sessions_run)
+    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"))).run("p")
+    assert captured["cwd"] is not None
+    assert not os.path.exists(captured["cwd"])


### PR DESCRIPTION
The Gemini and OpenClaw CLI agents declared rules/MCP/skills capabilities but only pre-approved tool names and delivered the operator brief — MCP servers were never launched and skills were ignored. This wires both agents to actually deliver MCP + skills through each binary's native, per-run channels.

**Behavior changes**
- Gemini: command-bearing MCP bindings are written as `mcpServers` in a per-run `<cwd>/.gemini/settings.json`, and skills are materialized to `<cwd>/.gemini/skills/<name>/SKILL.md` with `skills.enabled`; the binary then spawns the servers and loads the skills.
- OpenClaw: MCP bindings are written as `mcp.servers` in a per-run isolated config (`OPENCLAW_CONFIG_PATH`) and skills under `<OPENCLAW_STATE_DIR>/skills/`, both per-run so nothing touches `~/.openclaw`; the embedded `oc agent --local` consumes them. The model API key is threaded into the provider env var, and the agent id defaults to `oc`'s built-in `main`.
- Both agents now assign `mcp_servers` + `skills`, so they structurally satisfy `SupportsMcp` / `SupportsSkills`; granting those bindings used to be a silent no-op.