### PR TITLE
feat(bastion): static GCE bastion for running the eval harness

### DIFF
--- a/docs/bastion.md
+++ b/docs/bastion.md
@@ -1,0 +1,166 @@
+# Eval-harness bastion (GCE)
+
+A static Google Compute Engine VM that serves as the **execution environment for
+the eval harness**. Use it when you can't run the agent CLI (openclaw / `oc`)
+locally: you SSH into the bastion over IAP and run the whole harness there.
+
+The harness drives `oc` as a **local subprocess** (the openclaw agent is
+local-only), so everything — infra provisioning (tofu), the agent run (`oc`), and
+the judge — happens on the VM.
+
+The bastion is intentionally **generic and reusable**; secret-rotation is just
+the first eval it runs.
+
+## Architecture
+
+```
+You ──IAP SSH──> bastion VM "bench-bastion" (us-central1-a)
+                   runs as openclaw-vm-sa  (ADC via the metadata server)
+                   │
+                   ├─ devops-bench CLI (the harness)
+                   │    ├─ tofu apply  ->  GKE cluster + Secret Manager + ESO + app
+                   │    ├─ oc agent --local   (openclaw performs the rotation)
+                   │    │     └─ kubectl + gcloud + Secret Manager  (as the VM SA)
+                   │    └─ judge (Gemini/Anthropic via API key)
+                   └─ openclaw API key for the agent model
+   (code pushed from your laptop via gcloud compute scp over IAP, subset only)
+```
+
+### Why this service account
+The bastion runs as `openclaw-vm-sa@<project>.iam.gserviceaccount.com`. That is
+**not arbitrary**: the secret-rotation tofu stack already references that exact
+email — `tf/prebuilt/secret-rotation/cluster/main.tf` grants it
+`roles/secretmanager.admin`, and `tf/modules/gke` grants the cluster's
+`agent_service_account` `roles/container.admin` and opens an IAP-SSH firewall.
+Nothing in those stacks *creates* the SA or a VM — this bastion fills that gap.
+The SA id is the `sa_account_id` variable, so other harnesses can use a different
+one.
+
+The bastion SA also gets broad **provisioning** rights (`roles/editor` +
+`roles/resourcemanager.projectIamAdmin` + `roles/iam.serviceAccountAdmin`) so the
+harness can run the task's tofu (which creates GKE, secrets, service accounts, and
+sets project/SA IAM bindings) *as this SA*. These rights are owner-equivalent, so
+**run this only in a non-production / sandbox project**. Scope them down for your
+task with the `sa_roles` variable, granting only the roles the task's tofu needs.
+
+## Files
+
+| Path | Purpose |
+|------|---------|
+| `tf/modules/bastion/` | Reusable module: SA + IAM, the VM, the IAP-SSH firewall, `startup.sh`. |
+| `tf/prebuilt/bastion/` | Concrete stack you `tofu apply`. |
+| `scripts/bastion/sync-to-bastion.sh` | Push your local working tree (subset) to the VM. |
+| `scripts/bastion/vm-setup.sh` | One-time per-user setup on the VM (venv + install + env). |
+
+## 1. Provision the bastion
+
+```bash
+cd tf/prebuilt/bastion
+tofu init
+tofu apply -var project_id=<your-project>
+```
+
+Useful outputs: `iap_ssh_command`, `sa_email`. The VM's `startup.sh` installs the
+toolchain on first boot (OpenTofu, gcloud + gke-gcloud-auth-plugin, kubectl,
+Node 22, and `openclaw`, symlinked as `oc`); it touches
+`/var/lib/bench-bastion-ready` when finished and logs to
+`/var/log/bench-bastion-startup.log`.
+
+Variables you may want: `name` (VM name, default `bench-bastion`), `zone`
+(default `us-central1-a`), `machine_type` (default `e2-standard-4`),
+`sa_account_id` (default `openclaw-vm-sa`), `assign_external_ip` (default `true`).
+
+## 2. SSH in (over IAP)
+
+```bash
+gcloud compute ssh bench-bastion --zone us-central1-a --project <proj> --tunnel-through-iap
+```
+
+(the `iap_ssh_command` output prints this exact line). SSH ingress is restricted
+to Google's IAP range (`35.235.240.0/20`); the external IP, if any, is for egress
+only.
+
+Sanity-check the toolchain:
+
+```bash
+cat /var/lib/bench-bastion-ready   # exists once startup finished
+oc --version && tofu version && gcloud --version | head -1
+kubectl version --client | head -1 && python3 --version && node --version
+```
+
+## 3. Ship your code + set up
+
+From your laptop (reflects local, unpushed changes — only the needed subset is
+sent):
+
+```bash
+scripts/bastion/sync-to-bastion.sh        # tars + scps over IAP into ~/devops-bench
+```
+
+By default this uses `gcloud compute ssh/scp --tunnel-through-iap`. In special
+environments (e.g. Google corp hosts reachable directly at
+`nic0.<vm>.<zone>.c.<project>.internal.gcpnode.com`) you can override the
+transport without changing the default:
+
+```bash
+# Auto-build the gcpnode host from VM/zone/project, user defaults to <you>_google_com:
+BASTION_USE_GCPNODE=1 scripts/bastion/sync-to-bastion.sh
+# Or point at an explicit host / user:
+BASTION_SSH_HOST=nic0.bench-bastion.us-central1-a.c.my-proj.internal.gcpnode.com \
+  BASTION_SSH_USER=me_google_com scripts/bastion/sync-to-bastion.sh
+```
+
+Then on the VM, once:
+
+```bash
+~/devops-bench/scripts/bastion/vm-setup.sh   # venv + pip install .[all] + ~/bench.env
+openclaw onboard                              # persist the agent model API key
+```
+
+`vm-setup.sh` writes a `~/bench.env` template. Fill in your project and judge key,
+then `source ~/bench.env`.
+
+> Agent model key: when `AGENT_API_KEY` is unset, the harness passes no key to
+> `oc` and openclaw uses the key from `openclaw onboard`. When `AGENT_API_KEY` is
+> set, the harness threads it into the provider env var (`GEMINI_API_KEY` /
+> `ANTHROPIC_API_KEY` / …) for the run. Either way, provide the key once — via
+> `openclaw onboard` or that provider env var.
+
+## 4. Run the secret-rotation eval
+
+```bash
+cd ~/devops-bench && source .venv/bin/activate
+source ~/bench.env
+devops-bench complextasks/secret-rotation/task.yaml
+```
+
+The harness provisions the GKE cluster + Secret Manager + External Secrets
+Operator + the `db-secret-viewer` app, runs `oc agent --local` to rotate the
+secret, judges the result, then tears the infra down.
+
+Iterating: keep the cluster between runs with `export BENCH_NO_TEARDOWN=true`,
+bumping `NAMESPACE` per run so each run's resources don't collide in the shared
+cluster; or skip provisioning entirely with `--no-infra`. This per-run `NAMESPACE`
+bump applies only when reusing one cluster — parallel runs on separate clusters
+don't need it (see [`docs/parallel-evals.md`](./parallel-evals.md)).
+
+## Cost & security notes
+
+- **Static VM** — it bills while it exists. `tofu destroy` in `tf/prebuilt/bastion`
+  when you're done, or stop the instance between sessions.
+- **SSH is IAP-only.** The optional external IP is egress-only; remove it
+  (`-var assign_external_ip=false`) if your VPC has Cloud NAT.
+- **Broad SA.** `openclaw-vm-sa` holds near-project-admin rights so it can
+  provision eval infra. Keep it in a non-production / sandbox project. The agent's
+  model key lives in openclaw's config on the VM (per your chosen API-key auth);
+  promoting it to Secret Manager is a tracked follow-up.
+
+## Known issues (appendix)
+
+Record issues found while using the bastion here, so they live in one place.
+
+| Issue | Impact | Workaround / status |
+|-------|--------|---------------------|
+| Bastion SA is owner-equivalent (`editor` + `projectIamAdmin` + `serviceAccountAdmin`). | Anything running as the SA can grant itself any role and impersonate any SA. | Sandbox/non-prod projects only; scope down with `sa_roles`. Follow-up: ship a least-privilege default. |
+| Agent model key stored in openclaw's on-VM config. | Key sits in plaintext on the VM. | Keep the VM IAP-only. Follow-up: promote to Secret Manager. |
+| Static VM bills continuously. | Cost accrues while the VM exists. | `tofu destroy` (or stop the instance) when idle. |

--- a/docs/refactor/legacy-comparison.md
+++ b/docs/refactor/legacy-comparison.md
@@ -1,0 +1,89 @@
+# Legacy vs. refactor comparison harness (temporary)
+
+**Status: droppable scaffolding.** This harness is a regression gate used *during*
+the `pkg/evaluator/evaluate.py` -> `devops_bench` refactor. Both implementations
+currently coexist on this branch. Once the refactor is validated and the legacy
+evaluator is removed, delete `scripts/compare_legacy_vs_refactor.sh`,
+`scripts/compare_results.py`, and `tests/unit/comparison/`.
+
+## Purpose
+
+Run the same reference task through both entrypoints against a deterministic mock
+model and prove that the refactor changed *only* what it intended to change. The
+mock (`scripts/mock_ollama_server.py`) returns identical canned agent + judge
+output to both runs, so any difference in `results.json` is attributable to the
+code, not the model.
+
+## How to run
+
+```bash
+# default reference task: tasks/generic/gateway-https-redirect/task.yaml
+scripts/compare_legacy_vs_refactor.sh
+
+# a different task / a different mock port
+MOCK_PORT=11500 scripts/compare_legacy_vs_refactor.sh tasks/<...>/task.yaml
+```
+
+The orchestrator:
+
+1. Starts the mock Ollama server and health-checks `/v1/models` (killed via an
+   `EXIT` trap so a failed run still cleans up).
+2. Runs LEGACY (`python pkg/evaluator/evaluate.py <task>`), which writes
+   `results/run_<ts>/results.json` relative to CWD; the script picks the newest
+   run dir that did not exist before the run.
+3. Runs REFACTOR (`RESULTS_ROOT=<tmp> uv run python -m devops_bench <task>`) into
+   an isolated temp dir and parses the printed `results: <path>` line.
+4. Diffs the two files with `scripts/compare_results.py` and propagates its exit
+   code: **0** = no regressions, **1** = a regression, **2** = usage/IO error.
+
+You can also diff two existing files directly:
+
+```bash
+uv run python scripts/compare_results.py \
+  --legacy <legacy results.json> --refactor <refactor results.json> \
+  [--json-report report.json]
+```
+
+## The three buckets
+
+Every observed difference (after normalization that drops volatile fields:
+`latency`, `tokens`, timestamps, run-dir/absolute paths, and trajectory
+structure) is partitioned into:
+
+- **MATCHED** — identical after normalization.
+- **INTENDED** — explained by the allowlist below (a documented, deliberate
+  refactor change).
+- **REGRESSION** — any remaining unexplained difference (a dropped/added
+  non-allowlisted metric, a real status flip, materially different `output`, or a
+  value/success diff on a metric not on the value-delta allowlist). A single
+  regression fails the gate (exit 1).
+
+## Current intended-delta allowlist
+
+Defined as clearly-labeled module-level constants at the top of
+`scripts/compare_results.py`; edit there to extend. Rationale traces to
+`docs/refactor/metrics-extensibility-handoff.md` (section 3 reviewer note) plus
+two schema/trajectory deltas observed empirically on the reference task.
+
+| Allowlist constant | What it tolerates | Rationale |
+|---|---|---|
+| (always) score-key normalization | strips a trailing ` [GEval]` before aligning | Legacy wrote `OutcomeValidity [GEval]` / `ToolInvocation [GEval]`; refactor strips uniformly (handoff section 3). |
+| `INTENDED_METRIC_VALUE_DELTAS` = {GroundingAccuracy, ParameterRecallAccuracy, DocRetrievalRate} | numeric value/success diffs on these metrics | Constraint dedup (legacy double-counted) and missing-key robustness guard (handoff section 3). |
+| `INTENDED_CHECKLIST_TEXT_DELTAS` | a `Check: ...` key present on only one side | Trailing-hyphen fix changed some checklist item names (handoff section 3); only the *text* changed. |
+| `INTENDED_LEGACY_NULL_STATUS` | legacy `status=None` paired with any refactor status | Legacy non-infra path never set `status`; refactor sets an explicit terminal status. A real success<->failed flip (both non-None) is still a regression. |
+| `INTENDED_TRAJECTORY_PRESENCE_DELTA` | trajectory non-empty on one side, empty on the other | By design the two trajectories track different things: legacy stores conversation turns, refactor stores only canonical `ToolCall` entries (empty for a no-tool task). Trajectory is never diffed structurally. |
+| `INTENDED_MCP_READ_METRICS` = {ToolInvocation} | the `ToolInvocation` metric present on only one side | MCP-gated; `BENCH_USE_MCP` is read once by the refactor harness (handoff section 4.3). |
+
+## Reading the gate output
+
+`compare_results.py` prints each difference under its bucket, then exits `0` (no
+regressions) or `1` (one or more). A clean refactor on a no-infra,
+`BENCH_USE_MCP=false` task typically shows only **INTENDED** deltas (e.g. legacy
+`status=None` → refactor `success`; trajectory presence by design) plus
+**MATCHED** scores. Treat any **REGRESSION** row as a real change to investigate.
+(Per-run counts and scores are not recorded here — they're tracked separately.)
+
+> **Blind spots.** The allowlist deliberately tolerates value/success diffs on the
+> three grounding metrics (`INTENDED_METRIC_VALUE_DELTAS`) and `Check:` key-text
+> changes, so a value regression *on those* will not fail the gate. The gate is a
+> coarse guard, not a full equivalence proof.

--- a/scripts/bastion/sync-to-bastion.sh
+++ b/scripts/bastion/sync-to-bastion.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Push the LOCAL working tree (including uncommitted/unpushed changes) to the
+# bastion, so the harness on the VM runs exactly the code you have locally.
+#
+# Only the subset the harness needs is shipped (python + task + infra + docker
+# entrypoint); .git, virtualenvs, tofu state, caches and results are excluded.
+# It tars the subset, scps the single archive over IAP, and extracts it into
+# ~/devops-bench on the VM.
+#
+# Usage (from anywhere in the repo):
+#   scripts/bastion/sync-to-bastion.sh
+#
+# Env overrides:
+#   BASTION_VM       VM name        (default: bench-bastion)
+#   BASTION_ZONE     VM zone        (default: us-central1-a)
+#   BASTION_PROJECT  GCP project    (default: gcloud's active project)
+#   REMOTE_DIR       dir on the VM  (default: ~/devops-bench)
+set -euo pipefail
+
+BASTION_VM="${BASTION_VM:-bench-bastion}"
+BASTION_ZONE="${BASTION_ZONE:-us-central1-a}"
+BASTION_PROJECT="${BASTION_PROJECT:-$(gcloud config get-value project 2>/dev/null)}"
+REMOTE_DIR="${REMOTE_DIR:-devops-bench}" # relative to the SSH user's $HOME
+
+if [ -z "${BASTION_PROJECT}" ]; then
+  echo "ERROR: no project. Set BASTION_PROJECT or run 'gcloud config set project <id>'." >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+# The subset the harness needs on the VM. Missing paths are skipped silently.
+PATHS=(
+  devops_bench
+  pyproject.toml
+  complextasks
+  tasks
+  tf
+  scripts
+  Dockerfile.harness
+)
+PRESENT=()
+for p in "${PATHS[@]}"; do
+  [ -e "${p}" ] && PRESENT+=("${p}")
+done
+
+ARCHIVE="$(mktemp -t bench-sync-XXXXXX).tgz"
+trap 'rm -f "${ARCHIVE}"' EXIT
+
+echo "==> packing $(printf '%s ' "${PRESENT[@]}")"
+tar \
+  --exclude='.git' \
+  --exclude='.venv' \
+  --exclude='__pycache__' \
+  --exclude='.terraform' \
+  --exclude='*.tfstate' \
+  --exclude='*.tfstate.*' \
+  --exclude='results' \
+  --exclude='.pytest_cache' \
+  --exclude='.ruff_cache' \
+  -czf "${ARCHIVE}" "${PRESENT[@]}"
+
+# Transport selection. Default: gcloud IAP tunnel (works on a standard GCP
+# project). Override for special environments (e.g. Google corp hosts reachable
+# at nic0.<vm>.<zone>.c.<project>.internal.gcpnode.com) WITHOUT changing the
+# default by setting either:
+#   BASTION_SSH_HOST   explicit host to ssh/scp to (raw ssh, no gcloud), or
+#   BASTION_USE_GCPNODE=1   auto-build the gcpnode host from VM/zone/project.
+# BASTION_SSH_USER overrides the login user (default for the gcpnode form is
+# "<localuser>_google_com", matching that environment's convention).
+upload_archive() { :; }
+remote_exec() { :; }
+if [ -n "${BASTION_SSH_HOST:-}" ] || [ "${BASTION_USE_GCPNODE:-}" = "1" ]; then
+  SSH_HOST="${BASTION_SSH_HOST:-nic0.${BASTION_VM}.${BASTION_ZONE}.c.${BASTION_PROJECT}.internal.gcpnode.com}"
+  SSH_USER="${BASTION_SSH_USER:-$(id -un)_google_com}"
+  SSH_TARGET="${SSH_USER}@${SSH_HOST}"
+  echo "==> transport: direct ssh to ${SSH_TARGET}"
+  upload_archive() { scp "${ARCHIVE}" "${SSH_TARGET}:/tmp/bench-sync.tgz"; }
+  remote_exec() { ssh "${SSH_TARGET}" "$1"; }
+else
+  echo "==> transport: gcloud compute ssh over IAP"
+  upload_archive() {
+    gcloud compute scp --tunnel-through-iap --zone "${BASTION_ZONE}" \
+      --project "${BASTION_PROJECT}" "${ARCHIVE}" "${BASTION_VM}:/tmp/bench-sync.tgz"
+  }
+  remote_exec() {
+    gcloud compute ssh "${BASTION_VM}" --tunnel-through-iap --zone "${BASTION_ZONE}" \
+      --project "${BASTION_PROJECT}" --command "$1"
+  }
+fi
+
+echo "==> uploading archive to ${BASTION_VM}"
+upload_archive
+
+echo "==> extracting into ~/${REMOTE_DIR} on the VM"
+remote_exec "set -e; mkdir -p ~/${REMOTE_DIR}; tar -xzf /tmp/bench-sync.tgz -C ~/${REMOTE_DIR}; rm -f /tmp/bench-sync.tgz; echo 'synced to ~/${REMOTE_DIR}'"
+
+echo "==> done. Next: SSH in and run scripts/bastion/vm-setup.sh"

--- a/scripts/bastion/vm-setup.sh
+++ b/scripts/bastion/vm-setup.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Per-user setup, run ONCE on the bastion after the first sync-to-bastion.sh.
+#
+# The system toolchain (tofu, gcloud, kubectl, node, oc) is already installed by
+# the VM startup script. This finishes the user-scoped pieces: a Python venv with
+# the harness installed, an openclaw API key, and a ~/bench.env template.
+#
+# Usage (on the VM):
+#   ~/devops-bench/scripts/bastion/vm-setup.sh
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-${HOME}/devops-bench}"
+ENV_FILE="${HOME}/bench.env"
+
+if [ ! -f "${REPO_DIR}/pyproject.toml" ]; then
+  echo "ERROR: ${REPO_DIR}/pyproject.toml not found. Run sync-to-bastion.sh from your laptop first." >&2
+  exit 1
+fi
+
+# Wait for the startup-script toolchain in case the VM only just booted.
+if [ ! -f /var/lib/bench-bastion-ready ]; then
+  echo "==> waiting for VM startup toolchain (/var/lib/bench-bastion-ready)..."
+  for _ in $(seq 1 60); do
+    [ -f /var/lib/bench-bastion-ready ] && break
+    sleep 5
+  done
+  # The loop falls through on timeout; fail loudly instead of proceeding
+  # against a half-provisioned VM (toolchain not yet installed).
+  if [ ! -f /var/lib/bench-bastion-ready ]; then
+    echo "ERROR: VM startup toolchain not ready after ~5m; aborting." >&2
+    exit 1
+  fi
+fi
+
+cd "${REPO_DIR}"
+
+echo "==> creating venv + installing the harness (.[all])"
+python3 -m venv .venv
+# shellcheck disable=SC1091
+source .venv/bin/activate
+pip install --upgrade pip
+pip install ".[all]"
+
+echo "==> openclaw key check"
+# The harness does NOT pass an API key to oc; openclaw must hold the agent
+# model's key itself. Persist it once with the interactive wizard:
+#     openclaw onboard
+# or export the provider key (e.g. GEMINI_API_KEY / ANTHROPIC_API_KEY) before
+# running the harness. We don't store the key here to keep it off disk in plain
+# text beyond openclaw's own config.
+if oc models list >/dev/null 2>&1; then
+  echo "    oc reachable."
+else
+  echo "    NOTE: run 'openclaw onboard' to configure the agent model API key."
+fi
+
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "==> writing ${ENV_FILE} template (fill in values, then 'source ~/bench.env')"
+  cat > "${ENV_FILE}" <<'EOF'
+# DevOps Bench harness environment. Fill in, then: source ~/bench.env
+# --- GCP target ---
+export GCP_PROJECT_ID=""
+export GKE_CLUSTER_NAME="secret-rotation-cluster"
+export GCP_LOCATION="us-central1-a"
+export NAMESPACE="secret-rotation-run-1"
+
+# --- Agent (openclaw / oc) ---
+export BENCH_AGENT_TYPE="cli"
+export AGENT_TARGET="oc"
+export AGENT_PROVIDER="google"
+export AGENT_MODEL="gemini-3.1-pro-preview"
+# Agent model key: prefer 'openclaw onboard'. If your provider reads an env key,
+# set it here too (e.g. GEMINI_API_KEY / ANTHROPIC_API_KEY).
+# export GEMINI_API_KEY=""
+
+# --- Judge ---
+export JUDGE_PROVIDER="google"
+export JUDGE_MODEL="gemini-3.1-pro-preview"
+export JUDGE_API_KEY=""
+EOF
+else
+  echo "==> ${ENV_FILE} already exists; leaving it untouched"
+fi
+
+echo ""
+echo "==> setup complete. To run the secret-rotation eval:"
+echo "    source ~/bench.env   # after filling in project + keys"
+echo "    cd ${REPO_DIR} && source .venv/bin/activate"
+echo "    devops-bench complextasks/secret-rotation/task.yaml"

--- a/scripts/compare_legacy_vs_refactor.sh
+++ b/scripts/compare_legacy_vs_refactor.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Temporary legacy-vs-refactor regression gate (droppable scaffolding).
+#
+# Runs the SAME reference task through both the legacy entrypoint
+# (pkg/evaluator/evaluate.py) and the refactor entrypoint
+# (python -m devops_bench) against a deterministic mock Ollama server, then
+# diffs the two results.json files via scripts/compare_results.py.
+#
+# Usage: scripts/compare_legacy_vs_refactor.sh [TASK_FILE]
+# Env:   MOCK_PORT (default 11439)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MOCK_PORT="${MOCK_PORT:-11439}"
+TASK_FILE="${1:-tasks/generic/gateway-https-redirect/task.yaml}"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  if [[ -n "${MOCK_PID:-}" ]]; then
+    kill "${MOCK_PID}" 2>/dev/null || true
+  fi
+  rm -rf "${TMP_DIR}" 2>/dev/null || true
+}
+# Always clean up the mock + temp dir, even on a failed run (legacy script lacked this).
+trap cleanup EXIT
+
+echo "==> Starting mock Ollama server on port ${MOCK_PORT}"
+python3 scripts/mock_ollama_server.py "${MOCK_PORT}" >"${TMP_DIR}/mock.log" 2>&1 &
+MOCK_PID=$!
+
+# Health-check the mock before running anything.
+for _ in $(seq 1 30); do
+  if curl -sf "http://127.0.0.1:${MOCK_PORT}/v1/models" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.3
+done
+if ! curl -sf "http://127.0.0.1:${MOCK_PORT}/v1/models" >/dev/null 2>&1; then
+  echo "ERROR: mock server failed to start; log follows:" >&2
+  cat "${TMP_DIR}/mock.log" >&2
+  exit 2
+fi
+echo "    mock server healthy (pid ${MOCK_PID})"
+
+# Shared env mirroring scripts/run_ollama_e2e_test.sh, pointed at the mock.
+export BENCH_AGENT_TYPE=api
+export BENCH_USE_MCP=false
+export BENCH_NO_INFRA=true
+export AGENT_PROVIDER=ollama
+export JUDGE_PROVIDER=ollama
+export AGENT_MODEL=gemma4:2b
+export JUDGE_MODEL=gemma4:2b
+export OLLAMA_BASE_URL="http://127.0.0.1:${MOCK_PORT}/v1"
+export GCP_PROJECT_ID=test-project
+export CLUSTER_NAME=test-cluster
+
+echo ""
+echo "==> Running LEGACY: python3 pkg/evaluator/evaluate.py ${TASK_FILE}"
+# Legacy writes results/run_<ts>/results.json relative to CWD and ignores
+# RESULTS_ROOT. Record pre-existing run dirs, then pick the newest new one.
+BEFORE="$(ls -d results/run_* 2>/dev/null | sort || true)"
+uv run python pkg/evaluator/evaluate.py "${TASK_FILE}" >"${TMP_DIR}/legacy.log" 2>&1 || {
+  echo "ERROR: legacy run failed; log follows:" >&2
+  cat "${TMP_DIR}/legacy.log" >&2
+  exit 2
+}
+AFTER="$(ls -d results/run_* 2>/dev/null | sort || true)"
+LEGACY_RUN_DIR="$(comm -13 <(printf '%s\n' "${BEFORE}") <(printf '%s\n' "${AFTER}") | grep -E 'results/run_' | tail -1 || true)"
+if [[ -z "${LEGACY_RUN_DIR}" ]]; then
+  echo "ERROR: could not locate the legacy run directory" >&2
+  exit 2
+fi
+LEGACY_RESULTS="${REPO_ROOT}/${LEGACY_RUN_DIR}/results.json"
+echo "    legacy results: ${LEGACY_RESULTS}"
+
+echo ""
+echo "==> Running REFACTOR: uv run python -m devops_bench ${TASK_FILE}"
+# Isolate the refactor output under TMP_DIR via RESULTS_ROOT, then parse the
+# printed 'results: <path>' line.
+REFACTOR_LOG="${TMP_DIR}/refactor.log"
+RESULTS_ROOT="${TMP_DIR}/refactor_results" uv run python -m devops_bench "${TASK_FILE}" \
+  >"${REFACTOR_LOG}" 2>&1 || {
+  echo "ERROR: refactor run failed; log follows:" >&2
+  cat "${REFACTOR_LOG}" >&2
+  exit 2
+}
+REFACTOR_RESULTS="$(grep -oE 'results: .*results\.json' "${REFACTOR_LOG}" | tail -1 | sed 's/^results: //')"
+if [[ -z "${REFACTOR_RESULTS}" || ! -f "${REFACTOR_RESULTS}" ]]; then
+  echo "ERROR: could not parse refactor results path; log follows:" >&2
+  cat "${REFACTOR_LOG}" >&2
+  exit 2
+fi
+echo "    refactor results: ${REFACTOR_RESULTS}"
+
+echo ""
+echo "==> Comparing results"
+set +e
+uv run python scripts/compare_results.py \
+  --legacy "${LEGACY_RESULTS}" \
+  --refactor "${REFACTOR_RESULTS}"
+VERDICT=$?
+set -e
+
+echo ""
+echo "==> Result paths"
+echo "    legacy:   ${LEGACY_RESULTS}"
+echo "    refactor: ${REFACTOR_RESULTS}"
+if [[ "${VERDICT}" -eq 0 ]]; then
+  echo "==> VERDICT: PASS (no regressions); exit ${VERDICT}"
+else
+  echo "==> VERDICT: FAIL or error; exit ${VERDICT}"
+fi
+exit "${VERDICT}"

--- a/scripts/compare_results.py
+++ b/scripts/compare_results.py
@@ -1,0 +1,610 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compare two ``results.json`` files and classify each difference."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "INTENDED",
+    "MATCHED",
+    "REGRESSION",
+    "CompareError",
+    "Difference",
+    "TaskComparison",
+    "align_records",
+    "build_json_report",
+    "compare",
+    "compare_records",
+    "has_regression",
+    "main",
+    "normalize_score_key",
+    "normalize_scores",
+    "normalize_whitespace",
+    "render_report",
+    "score_entry_success",
+    "score_entry_value",
+]
+
+# --------------------------------------------------------------------------- #
+# Intended-delta allowlist. Differences NOT covered here are regressions.
+# --------------------------------------------------------------------------- #
+
+#: Score keys whose numeric value may legitimately differ between the two
+#: implementations.
+INTENDED_METRIC_VALUE_DELTAS: frozenset[str] = frozenset(
+    {
+        "GroundingAccuracy",  # constraint dedup
+        "ParameterRecallAccuracy",  # constraint dedup
+        "DocRetrievalRate",  # missing-key guard
+    }
+)
+
+#: When True, a ``Check:`` key present on one side but not the other is INTENDED:
+#: only the checklist item text changed.
+INTENDED_CHECKLIST_TEXT_DELTAS: bool = True
+
+#: When True, a legacy ``status`` of ``None`` paired with any refactor status is
+#: intended. A success<->failed flip (both sides non-None) is still a REGRESSION.
+INTENDED_LEGACY_NULL_STATUS: bool = True
+
+#: When True, a trajectory presence mismatch is intended; trajectory is never
+#: diffed structurally.
+INTENDED_TRAJECTORY_PRESENCE_DELTA: bool = True
+
+#: Metrics whose presence/absence depends on the ``BENCH_USE_MCP`` read.
+INTENDED_MCP_READ_METRICS: frozenset[str] = frozenset({"ToolInvocation"})
+
+#: Top-level keys that are volatile or refactor-only schema additions and kept
+#: out of the diff entirely.
+VOLATILE_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
+    {
+        "latency",
+        "tokens",
+        "trajectory",  # handled separately via presence-only check
+        "error",
+        "errors",
+        "score",
+        "capabilities_granted",
+        "verification_parse_errors",
+    }
+)
+
+_GEVAL_SUFFIX = " [GEval]"
+
+# Buckets.
+MATCHED = "MATCHED"
+INTENDED = "INTENDED"
+REGRESSION = "REGRESSION"
+
+
+class CompareError(Exception):
+    """Raised on usage or IO errors (mapped to exit code 2)."""
+
+
+@dataclass
+class Difference:
+    """A single classified difference between two aligned records.
+
+    Attributes:
+        bucket: One of MATCHED / INTENDED / REGRESSION.
+        field: Dotted field path the difference applies to.
+        detail: Human-readable explanation of the difference.
+        legacy: Legacy-side value (for display).
+        refactor: Refactor-side value (for display).
+    """
+
+    bucket: str
+    field: str
+    detail: str
+    legacy: Any = None
+    refactor: Any = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for the JSON report."""
+        return {
+            "bucket": self.bucket,
+            "field": self.field,
+            "detail": self.detail,
+            "legacy": self.legacy,
+            "refactor": self.refactor,
+        }
+
+
+@dataclass
+class TaskComparison:
+    """Per-task comparison outcome.
+
+    Attributes:
+        name: Aligned task name (or index fallback).
+        differences: All classified differences for this task.
+    """
+
+    name: str
+    differences: list[Difference] = field(default_factory=list)
+
+    @property
+    def regressions(self) -> list[Difference]:
+        """Differences in this task classified as regressions."""
+        return [d for d in self.differences if d.bucket == REGRESSION]
+
+    @property
+    def intended(self) -> list[Difference]:
+        """Differences in this task classified as intended deltas."""
+        return [d for d in self.differences if d.bucket == INTENDED]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for the JSON report."""
+        return {
+            "name": self.name,
+            "differences": [d.to_dict() for d in self.differences],
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Normalization helpers.
+# --------------------------------------------------------------------------- #
+
+
+def normalize_score_key(key: str) -> str:
+    """Strip a trailing ``" [GEval]"`` suffix from a score key.
+
+    >>> normalize_score_key("OutcomeValidity [GEval]")
+    'OutcomeValidity'
+    """
+    if key.endswith(_GEVAL_SUFFIX):
+        return key[: -len(_GEVAL_SUFFIX)]
+    return key
+
+
+def normalize_whitespace(text: Any) -> str:
+    """Collapse runs of whitespace and trim, for stable text comparison.
+
+    Args:
+        text: Any value; non-strings are stringified (None becomes "").
+
+    Returns:
+        Whitespace-normalized string.
+    """
+    if text is None:
+        return ""
+    return " ".join(str(text).split())
+
+
+def score_entry_value(entry: Any) -> float | None:
+    """Extract the numeric score from a score entry (dict or bare float).
+
+    >>> score_entry_value({"score": 0.5})
+    0.5
+    >>> score_entry_value(0.5)
+    0.5
+    >>> score_entry_value({}) is None
+    True
+    """
+    if isinstance(entry, dict):
+        val = entry.get("score")
+        return float(val) if isinstance(val, (int, float)) else None
+    if isinstance(entry, (int, float)):
+        return float(entry)
+    return None
+
+
+def score_entry_success(entry: Any) -> bool | None:
+    """Extract the success flag from a score entry, if any.
+
+    Args:
+        entry: Either ``{"score": ..., "success": ...}`` or a bare value.
+
+    Returns:
+        The success flag, or None for bare-value entries.
+    """
+    if isinstance(entry, dict):
+        val = entry.get("success")
+        return val if isinstance(val, bool) else None
+    return None
+
+
+def normalize_scores(scores: dict[str, Any]) -> dict[str, Any]:
+    """Re-key a scores dict by normalized (GEval-stripped) name.
+
+    Later keys win on collision.
+
+    >>> normalize_scores({"OutcomeValidity [GEval]": 0.5})
+    {'OutcomeValidity': 0.5}
+    """
+    out: dict[str, Any] = {}
+    for key, value in (scores or {}).items():
+        out[normalize_score_key(key)] = value
+    return out
+
+
+def _is_checklist_key(key: str) -> bool:
+    return key.startswith("Check:")
+
+
+def _trajectory_nonempty(record: dict[str, Any]) -> bool:
+    return bool(record.get("trajectory"))
+
+
+# --------------------------------------------------------------------------- #
+# Classification.
+# --------------------------------------------------------------------------- #
+
+
+def _classify_status(legacy: dict[str, Any], refactor: dict[str, Any]) -> Difference | None:
+    """Classify a ``status`` difference, or return None if equal."""
+    ls, rs = legacy.get("status"), refactor.get("status")
+    if ls == rs:
+        return None
+    if ls is None and INTENDED_LEGACY_NULL_STATUS:
+        return Difference(
+            INTENDED,
+            "status",
+            "legacy non-infra path leaves status=None; refactor sets explicit status",
+            ls,
+            rs,
+        )
+    return Difference(
+        REGRESSION,
+        "status",
+        "status flip between implementations",
+        ls,
+        rs,
+    )
+
+
+def _classify_output(legacy: dict[str, Any], refactor: dict[str, Any]) -> Difference | None:
+    """Classify an ``output`` difference (whitespace-normalized)."""
+    lo = normalize_whitespace(legacy.get("output"))
+    ro = normalize_whitespace(refactor.get("output"))
+    if lo == ro:
+        return None
+    return Difference(
+        REGRESSION,
+        "output",
+        "materially different output after whitespace normalization",
+        legacy.get("output"),
+        refactor.get("output"),
+    )
+
+
+def _classify_trajectory(legacy: dict[str, Any], refactor: dict[str, Any]) -> Difference | None:
+    """Classify a trajectory presence-only difference."""
+    ln, rn = _trajectory_nonempty(legacy), _trajectory_nonempty(refactor)
+    if ln == rn:
+        return None
+    if INTENDED_TRAJECTORY_PRESENCE_DELTA:
+        return Difference(
+            INTENDED,
+            "trajectory",
+            "trajectory presence differs by design (legacy: conversation turns; "
+            "refactor: tool-call entries only)",
+            f"non-empty={ln}",
+            f"non-empty={rn}",
+        )
+    return Difference(
+        REGRESSION,
+        "trajectory",
+        "trajectory presence mismatch",
+        f"non-empty={ln}",
+        f"non-empty={rn}",
+    )
+
+
+def _classify_metric_set(
+    legacy_scores: dict[str, Any], refactor_scores: dict[str, Any]
+) -> list[Difference]:
+    """Classify metric keys present on one side but not the other."""
+    diffs: list[Difference] = []
+    lkeys, rkeys = set(legacy_scores), set(refactor_scores)
+
+    for key in sorted(lkeys - rkeys):
+        diffs.append(_classify_missing_metric(key, side="refactor"))
+    for key in sorted(rkeys - lkeys):
+        diffs.append(_classify_missing_metric(key, side="legacy"))
+    return diffs
+
+
+def _classify_missing_metric(key: str, *, side: str) -> Difference:
+    """Classify a metric key missing on ``side``.
+
+    Args:
+        key: Normalized score key.
+        side: The implementation MISSING the key ("legacy" or "refactor").
+
+    Returns:
+        An INTENDED Difference when the gap is allowlisted, else REGRESSION.
+    """
+    field_path = f"scores[{key!r}]"
+    if _is_checklist_key(key) and INTENDED_CHECKLIST_TEXT_DELTAS:
+        return Difference(
+            INTENDED,
+            field_path,
+            f"checklist item text changed (trailing-hyphen fix); missing on {side}",
+            None if side == "legacy" else key,
+            None if side == "refactor" else key,
+        )
+    if key in INTENDED_MCP_READ_METRICS:
+        return Difference(
+            INTENDED,
+            field_path,
+            f"MCP-gated metric ({key}); presence depends on BENCH_USE_MCP read",
+        )
+    return Difference(
+        REGRESSION,
+        field_path,
+        f"metric {key!r} present on the other side but missing on {side}",
+    )
+
+
+def _classify_metric_values(
+    legacy_scores: dict[str, Any], refactor_scores: dict[str, Any]
+) -> list[Difference]:
+    """Classify per-metric value/success diffs for shared metric keys."""
+    diffs: list[Difference] = []
+    for key in sorted(set(legacy_scores) & set(refactor_scores)):
+        legacy_entry, refactor_entry = legacy_scores[key], refactor_scores[key]
+        lv, rv = score_entry_value(legacy_entry), score_entry_value(refactor_entry)
+        ls, rs = score_entry_success(legacy_entry), score_entry_success(refactor_entry)
+        field_path = f"scores[{key!r}]"
+
+        if lv == rv and ls == rs:
+            diffs.append(Difference(MATCHED, field_path, "score value and success match", lv, rv))
+            continue
+
+        if key in INTENDED_METRIC_VALUE_DELTAS:
+            diffs.append(
+                Difference(
+                    INTENDED,
+                    field_path,
+                    f"value/success delta allowed for {key} (constraint dedup / robustness)",
+                    {"score": lv, "success": ls},
+                    {"score": rv, "success": rs},
+                )
+            )
+            continue
+
+        diffs.append(
+            Difference(
+                REGRESSION,
+                field_path,
+                f"score value/success diff for non-allowlisted metric {key!r}",
+                {"score": lv, "success": ls},
+                {"score": rv, "success": rs},
+            )
+        )
+    return diffs
+
+
+def compare_records(
+    legacy: dict[str, Any], refactor: dict[str, Any], name: str
+) -> TaskComparison:
+    """Compare one aligned (legacy, refactor) record pair.
+
+    Args:
+        legacy: Legacy result record.
+        refactor: Refactor result record.
+        name: Aligned task name for reporting.
+
+    Returns:
+        A TaskComparison holding all classified differences.
+    """
+    comp = TaskComparison(name=name)
+
+    for classifier in (_classify_status, _classify_output, _classify_trajectory):
+        diff = classifier(legacy, refactor)
+        if diff is not None:
+            comp.differences.append(diff)
+
+    lscores = normalize_scores(legacy.get("scores", {}))
+    rscores = normalize_scores(refactor.get("scores", {}))
+    comp.differences.extend(_classify_metric_set(lscores, rscores))
+    comp.differences.extend(_classify_metric_values(lscores, rscores))
+
+    if not comp.differences:
+        comp.differences.append(Difference(MATCHED, "<record>", "no differences"))
+    return comp
+
+
+def align_records(
+    legacy: list[dict[str, Any]], refactor: list[dict[str, Any]]
+) -> list[tuple[str, dict[str, Any], dict[str, Any]]]:
+    """Align legacy and refactor records by task name, falling back to index.
+
+    Args:
+        legacy: Legacy result list.
+        refactor: Refactor result list.
+
+    Returns:
+        Triples of (name, legacy_record, refactor_record) for every aligned
+        pair. Unmatched records on either side are paired with ``{}``.
+
+    Raises:
+        CompareError: If either input is not a list.
+    """
+    if not isinstance(legacy, list) or not isinstance(refactor, list):
+        raise CompareError("both result files must contain a JSON list of records")
+
+    refactor_by_name = {r.get("name"): r for r in refactor if r.get("name")}
+    aligned: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+    used: set[str] = set()
+
+    name_match = all(r.get("name") for r in legacy) and all(r.get("name") for r in refactor)
+    if name_match:
+        for lr in legacy:
+            nm = lr.get("name")
+            rr = refactor_by_name.get(nm, {})
+            if rr:
+                used.add(nm)
+            aligned.append((nm, lr, rr))
+        for rr in refactor:
+            nm = rr.get("name")
+            if nm not in used:
+                aligned.append((nm, {}, rr))
+        return aligned
+
+    # Positional fallback.
+    for idx in range(max(len(legacy), len(refactor))):
+        lr = legacy[idx] if idx < len(legacy) else {}
+        rr = refactor[idx] if idx < len(refactor) else {}
+        nm = (lr.get("name") if lr else None) or (rr.get("name") if rr else None) or f"#{idx}"
+        aligned.append((nm, lr, rr))
+    return aligned
+
+
+def compare(
+    legacy: list[dict[str, Any]], refactor: list[dict[str, Any]]
+) -> list[TaskComparison]:
+    """Align and compare two full result lists.
+
+    Args:
+        legacy: Legacy result list.
+        refactor: Refactor result list.
+
+    Returns:
+        One TaskComparison per aligned task.
+    """
+    results: list[TaskComparison] = []
+    for name, lr, rr in align_records(legacy, refactor):
+        if not lr or not rr:
+            comp = TaskComparison(name=name)
+            missing = "legacy" if not lr else "refactor"
+            comp.differences.append(
+                Difference(REGRESSION, "<record>", f"task missing on {missing} side")
+            )
+            results.append(comp)
+            continue
+        results.append(compare_records(lr, rr, name))
+    return results
+
+
+# --------------------------------------------------------------------------- #
+# Reporting / CLI.
+# --------------------------------------------------------------------------- #
+
+
+def _load(path: str) -> list[dict[str, Any]]:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except OSError as exc:
+        raise CompareError(f"cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise CompareError(f"invalid JSON in {path}: {exc}") from exc
+
+
+def render_report(comparisons: list[TaskComparison]) -> str:
+    """Render a human-readable, bucket-grouped report.
+
+    Args:
+        comparisons: Per-task comparison outcomes.
+
+    Returns:
+        The full report text (no trailing newline).
+    """
+    lines: list[str] = []
+    total = {MATCHED: 0, INTENDED: 0, REGRESSION: 0}
+
+    for comp in comparisons:
+        lines.append(f"== task: {comp.name} ==")
+        for bucket in (REGRESSION, INTENDED, MATCHED):
+            items = [d for d in comp.differences if d.bucket == bucket]
+            for _ in items:
+                total[bucket] += 1
+            if not items:
+                continue
+            lines.append(f"  [{bucket}]")
+            for d in items:
+                lines.append(f"    - {d.field}: {d.detail}")
+                if d.legacy is not None or d.refactor is not None:
+                    lines.append(f"        legacy:   {d.legacy!r}")
+                    lines.append(f"        refactor: {d.refactor!r}")
+        lines.append("")
+
+    verdict = "PASS (no regressions)" if total[REGRESSION] == 0 else "FAIL (regressions found)"
+    lines.append(
+        f"SUMMARY: {total[MATCHED]} matched, {total[INTENDED]} intended, "
+        f"{total[REGRESSION]} regression(s) -> {verdict}"
+    )
+    return "\n".join(lines)
+
+
+def build_json_report(comparisons: list[TaskComparison]) -> dict[str, Any]:
+    """Build the machine-readable report payload.
+
+    Args:
+        comparisons: Per-task comparison outcomes.
+
+    Returns:
+        A JSON-serializable dict with per-task differences and totals.
+    """
+    totals = {MATCHED: 0, INTENDED: 0, REGRESSION: 0}
+    for comp in comparisons:
+        for d in comp.differences:
+            totals[d.bucket] += 1
+    return {
+        "tasks": [c.to_dict() for c in comparisons],
+        "totals": totals,
+        "regressions": totals[REGRESSION],
+    }
+
+
+def has_regression(comparisons: list[TaskComparison]) -> bool:
+    """Whether any task has at least one regression."""
+    return any(c.regressions for c in comparisons)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint.
+
+    Args:
+        argv: Argument vector (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        0 if no regressions, 1 if any regression, 2 on usage/IO error.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--legacy", required=True, help="legacy results.json path")
+    parser.add_argument("--refactor", required=True, help="refactor results.json path")
+    parser.add_argument("--json-report", help="optional path to write a JSON report")
+    try:
+        args = parser.parse_args(argv)
+        legacy = _load(args.legacy)
+        refactor = _load(args.refactor)
+        comparisons = compare(legacy, refactor)
+    except CompareError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    print(render_report(comparisons))
+
+    if args.json_report:
+        try:
+            with open(args.json_report, "w", encoding="utf-8") as fh:
+                json.dump(build_json_report(comparisons), fh, indent=2)
+        except OSError as exc:
+            print(f"error: cannot write report: {exc}", file=sys.stderr)
+            return 2
+
+    return 1 if has_regression(comparisons) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_compare.sh
+++ b/scripts/run_compare.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Legacy-vs-refactored comparison for ANY task, ANY CLI agent, on real infra.
+#
+#   Arm A (LEGACY):     python3 pkg/evaluator/evaluate.py  <task>
+#   Arm B (REFACTORED): python3 -m devops_bench           <task>
+#
+# Runs the same task through both entrypoints with the same agent/judge config,
+# then diffs the two results.json via scripts/compare_results.py. The agent is
+# selected entirely by env, so this works for gemini, openclaw, or any other
+# registered CLI agent — nothing here is task- or agent-specific.
+#
+# (This is the real-infra comparison. scripts/compare_legacy_vs_refactor.sh is a
+# separate, mock-Ollama regression gate.)
+#
+# Usage:
+#   scripts/run_compare.sh <task.yaml>
+#
+# Required env:
+#   AGENT_API_KEY, JUDGE_API_KEY
+#   GCP_PROJECT_ID, GKE_CLUSTER_NAME   (unless BENCH_NO_INFRA=true)
+# Optional env:
+#   RESULTS_ROOT (default results), NAMESPACE, GCP_LOCATION (us-central1-a),
+#   AGENT_MODEL / JUDGE_MODEL (default gemini-3.1-pro-preview),
+#   RULES_FILE   (operator brief; delivered to refactored via AGENT_RULES_TEXT
+#                 and to the legacy gemini arm via a repo-root GEMINI.md shadow),
+#   BENCH_NO_INFRA=true  (plumbing smoke; skips GKE).
+#   ...plus any agent-specific vars you export, e.g.:
+#     gemini   : AGENT_TARGET=gemini   BENCH_AGENT_TYPE stays default (cli->gemini)
+#     openclaw : AGENT_TARGET=oc  OPENCLAW_LOCAL=true  OPENCLAW_BIN=oc
+#                refactored arm: BENCH_AGENT_TYPE=openclaw  AGENT_MCP_SERVER=gke-mcp
+#                                AGENT_SKILLS_PATHS=skills
+set -euo pipefail
+
+TASK_FILE="${1:?usage: scripts/run_compare.sh <task.yaml>}"
+[[ -f "$TASK_FILE" ]] || { echo "ERROR: task file not found: $TASK_FILE" >&2; exit 2; }
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+STAMP="${STAMP:-$(date +%Y%m%d_%H%M%S)}"
+RUN_DIR="${RESULTS_ROOT:-results}/compare_${STAMP}"
+mkdir -p "${RUN_DIR}/legacy" "${RUN_DIR}/refactored"
+
+: "${AGENT_API_KEY:?set AGENT_API_KEY}"
+: "${JUDGE_API_KEY:?set JUDGE_API_KEY}"
+BENCH_NO_INFRA="${BENCH_NO_INFRA:-false}"
+if [[ "$BENCH_NO_INFRA" != "true" ]]; then
+  : "${GCP_PROJECT_ID:?set GCP_PROJECT_ID (or BENCH_NO_INFRA=true)}"
+  : "${GKE_CLUSTER_NAME:?set GKE_CLUSTER_NAME (or BENCH_NO_INFRA=true)}"
+fi
+
+# Shared agent/judge config (both arms identical where it matters). Anything the
+# caller already exported (AGENT_TARGET, BENCH_AGENT_TYPE, OPENCLAW_*, MCP, etc.)
+# is passed through to both arms.
+export BENCH_AGENT_TYPE="${BENCH_AGENT_TYPE:-cli}"
+export AGENT_PROVIDER="${AGENT_PROVIDER:-google}"
+export AGENT_MODEL="${AGENT_MODEL:-gemini-3.1-pro-preview}"
+export JUDGE_PROVIDER="${JUDGE_PROVIDER:-google}"
+export JUDGE_MODEL="${JUDGE_MODEL:-gemini-3.1-pro-preview}"
+export AGENT_API_KEY JUDGE_API_KEY
+# google-provider CLIs read the key from these; harmless for other providers.
+export GEMINI_API_KEY="${GEMINI_API_KEY:-$AGENT_API_KEY}"
+export GOOGLE_API_KEY="${GOOGLE_API_KEY:-$AGENT_API_KEY}"
+export GCP_LOCATION="${GCP_LOCATION:-us-central1-a}"
+export NAMESPACE="${NAMESPACE:-compare}"
+export BENCH_NO_INFRA
+
+RULES_TEXT=""
+[[ -n "${RULES_FILE:-}" && -f "${RULES_FILE}" ]] && RULES_TEXT="$(cat "${RULES_FILE}")"
+
+echo "==> compare dir: ${RUN_DIR}  (task: ${TASK_FILE}; mode: $([[ "$BENCH_NO_INFRA" == true ]] && echo NO-INFRA || echo 'REAL INFRA'))"
+
+# ----------------------------- ARM A: LEGACY ------------------------------- #
+echo "==> ARM A (LEGACY): pkg/evaluator/evaluate.py"
+BEFORE="$(ls -d results/run_* 2>/dev/null || true)"
+GEMINI_MD="${REPO_ROOT}/GEMINI.md"; GEMINI_MD_BAK=""
+restore_gemini_md() {
+  if [[ -n "$RULES_TEXT" ]]; then
+    if [[ -n "$GEMINI_MD_BAK" ]]; then mv "$GEMINI_MD_BAK" "$GEMINI_MD"; else rm -f "$GEMINI_MD"; fi
+  fi
+}
+if [[ -n "$RULES_TEXT" ]]; then
+  # Legacy gemini auto-loads a repo-root GEMINI.md; shadow it for the run, then
+  # restore. (Other legacy agents ignore it — harmless.)
+  [[ -f "$GEMINI_MD" ]] && { GEMINI_MD_BAK="$(mktemp)"; cp "$GEMINI_MD" "$GEMINI_MD_BAK"; }
+  printf '%s' "$RULES_TEXT" > "$GEMINI_MD"
+  # Restore on ANY exit path (a ``set -e`` abort, a later arm failure, or a
+  # clean finish) so a tracked GEMINI.md is never left clobbered.
+  trap restore_gemini_md EXIT
+fi
+if ! python3 pkg/evaluator/evaluate.py "${TASK_FILE}" >"${RUN_DIR}/legacy/run.log" 2>&1; then
+  echo "ERROR: legacy arm failed"; tail -30 "${RUN_DIR}/legacy/run.log"; exit 2
+fi
+AFTER="$(ls -d results/run_* 2>/dev/null || true)"
+LEGACY_RUN_DIR="$(comm -13 <(printf '%s\n' "${BEFORE}") <(printf '%s\n' "${AFTER}") | grep -E 'results/run_' | tail -1 || true)"
+if [[ -z "${LEGACY_RUN_DIR}" || ! -f "${LEGACY_RUN_DIR}/results.json" ]]; then
+  echo "ERROR: legacy results.json not found"; tail -30 "${RUN_DIR}/legacy/run.log"; exit 2
+fi
+cp -R "${LEGACY_RUN_DIR}/." "${RUN_DIR}/legacy/"
+LEGACY_RESULTS="${RUN_DIR}/legacy/results.json"
+echo "    legacy results: ${LEGACY_RESULTS}"
+
+# --------------------------- ARM B: REFACTORED ----------------------------- #
+echo "==> ARM B (REFACTORED): python3 -m devops_bench"
+REFACTOR_LOG="${RUN_DIR}/refactored/run.log"
+(
+  [[ -n "$RULES_TEXT" ]] && export AGENT_RULES_TEXT="$RULES_TEXT"
+  if [[ "$BENCH_NO_INFRA" == "true" ]]; then
+    python3 -m devops_bench --results-root "${RUN_DIR}/refactored" "${TASK_FILE}"
+  else
+    python3 -m devops_bench --project "${GCP_PROJECT_ID}" --cluster "${GKE_CLUSTER_NAME}" \
+      --results-root "${RUN_DIR}/refactored" "${TASK_FILE}"
+  fi
+) >"${REFACTOR_LOG}" 2>&1 || { echo "ERROR: refactored arm failed"; tail -30 "${REFACTOR_LOG}"; exit 2; }
+REFACTOR_RESULTS="$(grep -oE 'results: .*results\.json' "${REFACTOR_LOG}" | tail -1 | sed 's/^results: //')"
+[[ -z "${REFACTOR_RESULTS}" || ! -f "${REFACTOR_RESULTS}" ]] && REFACTOR_RESULTS="$(find "${RUN_DIR}/refactored" -name results.json | head -1)"
+if [[ -z "${REFACTOR_RESULTS}" || ! -f "${REFACTOR_RESULTS}" ]]; then
+  echo "ERROR: refactored results.json not found"; tail -30 "${REFACTOR_LOG}"; exit 2
+fi
+echo "    refactored results: ${REFACTOR_RESULTS}"
+
+# -------------------------------- DIFF ------------------------------------- #
+echo "==> compare_results.py"
+set +e
+python3 scripts/compare_results.py \
+  --legacy "${LEGACY_RESULTS}" \
+  --refactor "${REFACTOR_RESULTS}" \
+  --json-report "${RUN_DIR}/comparison-report.json" | tee "${RUN_DIR}/comparison-report.md"
+echo "==> done. RUN_DIR=${RUN_DIR}"

--- a/tests/unit/comparison/__init__.py
+++ b/tests/unit/comparison/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the temporary legacy-vs-refactor comparison harness."""

--- a/tests/unit/comparison/test_compare_results.py
+++ b/tests/unit/comparison/test_compare_results.py
@@ -1,0 +1,187 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the comparison bucket classifier and normalizers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "compare_results.py"
+_spec = importlib.util.spec_from_file_location("compare_results", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+cr = importlib.util.module_from_spec(_spec)
+sys.modules["compare_results"] = cr
+_spec.loader.exec_module(cr)
+
+
+def _record(scores: dict, **overrides) -> dict:
+    """Build a minimal result record with matching status/output/trajectory."""
+    base = {
+        "name": "t",
+        "status": "success",
+        "output": "same output",
+        "trajectory": [{"name": "x"}],
+        "scores": scores,
+    }
+    base.update(overrides)
+    return base
+
+
+def _buckets(comp) -> dict[str, list]:
+    out: dict[str, list] = {cr.MATCHED: [], cr.INTENDED: [], cr.REGRESSION: []}
+    for d in comp.differences:
+        out[d.bucket].append(d)
+    return out
+
+
+def test_geval_suffix_normalizes_to_matched():
+    legacy = _record({"OutcomeValidity [GEval]": {"score": 0.1, "success": False}})
+    refactor = _record({"OutcomeValidity": {"score": 0.1, "success": False}})
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert any("OutcomeValidity" in d.field for d in b[cr.MATCHED])
+
+
+def test_normalize_score_key_strips_suffix():
+    assert cr.normalize_score_key("ToolInvocation [GEval]") == "ToolInvocation"
+    assert cr.normalize_score_key("ChecklistScore") == "ChecklistScore"
+
+
+def test_grounding_value_diff_is_intended():
+    legacy = _record({"GroundingAccuracy": 3.0})
+    refactor = _record({"GroundingAccuracy": 5.0})
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert any("GroundingAccuracy" in d.field for d in b[cr.INTENDED])
+
+
+def test_status_flip_is_regression():
+    legacy = _record({}, status="success")
+    refactor = _record({}, status="failed")
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert any(d.field == "status" for d in b[cr.REGRESSION])
+
+
+def test_legacy_null_status_is_intended():
+    legacy = _record({}, status=None)
+    refactor = _record({}, status="success")
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert any(d.field == "status" for d in b[cr.INTENDED])
+
+
+def test_dropped_non_allowlisted_metric_is_regression():
+    legacy = _record({"OutcomeValidity": {"score": 0.1, "success": False}})
+    refactor = _record({})
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert any("OutcomeValidity" in d.field for d in b[cr.REGRESSION])
+
+
+def test_dropped_checklist_metric_is_intended():
+    legacy = _record({"Check: do a thing-": {"score": 0.1, "success": False}})
+    refactor = _record({"Check: do a thing": {"score": 0.1, "success": False}})
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert len(b[cr.INTENDED]) >= 2  # one missing on each side
+
+
+def test_mcp_gated_metric_missing_is_intended():
+    legacy = _record({"ToolInvocation": {"score": 0.5, "success": True}})
+    refactor = _record({})
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert any("ToolInvocation" in d.field for d in b[cr.INTENDED])
+
+
+def test_non_allowlisted_value_diff_is_regression():
+    legacy = _record({"OutcomeValidity": {"score": 0.1, "success": False}})
+    refactor = _record({"OutcomeValidity": {"score": 0.9, "success": True}})
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert any("OutcomeValidity" in d.field for d in b[cr.REGRESSION])
+
+
+def test_output_whitespace_normalized_matches():
+    legacy = _record({}, output="hello   world\n")
+    refactor = _record({}, output="hello world")
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not any(d.field == "output" for d in b[cr.REGRESSION])
+
+
+def test_output_material_diff_is_regression():
+    legacy = _record({}, output="apply manifest A")
+    refactor = _record({}, output="apply manifest B")
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert any(d.field == "output" for d in b[cr.REGRESSION])
+
+
+def test_trajectory_presence_delta_is_intended():
+    legacy = _record({}, trajectory=[{"type": "user_input"}])
+    refactor = _record({}, trajectory=[])
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert any(d.field == "trajectory" for d in b[cr.INTENDED])
+
+
+def test_identical_records_all_matched():
+    rec = _record({"OutcomeValidity": {"score": 0.1, "success": False}})
+    comp = cr.compare_records(rec, dict(rec), "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert not b[cr.INTENDED]
+
+
+def test_align_by_name():
+    legacy = [{"name": "b"}, {"name": "a"}]
+    refactor = [{"name": "a"}, {"name": "b"}]
+    aligned = cr.align_records(legacy, refactor)
+    pairs = {nm: (lr["name"], rr["name"]) for nm, lr, rr in aligned}
+    assert pairs["a"] == ("a", "a")
+    assert pairs["b"] == ("b", "b")
+
+
+def test_missing_task_is_regression():
+    legacy = [_record({}, name="only_legacy")]
+    refactor = []
+    comps = cr.compare(legacy, refactor)
+    assert cr.has_regression(comps)
+
+
+def test_non_list_input_raises():
+    with pytest.raises(cr.CompareError):
+        cr.align_records({"not": "a list"}, [])
+
+
+def test_has_regression_and_exit_semantics():
+    clean = cr.compare([_record({})], [_record({})])
+    assert not cr.has_regression(clean)
+    flipped = cr.compare(
+        [_record({}, status="success")], [_record({}, status="failed")]
+    )
+    assert cr.has_regression(flipped)

--- a/tf/modules/bastion/main.tf
+++ b/tf/modules/bastion/main.tf
@@ -1,0 +1,86 @@
+# Reusable, harness-agnostic GCE bastion for running the eval harness.
+#
+# The bastion is a plain Compute Engine VM (NOT Cloud Workstations). It runs as a
+# dedicated service account and, via its startup script, installs the full
+# harness toolchain plus the openclaw `oc` binary, so the whole harness runs on
+# the VM and invokes `oc` as a local subprocess. SSH is reached over IAP.
+#
+# It deliberately mirrors the plain-Compute patterns in tf/modules/gke (the agent
+# service account + the IAP-SSH firewall rule).
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+  }
+}
+
+# Service account the VM runs as. The harness uses this SA as ADC (via the
+# metadata server) for both `gcloud`/`kubectl` and Secret Manager.
+resource "google_service_account" "bastion" {
+  account_id   = var.sa_account_id
+  display_name = "Bastion SA for the DevOps Bench eval harness (${var.name})"
+  project      = var.project_id
+}
+
+# Provisioning rights so the harness can run tofu AS this SA. See var.sa_roles
+# for the rationale and the least-privilege/owner trade-off.
+resource "google_project_iam_member" "bastion" {
+  for_each = toset(var.sa_roles)
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.bastion.email}"
+}
+
+# Allow SSH only from Google's IAP TCP-forwarding range, scoped to this VM's tag.
+resource "google_compute_firewall" "allow_iap_ssh" {
+  name    = "allow-iap-ssh-${var.name}"
+  network = var.network
+  project = var.project_id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["35.235.240.0/20"]
+  target_tags   = [var.name]
+}
+
+resource "google_compute_instance" "bastion" {
+  name         = var.name
+  project      = var.project_id
+  zone         = var.zone
+  machine_type = var.machine_type
+  tags         = [var.name]
+
+  # Let tofu stop/restart the VM to apply machine-type or metadata changes.
+  allow_stopping_for_update = true
+
+  boot_disk {
+    initialize_params {
+      image = var.image
+      size  = var.boot_disk_gb
+    }
+  }
+
+  network_interface {
+    network    = var.network
+    subnetwork = var.subnetwork != "" ? var.subnetwork : null
+
+    # Ephemeral external IP for egress; omit entirely when relying on Cloud NAT.
+    dynamic "access_config" {
+      for_each = var.assign_external_ip ? [1] : []
+      content {}
+    }
+  }
+
+  service_account {
+    email  = google_service_account.bastion.email
+    scopes = ["cloud-platform"]
+  }
+
+  metadata_startup_script = file("${path.module}/startup.sh")
+}

--- a/tf/modules/bastion/outputs.tf
+++ b/tf/modules/bastion/outputs.tf
@@ -1,0 +1,19 @@
+output "sa_email" {
+  description = "Email of the service account the bastion runs as."
+  value       = google_service_account.bastion.email
+}
+
+output "name" {
+  description = "Name of the bastion VM."
+  value       = google_compute_instance.bastion.name
+}
+
+output "zone" {
+  description = "Zone of the bastion VM."
+  value       = google_compute_instance.bastion.zone
+}
+
+output "iap_ssh_command" {
+  description = "Command to SSH into the bastion over IAP."
+  value       = "gcloud compute ssh ${google_compute_instance.bastion.name} --zone ${google_compute_instance.bastion.zone} --project ${var.project_id} --tunnel-through-iap"
+}

--- a/tf/modules/bastion/startup.sh
+++ b/tf/modules/bastion/startup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Bastion startup script (runs as root on first boot via metadata_startup_script).
+#
+# Installs the system-wide toolchain the eval harness drives at runtime, plus the
+# openclaw `oc` binary. Mirrors the install steps in Dockerfile.harness (adapted
+# to Ubuntu apt + Node 22, which openclaw requires). Per-user setup (the repo,
+# the venv, and the openclaw API key) is done separately by scripts/bastion/.
+#
+# Logs to /var/log/bench-bastion-startup.log; on success it touches
+# /var/lib/bench-bastion-ready so callers can poll for readiness.
+set -euxo pipefail
+
+exec > >(tee -a /var/log/bench-bastion-startup.log) 2>&1
+echo "==> bench-bastion startup begin: $(date -u +%FT%TZ)"
+
+export DEBIAN_FRONTEND=noninteractive
+
+TOFU_VERSION="1.8.8"
+NODE_MAJOR="22"
+# Pin openclaw so VM rebuilds are reproducible; bump deliberately when adopting a
+# new release rather than tracking @latest.
+OPENCLAW_VERSION="2026.6.10"
+
+# Already provisioned (e.g. on VM restart)? Skip the heavy install.
+if [ -f /var/lib/bench-bastion-ready ]; then
+  echo "==> already provisioned; nothing to do"
+  exit 0
+fi
+
+echo "==> base packages"
+apt-get update -y
+apt-get install -y --no-install-recommends \
+  curl wget gnupg unzip ca-certificates git jq build-essential python3-venv python3-pip
+
+echo "==> OpenTofu ${TOFU_VERSION}"
+ARCH="$(dpkg --print-architecture)" # amd64 / arm64
+wget -q "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_${ARCH}.zip" -O /tmp/tofu.zip
+unzip -o /tmp/tofu.zip -d /usr/local/bin/
+rm -f /tmp/tofu.zip
+
+echo "==> Node.js ${NODE_MAJOR} (openclaw requires >=22)"
+curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -
+apt-get install -y --no-install-recommends nodejs
+
+echo "==> Google Cloud SDK + gke-gcloud-auth-plugin + kubectl"
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list
+apt-get update -y
+apt-get install -y --no-install-recommends \
+  google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin kubectl
+
+echo "==> openclaw (oc) ${OPENCLAW_VERSION}"
+npm install -g "openclaw@${OPENCLAW_VERSION}"
+# `oc` is this project's alias for the standard openclaw binary.
+ln -sf "$(command -v openclaw)" /usr/local/bin/oc
+
+echo "==> gke-mcp (GKE MCP server for the agent's MCP capability)"
+# Official prebuilt installer drops an arch-matched binary on PATH (no Go build).
+# Download to a file first, then execute: piping ``curl | bash`` can run a
+# truncated script if the connection drops mid-transfer.
+curl -fsSL https://raw.githubusercontent.com/GoogleCloudPlatform/gke-mcp/main/install.sh \
+  -o /tmp/gke-mcp-install.sh
+bash /tmp/gke-mcp-install.sh
+rm -f /tmp/gke-mcp-install.sh
+
+echo "==> versions"
+tofu version || true
+node --version || true
+gcloud --version | head -1 || true
+kubectl version --client 2>/dev/null | head -1 || true
+oc --version || true
+python3 --version || true
+
+touch /var/lib/bench-bastion-ready
+echo "==> bench-bastion startup complete: $(date -u +%FT%TZ)"

--- a/tf/modules/bastion/variables.tf
+++ b/tf/modules/bastion/variables.tf
@@ -1,0 +1,80 @@
+variable "project_id" {
+  type        = string
+  description = "GCP Project ID the bastion and its service account live in."
+}
+
+variable "zone" {
+  type        = string
+  description = "GCE zone for the bastion VM."
+  default     = "us-central1-a"
+}
+
+variable "name" {
+  type        = string
+  description = "Name of the bastion VM (also used to name its firewall rule and network tag)."
+  default     = "bench-bastion"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type for the bastion VM. Needs headroom for tofu + node + the harness."
+  default     = "e2-standard-4"
+}
+
+variable "boot_disk_gb" {
+  type        = number
+  description = "Boot disk size in GB."
+  default     = 50
+}
+
+variable "image" {
+  type        = string
+  description = "Boot image. Ubuntu 24.04 LTS ships Python 3.12, matching pyproject's requires-python."
+  default     = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
+}
+
+variable "sa_account_id" {
+  type        = string
+  description = <<-EOT
+    Account id for the bastion's service account (the VM runs as this SA, so the
+    harness uses it as ADC). Defaults to "openclaw-vm-sa" because the existing
+    secret-rotation tofu stack references that literal email
+    (openclaw-vm-sa@<project>.iam.gserviceaccount.com); override it per harness.
+  EOT
+  default     = "openclaw-vm-sa"
+}
+
+variable "sa_roles" {
+  type        = list(string)
+  description = <<-EOT
+    Project roles granted to the bastion SA so the harness can PROVISION infra by
+    running tofu as this SA. Defaults to [] (least privilege) — this reusable
+    module grants nothing unless the caller opts in. The prebuilt secret-rotation
+    consumer passes the roles its stack needs: create GKE/secrets/service-accounts
+    (editor) and set project & SA IAM policy bindings (projectIamAdmin +
+    serviceAccountAdmin).
+  EOT
+  default     = []
+}
+
+variable "network" {
+  type        = string
+  description = "VPC network for the bastion."
+  default     = "default"
+}
+
+variable "subnetwork" {
+  type        = string
+  description = "Optional subnetwork. Leave empty to use the network's auto subnet in the VM's region."
+  default     = ""
+}
+
+variable "assign_external_ip" {
+  type        = bool
+  description = <<-EOT
+    Attach an ephemeral external IP for egress (apt, npm, model APIs). SSH ingress
+    is restricted to the IAP range regardless. Set false only if the network has
+    Cloud NAT for egress.
+  EOT
+  default     = true
+}

--- a/tf/prebuilt/bastion/main.tf
+++ b/tf/prebuilt/bastion/main.tf
@@ -1,0 +1,49 @@
+# Concrete stack that provisions a static eval-harness bastion.
+#
+#   cd tf/prebuilt/bastion && tofu init && tofu apply -var project_id=<proj>
+#
+# See docs/bastion.md for the full workflow.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  zone    = var.zone
+}
+
+module "bastion" {
+  source = "../../modules/bastion"
+
+  project_id         = var.project_id
+  zone               = var.zone
+  name               = var.name
+  machine_type       = var.machine_type
+  sa_account_id      = var.sa_account_id
+  assign_external_ip = var.assign_external_ip
+
+  # This batteries-included consumer opts the bastion SA into the roles the
+  # secret-rotation stack provisions with. The reusable module itself defaults
+  # to [] (least privilege); the broad grant lives here, not in the module.
+  sa_roles = [
+    "roles/editor",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/iam.serviceAccountAdmin",
+  ]
+}
+
+output "sa_email" {
+  description = "Email of the service account the bastion runs as."
+  value       = module.bastion.sa_email
+}
+
+output "iap_ssh_command" {
+  description = "Command to SSH into the bastion over IAP."
+  value       = module.bastion.iap_ssh_command
+}

--- a/tf/prebuilt/bastion/variables.tf
+++ b/tf/prebuilt/bastion/variables.tf
@@ -1,0 +1,34 @@
+variable "project_id" {
+  type        = string
+  description = "GCP Project ID."
+}
+
+variable "zone" {
+  type        = string
+  description = "GCE zone for the bastion VM."
+  default     = "us-central1-a"
+}
+
+variable "name" {
+  type        = string
+  description = "Name of the bastion VM."
+  default     = "bench-bastion"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type for the bastion VM."
+  default     = "e2-standard-4"
+}
+
+variable "sa_account_id" {
+  type        = string
+  description = "Account id for the bastion service account (see module docs)."
+  default     = "openclaw-vm-sa"
+}
+
+variable "assign_external_ip" {
+  type        = bool
+  description = "Attach an ephemeral external IP for egress (SSH stays IAP-only)."
+  default     = true
+}


### PR DESCRIPTION
Adds a reusable, harness-agnostic GCE bastion so the eval harness (and the `oc` binary, which runs locally) can run on a VM reached over IAP SSH instead of a laptop. The bastion runs as the service account the secret-rotation stack already references.

- `tf/modules/bastion` + `tf/prebuilt/bastion`: a plain Compute Engine VM (Ubuntu 24.04, runs as a configurable SA with provisioning IAM) plus an IAP-SSH firewall; `startup.sh` installs the toolchain (OpenTofu, gcloud + gke-gcloud-auth-plugin, kubectl, Node 22, openclaw, gke-mcp).
- `scripts/bastion/`: `sync-to-bastion.sh` pushes the working tree to the VM over IAP (with an opt-in gcpnode SSH override); `vm-setup.sh` builds the venv, installs the package, and seeds `bench.env`.
- `docs/bastion.md`: architecture + provision/sync/run/teardown guide.

Net-new infrastructure (no prior implementation); a plain Compute VM is used rather than Cloud Workstations.