### PR TITLE
test(compare): results comparison harness (pkg evaluator vs devops_bench)

### DIFF
--- a/docs/refactor/legacy-comparison.md
+++ b/docs/refactor/legacy-comparison.md
@@ -1,0 +1,89 @@
+# Legacy vs. refactor comparison harness (temporary)
+
+**Status: droppable scaffolding.** This harness is a regression gate used *during*
+the `pkg/evaluator/evaluate.py` -> `devops_bench` refactor. Both implementations
+currently coexist on this branch. Once the refactor is validated and the legacy
+evaluator is removed, delete `scripts/compare_legacy_vs_refactor.sh`,
+`scripts/compare_results.py`, and `tests/unit/comparison/`.
+
+## Purpose
+
+Run the same reference task through both entrypoints against a deterministic mock
+model and prove that the refactor changed *only* what it intended to change. The
+mock (`scripts/mock_ollama_server.py`) returns identical canned agent + judge
+output to both runs, so any difference in `results.json` is attributable to the
+code, not the model.
+
+## How to run
+
+```bash
+# default reference task: tasks/generic/gateway-https-redirect/task.yaml
+scripts/compare_legacy_vs_refactor.sh
+
+# a different task / a different mock port
+MOCK_PORT=11500 scripts/compare_legacy_vs_refactor.sh tasks/<...>/task.yaml
+```
+
+The orchestrator:
+
+1. Starts the mock Ollama server and health-checks `/v1/models` (killed via an
+   `EXIT` trap so a failed run still cleans up).
+2. Runs LEGACY (`python pkg/evaluator/evaluate.py <task>`), which writes
+   `results/run_<ts>/results.json` relative to CWD; the script picks the newest
+   run dir that did not exist before the run.
+3. Runs REFACTOR (`RESULTS_ROOT=<tmp> uv run python -m devops_bench <task>`) into
+   an isolated temp dir and parses the printed `results: <path>` line.
+4. Diffs the two files with `scripts/compare_results.py` and propagates its exit
+   code: **0** = no regressions, **1** = a regression, **2** = usage/IO error.
+
+You can also diff two existing files directly:
+
+```bash
+uv run python scripts/compare_results.py \
+  --legacy <legacy results.json> --refactor <refactor results.json> \
+  [--json-report report.json]
+```
+
+## The three buckets
+
+Every observed difference (after normalization that drops volatile fields:
+`latency`, `tokens`, timestamps, run-dir/absolute paths, and trajectory
+structure) is partitioned into:
+
+- **MATCHED** — identical after normalization.
+- **INTENDED** — explained by the allowlist below (a documented, deliberate
+  refactor change).
+- **REGRESSION** — any remaining unexplained difference (a dropped/added
+  non-allowlisted metric, a real status flip, materially different `output`, or a
+  value/success diff on a metric not on the value-delta allowlist). A single
+  regression fails the gate (exit 1).
+
+## Current intended-delta allowlist
+
+Defined as clearly-labeled module-level constants at the top of
+`scripts/compare_results.py`; edit there to extend. Rationale traces to
+`docs/refactor/metrics-extensibility-handoff.md` (section 3 reviewer note) plus
+two schema/trajectory deltas observed empirically on the reference task.
+
+| Allowlist constant | What it tolerates | Rationale |
+|---|---|---|
+| (always) score-key normalization | strips a trailing ` [GEval]` before aligning | Legacy wrote `OutcomeValidity [GEval]` / `ToolInvocation [GEval]`; refactor strips uniformly (handoff section 3). |
+| `INTENDED_METRIC_VALUE_DELTAS` = {GroundingAccuracy, ParameterRecallAccuracy, DocRetrievalRate} | numeric value/success diffs on these metrics | Constraint dedup (legacy double-counted) and missing-key robustness guard (handoff section 3). |
+| `INTENDED_CHECKLIST_TEXT_DELTAS` | a `Check: ...` key present on only one side | Trailing-hyphen fix changed some checklist item names (handoff section 3); only the *text* changed. |
+| `INTENDED_LEGACY_NULL_STATUS` | legacy `status=None` paired with any refactor status | Legacy non-infra path never set `status`; refactor sets an explicit terminal status. A real success<->failed flip (both non-None) is still a regression. |
+| `INTENDED_TRAJECTORY_PRESENCE_DELTA` | trajectory non-empty on one side, empty on the other | By design the two trajectories track different things: legacy stores conversation turns, refactor stores only canonical `ToolCall` entries (empty for a no-tool task). Trajectory is never diffed structurally. |
+| `INTENDED_MCP_READ_METRICS` = {ToolInvocation} | the `ToolInvocation` metric present on only one side | MCP-gated; `BENCH_USE_MCP` is read once by the refactor harness (handoff section 4.3). |
+
+## Reading the gate output
+
+`compare_results.py` prints each difference under its bucket, then exits `0` (no
+regressions) or `1` (one or more). A clean refactor on a no-infra,
+`BENCH_USE_MCP=false` task typically shows only **INTENDED** deltas (e.g. legacy
+`status=None` → refactor `success`; trajectory presence by design) plus
+**MATCHED** scores. Treat any **REGRESSION** row as a real change to investigate.
+(Per-run counts and scores are not recorded here — they're tracked separately.)
+
+> **Blind spots.** The allowlist deliberately tolerates value/success diffs on the
+> three grounding metrics (`INTENDED_METRIC_VALUE_DELTAS`) and `Check:` key-text
+> changes, so a value regression *on those* will not fail the gate. The gate is a
+> coarse guard, not a full equivalence proof.

--- a/scripts/compare_legacy_vs_refactor.sh
+++ b/scripts/compare_legacy_vs_refactor.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Temporary legacy-vs-refactor regression gate (droppable scaffolding).
+#
+# Runs the SAME reference task through both the legacy entrypoint
+# (pkg/evaluator/evaluate.py) and the refactor entrypoint
+# (python -m devops_bench) against a deterministic mock Ollama server, then
+# diffs the two results.json files via scripts/compare_results.py.
+#
+# Usage: scripts/compare_legacy_vs_refactor.sh [TASK_FILE]
+# Env:   MOCK_PORT (default 11439)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MOCK_PORT="${MOCK_PORT:-11439}"
+TASK_FILE="${1:-tasks/generic/gateway-https-redirect/task.yaml}"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  if [[ -n "${MOCK_PID:-}" ]]; then
+    kill "${MOCK_PID}" 2>/dev/null || true
+  fi
+  rm -rf "${TMP_DIR}" 2>/dev/null || true
+}
+# Always clean up the mock + temp dir, even on a failed run (legacy script lacked this).
+trap cleanup EXIT
+
+echo "==> Starting mock Ollama server on port ${MOCK_PORT}"
+python3 scripts/mock_ollama_server.py "${MOCK_PORT}" >"${TMP_DIR}/mock.log" 2>&1 &
+MOCK_PID=$!
+
+# Health-check the mock before running anything.
+for _ in $(seq 1 30); do
+  if curl -sf "http://127.0.0.1:${MOCK_PORT}/v1/models" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.3
+done
+if ! curl -sf "http://127.0.0.1:${MOCK_PORT}/v1/models" >/dev/null 2>&1; then
+  echo "ERROR: mock server failed to start; log follows:" >&2
+  cat "${TMP_DIR}/mock.log" >&2
+  exit 2
+fi
+echo "    mock server healthy (pid ${MOCK_PID})"
+
+# Shared env mirroring scripts/run_ollama_e2e_test.sh, pointed at the mock.
+export BENCH_AGENT_TYPE=api
+export BENCH_USE_MCP=false
+export BENCH_NO_INFRA=true
+export AGENT_PROVIDER=ollama
+export JUDGE_PROVIDER=ollama
+export AGENT_MODEL=gemma4:2b
+export JUDGE_MODEL=gemma4:2b
+export OLLAMA_BASE_URL="http://127.0.0.1:${MOCK_PORT}/v1"
+export GCP_PROJECT_ID=test-project
+export CLUSTER_NAME=test-cluster
+
+echo ""
+echo "==> Running LEGACY: python3 pkg/evaluator/evaluate.py ${TASK_FILE}"
+# Legacy writes results/run_<ts>/results.json relative to CWD and ignores
+# RESULTS_ROOT. Record pre-existing run dirs, then pick the newest new one.
+BEFORE="$(ls -d results/run_* 2>/dev/null | sort || true)"
+uv run python pkg/evaluator/evaluate.py "${TASK_FILE}" >"${TMP_DIR}/legacy.log" 2>&1 || {
+  echo "ERROR: legacy run failed; log follows:" >&2
+  cat "${TMP_DIR}/legacy.log" >&2
+  exit 2
+}
+AFTER="$(ls -d results/run_* 2>/dev/null | sort || true)"
+LEGACY_RUN_DIR="$(comm -13 <(printf '%s\n' "${BEFORE}") <(printf '%s\n' "${AFTER}") | grep -E 'results/run_' | tail -1 || true)"
+if [[ -z "${LEGACY_RUN_DIR}" ]]; then
+  echo "ERROR: could not locate the legacy run directory" >&2
+  exit 2
+fi
+LEGACY_RESULTS="${REPO_ROOT}/${LEGACY_RUN_DIR}/results.json"
+echo "    legacy results: ${LEGACY_RESULTS}"
+
+echo ""
+echo "==> Running REFACTOR: uv run python -m devops_bench ${TASK_FILE}"
+# Isolate the refactor output under TMP_DIR via RESULTS_ROOT, then parse the
+# printed 'results: <path>' line.
+REFACTOR_LOG="${TMP_DIR}/refactor.log"
+RESULTS_ROOT="${TMP_DIR}/refactor_results" uv run python -m devops_bench "${TASK_FILE}" \
+  >"${REFACTOR_LOG}" 2>&1 || {
+  echo "ERROR: refactor run failed; log follows:" >&2
+  cat "${REFACTOR_LOG}" >&2
+  exit 2
+}
+REFACTOR_RESULTS="$(grep -oE 'results: .*results\.json' "${REFACTOR_LOG}" | tail -1 | sed 's/^results: //')"
+if [[ -z "${REFACTOR_RESULTS}" || ! -f "${REFACTOR_RESULTS}" ]]; then
+  echo "ERROR: could not parse refactor results path; log follows:" >&2
+  cat "${REFACTOR_LOG}" >&2
+  exit 2
+fi
+echo "    refactor results: ${REFACTOR_RESULTS}"
+
+echo ""
+echo "==> Comparing results"
+set +e
+uv run python scripts/compare_results.py \
+  --legacy "${LEGACY_RESULTS}" \
+  --refactor "${REFACTOR_RESULTS}"
+VERDICT=$?
+set -e
+
+echo ""
+echo "==> Result paths"
+echo "    legacy:   ${LEGACY_RESULTS}"
+echo "    refactor: ${REFACTOR_RESULTS}"
+if [[ "${VERDICT}" -eq 0 ]]; then
+  echo "==> VERDICT: PASS (no regressions); exit ${VERDICT}"
+else
+  echo "==> VERDICT: FAIL or error; exit ${VERDICT}"
+fi
+exit "${VERDICT}"

--- a/scripts/compare_results.py
+++ b/scripts/compare_results.py
@@ -1,0 +1,610 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compare two ``results.json`` files and classify each difference."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "INTENDED",
+    "MATCHED",
+    "REGRESSION",
+    "CompareError",
+    "Difference",
+    "TaskComparison",
+    "align_records",
+    "build_json_report",
+    "compare",
+    "compare_records",
+    "has_regression",
+    "main",
+    "normalize_score_key",
+    "normalize_scores",
+    "normalize_whitespace",
+    "render_report",
+    "score_entry_success",
+    "score_entry_value",
+]
+
+# --------------------------------------------------------------------------- #
+# Intended-delta allowlist. Differences NOT covered here are regressions.
+# --------------------------------------------------------------------------- #
+
+#: Score keys whose numeric value may legitimately differ between the two
+#: implementations.
+INTENDED_METRIC_VALUE_DELTAS: frozenset[str] = frozenset(
+    {
+        "GroundingAccuracy",  # constraint dedup
+        "ParameterRecallAccuracy",  # constraint dedup
+        "DocRetrievalRate",  # missing-key guard
+    }
+)
+
+#: When True, a ``Check:`` key present on one side but not the other is INTENDED:
+#: only the checklist item text changed.
+INTENDED_CHECKLIST_TEXT_DELTAS: bool = True
+
+#: When True, a legacy ``status`` of ``None`` paired with any refactor status is
+#: intended. A success<->failed flip (both sides non-None) is still a REGRESSION.
+INTENDED_LEGACY_NULL_STATUS: bool = True
+
+#: When True, a trajectory presence mismatch is intended; trajectory is never
+#: diffed structurally.
+INTENDED_TRAJECTORY_PRESENCE_DELTA: bool = True
+
+#: Metrics whose presence/absence depends on the ``BENCH_USE_MCP`` read.
+INTENDED_MCP_READ_METRICS: frozenset[str] = frozenset({"ToolInvocation"})
+
+#: Top-level keys that are volatile or refactor-only schema additions and kept
+#: out of the diff entirely.
+VOLATILE_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
+    {
+        "latency",
+        "tokens",
+        "trajectory",  # handled separately via presence-only check
+        "error",
+        "errors",
+        "score",
+        "capabilities_granted",
+        "verification_parse_errors",
+    }
+)
+
+_GEVAL_SUFFIX = " [GEval]"
+
+# Buckets.
+MATCHED = "MATCHED"
+INTENDED = "INTENDED"
+REGRESSION = "REGRESSION"
+
+
+class CompareError(Exception):
+    """Raised on usage or IO errors (mapped to exit code 2)."""
+
+
+@dataclass
+class Difference:
+    """A single classified difference between two aligned records.
+
+    Attributes:
+        bucket: One of MATCHED / INTENDED / REGRESSION.
+        field: Dotted field path the difference applies to.
+        detail: Human-readable explanation of the difference.
+        legacy: Legacy-side value (for display).
+        refactor: Refactor-side value (for display).
+    """
+
+    bucket: str
+    field: str
+    detail: str
+    legacy: Any = None
+    refactor: Any = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for the JSON report."""
+        return {
+            "bucket": self.bucket,
+            "field": self.field,
+            "detail": self.detail,
+            "legacy": self.legacy,
+            "refactor": self.refactor,
+        }
+
+
+@dataclass
+class TaskComparison:
+    """Per-task comparison outcome.
+
+    Attributes:
+        name: Aligned task name (or index fallback).
+        differences: All classified differences for this task.
+    """
+
+    name: str
+    differences: list[Difference] = field(default_factory=list)
+
+    @property
+    def regressions(self) -> list[Difference]:
+        """Differences in this task classified as regressions."""
+        return [d for d in self.differences if d.bucket == REGRESSION]
+
+    @property
+    def intended(self) -> list[Difference]:
+        """Differences in this task classified as intended deltas."""
+        return [d for d in self.differences if d.bucket == INTENDED]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for the JSON report."""
+        return {
+            "name": self.name,
+            "differences": [d.to_dict() for d in self.differences],
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Normalization helpers.
+# --------------------------------------------------------------------------- #
+
+
+def normalize_score_key(key: str) -> str:
+    """Strip a trailing ``" [GEval]"`` suffix from a score key.
+
+    >>> normalize_score_key("OutcomeValidity [GEval]")
+    'OutcomeValidity'
+    """
+    if key.endswith(_GEVAL_SUFFIX):
+        return key[: -len(_GEVAL_SUFFIX)]
+    return key
+
+
+def normalize_whitespace(text: Any) -> str:
+    """Collapse runs of whitespace and trim, for stable text comparison.
+
+    Args:
+        text: Any value; non-strings are stringified (None becomes "").
+
+    Returns:
+        Whitespace-normalized string.
+    """
+    if text is None:
+        return ""
+    return " ".join(str(text).split())
+
+
+def score_entry_value(entry: Any) -> float | None:
+    """Extract the numeric score from a score entry (dict or bare float).
+
+    >>> score_entry_value({"score": 0.5})
+    0.5
+    >>> score_entry_value(0.5)
+    0.5
+    >>> score_entry_value({}) is None
+    True
+    """
+    if isinstance(entry, dict):
+        val = entry.get("score")
+        return float(val) if isinstance(val, (int, float)) else None
+    if isinstance(entry, (int, float)):
+        return float(entry)
+    return None
+
+
+def score_entry_success(entry: Any) -> bool | None:
+    """Extract the success flag from a score entry, if any.
+
+    Args:
+        entry: Either ``{"score": ..., "success": ...}`` or a bare value.
+
+    Returns:
+        The success flag, or None for bare-value entries.
+    """
+    if isinstance(entry, dict):
+        val = entry.get("success")
+        return val if isinstance(val, bool) else None
+    return None
+
+
+def normalize_scores(scores: dict[str, Any]) -> dict[str, Any]:
+    """Re-key a scores dict by normalized (GEval-stripped) name.
+
+    Later keys win on collision.
+
+    >>> normalize_scores({"OutcomeValidity [GEval]": 0.5})
+    {'OutcomeValidity': 0.5}
+    """
+    out: dict[str, Any] = {}
+    for key, value in (scores or {}).items():
+        out[normalize_score_key(key)] = value
+    return out
+
+
+def _is_checklist_key(key: str) -> bool:
+    return key.startswith("Check:")
+
+
+def _trajectory_nonempty(record: dict[str, Any]) -> bool:
+    return bool(record.get("trajectory"))
+
+
+# --------------------------------------------------------------------------- #
+# Classification.
+# --------------------------------------------------------------------------- #
+
+
+def _classify_status(legacy: dict[str, Any], refactor: dict[str, Any]) -> Difference | None:
+    """Classify a ``status`` difference, or return None if equal."""
+    ls, rs = legacy.get("status"), refactor.get("status")
+    if ls == rs:
+        return None
+    if ls is None and INTENDED_LEGACY_NULL_STATUS:
+        return Difference(
+            INTENDED,
+            "status",
+            "legacy non-infra path leaves status=None; refactor sets explicit status",
+            ls,
+            rs,
+        )
+    return Difference(
+        REGRESSION,
+        "status",
+        "status flip between implementations",
+        ls,
+        rs,
+    )
+
+
+def _classify_output(legacy: dict[str, Any], refactor: dict[str, Any]) -> Difference | None:
+    """Classify an ``output`` difference (whitespace-normalized)."""
+    lo = normalize_whitespace(legacy.get("output"))
+    ro = normalize_whitespace(refactor.get("output"))
+    if lo == ro:
+        return None
+    return Difference(
+        REGRESSION,
+        "output",
+        "materially different output after whitespace normalization",
+        legacy.get("output"),
+        refactor.get("output"),
+    )
+
+
+def _classify_trajectory(legacy: dict[str, Any], refactor: dict[str, Any]) -> Difference | None:
+    """Classify a trajectory presence-only difference."""
+    ln, rn = _trajectory_nonempty(legacy), _trajectory_nonempty(refactor)
+    if ln == rn:
+        return None
+    if INTENDED_TRAJECTORY_PRESENCE_DELTA:
+        return Difference(
+            INTENDED,
+            "trajectory",
+            "trajectory presence differs by design (legacy: conversation turns; "
+            "refactor: tool-call entries only)",
+            f"non-empty={ln}",
+            f"non-empty={rn}",
+        )
+    return Difference(
+        REGRESSION,
+        "trajectory",
+        "trajectory presence mismatch",
+        f"non-empty={ln}",
+        f"non-empty={rn}",
+    )
+
+
+def _classify_metric_set(
+    legacy_scores: dict[str, Any], refactor_scores: dict[str, Any]
+) -> list[Difference]:
+    """Classify metric keys present on one side but not the other."""
+    diffs: list[Difference] = []
+    lkeys, rkeys = set(legacy_scores), set(refactor_scores)
+
+    for key in sorted(lkeys - rkeys):
+        diffs.append(_classify_missing_metric(key, side="refactor"))
+    for key in sorted(rkeys - lkeys):
+        diffs.append(_classify_missing_metric(key, side="legacy"))
+    return diffs
+
+
+def _classify_missing_metric(key: str, *, side: str) -> Difference:
+    """Classify a metric key missing on ``side``.
+
+    Args:
+        key: Normalized score key.
+        side: The implementation MISSING the key ("legacy" or "refactor").
+
+    Returns:
+        An INTENDED Difference when the gap is allowlisted, else REGRESSION.
+    """
+    field_path = f"scores[{key!r}]"
+    if _is_checklist_key(key) and INTENDED_CHECKLIST_TEXT_DELTAS:
+        return Difference(
+            INTENDED,
+            field_path,
+            f"checklist item text changed (trailing-hyphen fix); missing on {side}",
+            None if side == "legacy" else key,
+            None if side == "refactor" else key,
+        )
+    if key in INTENDED_MCP_READ_METRICS:
+        return Difference(
+            INTENDED,
+            field_path,
+            f"MCP-gated metric ({key}); presence depends on BENCH_USE_MCP read",
+        )
+    return Difference(
+        REGRESSION,
+        field_path,
+        f"metric {key!r} present on the other side but missing on {side}",
+    )
+
+
+def _classify_metric_values(
+    legacy_scores: dict[str, Any], refactor_scores: dict[str, Any]
+) -> list[Difference]:
+    """Classify per-metric value/success diffs for shared metric keys."""
+    diffs: list[Difference] = []
+    for key in sorted(set(legacy_scores) & set(refactor_scores)):
+        legacy_entry, refactor_entry = legacy_scores[key], refactor_scores[key]
+        lv, rv = score_entry_value(legacy_entry), score_entry_value(refactor_entry)
+        ls, rs = score_entry_success(legacy_entry), score_entry_success(refactor_entry)
+        field_path = f"scores[{key!r}]"
+
+        if lv == rv and ls == rs:
+            diffs.append(Difference(MATCHED, field_path, "score value and success match", lv, rv))
+            continue
+
+        if key in INTENDED_METRIC_VALUE_DELTAS:
+            diffs.append(
+                Difference(
+                    INTENDED,
+                    field_path,
+                    f"value/success delta allowed for {key} (constraint dedup / robustness)",
+                    {"score": lv, "success": ls},
+                    {"score": rv, "success": rs},
+                )
+            )
+            continue
+
+        diffs.append(
+            Difference(
+                REGRESSION,
+                field_path,
+                f"score value/success diff for non-allowlisted metric {key!r}",
+                {"score": lv, "success": ls},
+                {"score": rv, "success": rs},
+            )
+        )
+    return diffs
+
+
+def compare_records(
+    legacy: dict[str, Any], refactor: dict[str, Any], name: str
+) -> TaskComparison:
+    """Compare one aligned (legacy, refactor) record pair.
+
+    Args:
+        legacy: Legacy result record.
+        refactor: Refactor result record.
+        name: Aligned task name for reporting.
+
+    Returns:
+        A TaskComparison holding all classified differences.
+    """
+    comp = TaskComparison(name=name)
+
+    for classifier in (_classify_status, _classify_output, _classify_trajectory):
+        diff = classifier(legacy, refactor)
+        if diff is not None:
+            comp.differences.append(diff)
+
+    lscores = normalize_scores(legacy.get("scores", {}))
+    rscores = normalize_scores(refactor.get("scores", {}))
+    comp.differences.extend(_classify_metric_set(lscores, rscores))
+    comp.differences.extend(_classify_metric_values(lscores, rscores))
+
+    if not comp.differences:
+        comp.differences.append(Difference(MATCHED, "<record>", "no differences"))
+    return comp
+
+
+def align_records(
+    legacy: list[dict[str, Any]], refactor: list[dict[str, Any]]
+) -> list[tuple[str, dict[str, Any], dict[str, Any]]]:
+    """Align legacy and refactor records by task name, falling back to index.
+
+    Args:
+        legacy: Legacy result list.
+        refactor: Refactor result list.
+
+    Returns:
+        Triples of (name, legacy_record, refactor_record) for every aligned
+        pair. Unmatched records on either side are paired with ``{}``.
+
+    Raises:
+        CompareError: If either input is not a list.
+    """
+    if not isinstance(legacy, list) or not isinstance(refactor, list):
+        raise CompareError("both result files must contain a JSON list of records")
+
+    refactor_by_name = {r.get("name"): r for r in refactor if r.get("name")}
+    aligned: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+    used: set[str] = set()
+
+    name_match = all(r.get("name") for r in legacy) and all(r.get("name") for r in refactor)
+    if name_match:
+        for lr in legacy:
+            nm = lr.get("name")
+            rr = refactor_by_name.get(nm, {})
+            if rr:
+                used.add(nm)
+            aligned.append((nm, lr, rr))
+        for rr in refactor:
+            nm = rr.get("name")
+            if nm not in used:
+                aligned.append((nm, {}, rr))
+        return aligned
+
+    # Positional fallback.
+    for idx in range(max(len(legacy), len(refactor))):
+        lr = legacy[idx] if idx < len(legacy) else {}
+        rr = refactor[idx] if idx < len(refactor) else {}
+        nm = (lr.get("name") if lr else None) or (rr.get("name") if rr else None) or f"#{idx}"
+        aligned.append((nm, lr, rr))
+    return aligned
+
+
+def compare(
+    legacy: list[dict[str, Any]], refactor: list[dict[str, Any]]
+) -> list[TaskComparison]:
+    """Align and compare two full result lists.
+
+    Args:
+        legacy: Legacy result list.
+        refactor: Refactor result list.
+
+    Returns:
+        One TaskComparison per aligned task.
+    """
+    results: list[TaskComparison] = []
+    for name, lr, rr in align_records(legacy, refactor):
+        if not lr or not rr:
+            comp = TaskComparison(name=name)
+            missing = "legacy" if not lr else "refactor"
+            comp.differences.append(
+                Difference(REGRESSION, "<record>", f"task missing on {missing} side")
+            )
+            results.append(comp)
+            continue
+        results.append(compare_records(lr, rr, name))
+    return results
+
+
+# --------------------------------------------------------------------------- #
+# Reporting / CLI.
+# --------------------------------------------------------------------------- #
+
+
+def _load(path: str) -> list[dict[str, Any]]:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except OSError as exc:
+        raise CompareError(f"cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise CompareError(f"invalid JSON in {path}: {exc}") from exc
+
+
+def render_report(comparisons: list[TaskComparison]) -> str:
+    """Render a human-readable, bucket-grouped report.
+
+    Args:
+        comparisons: Per-task comparison outcomes.
+
+    Returns:
+        The full report text (no trailing newline).
+    """
+    lines: list[str] = []
+    total = {MATCHED: 0, INTENDED: 0, REGRESSION: 0}
+
+    for comp in comparisons:
+        lines.append(f"== task: {comp.name} ==")
+        for bucket in (REGRESSION, INTENDED, MATCHED):
+            items = [d for d in comp.differences if d.bucket == bucket]
+            for _ in items:
+                total[bucket] += 1
+            if not items:
+                continue
+            lines.append(f"  [{bucket}]")
+            for d in items:
+                lines.append(f"    - {d.field}: {d.detail}")
+                if d.legacy is not None or d.refactor is not None:
+                    lines.append(f"        legacy:   {d.legacy!r}")
+                    lines.append(f"        refactor: {d.refactor!r}")
+        lines.append("")
+
+    verdict = "PASS (no regressions)" if total[REGRESSION] == 0 else "FAIL (regressions found)"
+    lines.append(
+        f"SUMMARY: {total[MATCHED]} matched, {total[INTENDED]} intended, "
+        f"{total[REGRESSION]} regression(s) -> {verdict}"
+    )
+    return "\n".join(lines)
+
+
+def build_json_report(comparisons: list[TaskComparison]) -> dict[str, Any]:
+    """Build the machine-readable report payload.
+
+    Args:
+        comparisons: Per-task comparison outcomes.
+
+    Returns:
+        A JSON-serializable dict with per-task differences and totals.
+    """
+    totals = {MATCHED: 0, INTENDED: 0, REGRESSION: 0}
+    for comp in comparisons:
+        for d in comp.differences:
+            totals[d.bucket] += 1
+    return {
+        "tasks": [c.to_dict() for c in comparisons],
+        "totals": totals,
+        "regressions": totals[REGRESSION],
+    }
+
+
+def has_regression(comparisons: list[TaskComparison]) -> bool:
+    """Whether any task has at least one regression."""
+    return any(c.regressions for c in comparisons)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint.
+
+    Args:
+        argv: Argument vector (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        0 if no regressions, 1 if any regression, 2 on usage/IO error.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--legacy", required=True, help="legacy results.json path")
+    parser.add_argument("--refactor", required=True, help="refactor results.json path")
+    parser.add_argument("--json-report", help="optional path to write a JSON report")
+    try:
+        args = parser.parse_args(argv)
+        legacy = _load(args.legacy)
+        refactor = _load(args.refactor)
+        comparisons = compare(legacy, refactor)
+    except CompareError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    print(render_report(comparisons))
+
+    if args.json_report:
+        try:
+            with open(args.json_report, "w", encoding="utf-8") as fh:
+                json.dump(build_json_report(comparisons), fh, indent=2)
+        except OSError as exc:
+            print(f"error: cannot write report: {exc}", file=sys.stderr)
+            return 2
+
+    return 1 if has_regression(comparisons) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_compare.sh
+++ b/scripts/run_compare.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Legacy-vs-refactored comparison for ANY task, ANY CLI agent, on real infra.
+#
+#   Arm A (LEGACY):     python3 pkg/evaluator/evaluate.py  <task>
+#   Arm B (REFACTORED): python3 -m devops_bench           <task>
+#
+# Runs the same task through both entrypoints with the same agent/judge config,
+# then diffs the two results.json via scripts/compare_results.py. The agent is
+# selected entirely by env, so this works for gemini, openclaw, or any other
+# registered CLI agent — nothing here is task- or agent-specific.
+#
+# (This is the real-infra comparison. scripts/compare_legacy_vs_refactor.sh is a
+# separate, mock-Ollama regression gate.)
+#
+# Usage:
+#   scripts/run_compare.sh <task.yaml>
+#
+# Required env:
+#   AGENT_API_KEY, JUDGE_API_KEY
+#   GCP_PROJECT_ID, GKE_CLUSTER_NAME   (unless BENCH_NO_INFRA=true)
+# Optional env:
+#   RESULTS_ROOT (default results), NAMESPACE, GCP_LOCATION (us-central1-a),
+#   AGENT_MODEL / JUDGE_MODEL (default gemini-3.1-pro-preview),
+#   RULES_FILE   (operator brief; delivered to refactored via AGENT_RULES_TEXT
+#                 and to the legacy gemini arm via a repo-root GEMINI.md shadow),
+#   BENCH_NO_INFRA=true  (plumbing smoke; skips GKE).
+#   ...plus any agent-specific vars you export, e.g.:
+#     gemini   : AGENT_TARGET=gemini   BENCH_AGENT_TYPE stays default (cli->gemini)
+#     openclaw : AGENT_TARGET=oc  OPENCLAW_LOCAL=true  OPENCLAW_BIN=oc
+#                refactored arm: BENCH_AGENT_TYPE=openclaw  AGENT_MCP_SERVER=gke-mcp
+#                                AGENT_SKILLS_PATHS=skills
+set -euo pipefail
+
+TASK_FILE="${1:?usage: scripts/run_compare.sh <task.yaml>}"
+[[ -f "$TASK_FILE" ]] || { echo "ERROR: task file not found: $TASK_FILE" >&2; exit 2; }
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+STAMP="${STAMP:-$(date +%Y%m%d_%H%M%S)}"
+RUN_DIR="${RESULTS_ROOT:-results}/compare_${STAMP}"
+mkdir -p "${RUN_DIR}/legacy" "${RUN_DIR}/refactored"
+
+: "${AGENT_API_KEY:?set AGENT_API_KEY}"
+: "${JUDGE_API_KEY:?set JUDGE_API_KEY}"
+BENCH_NO_INFRA="${BENCH_NO_INFRA:-false}"
+if [[ "$BENCH_NO_INFRA" != "true" ]]; then
+  : "${GCP_PROJECT_ID:?set GCP_PROJECT_ID (or BENCH_NO_INFRA=true)}"
+  : "${GKE_CLUSTER_NAME:?set GKE_CLUSTER_NAME (or BENCH_NO_INFRA=true)}"
+fi
+
+# Shared agent/judge config (both arms identical where it matters). Anything the
+# caller already exported (AGENT_TARGET, BENCH_AGENT_TYPE, OPENCLAW_*, MCP, etc.)
+# is passed through to both arms.
+export BENCH_AGENT_TYPE="${BENCH_AGENT_TYPE:-cli}"
+export AGENT_PROVIDER="${AGENT_PROVIDER:-google}"
+export AGENT_MODEL="${AGENT_MODEL:-gemini-3.1-pro-preview}"
+export JUDGE_PROVIDER="${JUDGE_PROVIDER:-google}"
+export JUDGE_MODEL="${JUDGE_MODEL:-gemini-3.1-pro-preview}"
+export AGENT_API_KEY JUDGE_API_KEY
+# google-provider CLIs read the key from these; harmless for other providers.
+export GEMINI_API_KEY="${GEMINI_API_KEY:-$AGENT_API_KEY}"
+export GOOGLE_API_KEY="${GOOGLE_API_KEY:-$AGENT_API_KEY}"
+export GCP_LOCATION="${GCP_LOCATION:-us-central1-a}"
+export NAMESPACE="${NAMESPACE:-compare}"
+export BENCH_NO_INFRA
+
+RULES_TEXT=""
+[[ -n "${RULES_FILE:-}" && -f "${RULES_FILE}" ]] && RULES_TEXT="$(cat "${RULES_FILE}")"
+
+echo "==> compare dir: ${RUN_DIR}  (task: ${TASK_FILE}; mode: $([[ "$BENCH_NO_INFRA" == true ]] && echo NO-INFRA || echo 'REAL INFRA'))"
+
+# ----------------------------- ARM A: LEGACY ------------------------------- #
+echo "==> ARM A (LEGACY): pkg/evaluator/evaluate.py"
+BEFORE="$(ls -d results/run_* 2>/dev/null || true)"
+GEMINI_MD="${REPO_ROOT}/GEMINI.md"; GEMINI_MD_BAK=""
+restore_gemini_md() {
+  if [[ -n "$RULES_TEXT" ]]; then
+    if [[ -n "$GEMINI_MD_BAK" ]]; then mv "$GEMINI_MD_BAK" "$GEMINI_MD"; else rm -f "$GEMINI_MD"; fi
+  fi
+}
+if [[ -n "$RULES_TEXT" ]]; then
+  # Legacy gemini auto-loads a repo-root GEMINI.md; shadow it for the run, then
+  # restore. (Other legacy agents ignore it — harmless.)
+  [[ -f "$GEMINI_MD" ]] && { GEMINI_MD_BAK="$(mktemp)"; cp "$GEMINI_MD" "$GEMINI_MD_BAK"; }
+  printf '%s' "$RULES_TEXT" > "$GEMINI_MD"
+  # Restore on ANY exit path (a ``set -e`` abort, a later arm failure, or a
+  # clean finish) so a tracked GEMINI.md is never left clobbered.
+  trap restore_gemini_md EXIT
+fi
+if ! python3 pkg/evaluator/evaluate.py "${TASK_FILE}" >"${RUN_DIR}/legacy/run.log" 2>&1; then
+  echo "ERROR: legacy arm failed"; tail -30 "${RUN_DIR}/legacy/run.log"; exit 2
+fi
+AFTER="$(ls -d results/run_* 2>/dev/null || true)"
+LEGACY_RUN_DIR="$(comm -13 <(printf '%s\n' "${BEFORE}") <(printf '%s\n' "${AFTER}") | grep -E 'results/run_' | tail -1 || true)"
+if [[ -z "${LEGACY_RUN_DIR}" || ! -f "${LEGACY_RUN_DIR}/results.json" ]]; then
+  echo "ERROR: legacy results.json not found"; tail -30 "${RUN_DIR}/legacy/run.log"; exit 2
+fi
+cp -R "${LEGACY_RUN_DIR}/." "${RUN_DIR}/legacy/"
+LEGACY_RESULTS="${RUN_DIR}/legacy/results.json"
+echo "    legacy results: ${LEGACY_RESULTS}"
+
+# --------------------------- ARM B: REFACTORED ----------------------------- #
+echo "==> ARM B (REFACTORED): python3 -m devops_bench"
+REFACTOR_LOG="${RUN_DIR}/refactored/run.log"
+(
+  [[ -n "$RULES_TEXT" ]] && export AGENT_RULES_TEXT="$RULES_TEXT"
+  if [[ "$BENCH_NO_INFRA" == "true" ]]; then
+    python3 -m devops_bench --results-root "${RUN_DIR}/refactored" "${TASK_FILE}"
+  else
+    python3 -m devops_bench --project "${GCP_PROJECT_ID}" --cluster "${GKE_CLUSTER_NAME}" \
+      --results-root "${RUN_DIR}/refactored" "${TASK_FILE}"
+  fi
+) >"${REFACTOR_LOG}" 2>&1 || { echo "ERROR: refactored arm failed"; tail -30 "${REFACTOR_LOG}"; exit 2; }
+REFACTOR_RESULTS="$(grep -oE 'results: .*results\.json' "${REFACTOR_LOG}" | tail -1 | sed 's/^results: //')"
+[[ -z "${REFACTOR_RESULTS}" || ! -f "${REFACTOR_RESULTS}" ]] && REFACTOR_RESULTS="$(find "${RUN_DIR}/refactored" -name results.json | head -1)"
+if [[ -z "${REFACTOR_RESULTS}" || ! -f "${REFACTOR_RESULTS}" ]]; then
+  echo "ERROR: refactored results.json not found"; tail -30 "${REFACTOR_LOG}"; exit 2
+fi
+echo "    refactored results: ${REFACTOR_RESULTS}"
+
+# -------------------------------- DIFF ------------------------------------- #
+echo "==> compare_results.py"
+set +e
+python3 scripts/compare_results.py \
+  --legacy "${LEGACY_RESULTS}" \
+  --refactor "${REFACTOR_RESULTS}" \
+  --json-report "${RUN_DIR}/comparison-report.json" | tee "${RUN_DIR}/comparison-report.md"
+echo "==> done. RUN_DIR=${RUN_DIR}"

--- a/tests/unit/comparison/__init__.py
+++ b/tests/unit/comparison/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the temporary legacy-vs-refactor comparison harness."""

--- a/tests/unit/comparison/test_compare_results.py
+++ b/tests/unit/comparison/test_compare_results.py
@@ -1,0 +1,187 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the comparison bucket classifier and normalizers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "compare_results.py"
+_spec = importlib.util.spec_from_file_location("compare_results", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+cr = importlib.util.module_from_spec(_spec)
+sys.modules["compare_results"] = cr
+_spec.loader.exec_module(cr)
+
+
+def _record(scores: dict, **overrides) -> dict:
+    """Build a minimal result record with matching status/output/trajectory."""
+    base = {
+        "name": "t",
+        "status": "success",
+        "output": "same output",
+        "trajectory": [{"name": "x"}],
+        "scores": scores,
+    }
+    base.update(overrides)
+    return base
+
+
+def _buckets(comp) -> dict[str, list]:
+    out: dict[str, list] = {cr.MATCHED: [], cr.INTENDED: [], cr.REGRESSION: []}
+    for d in comp.differences:
+        out[d.bucket].append(d)
+    return out
+
+
+def test_geval_suffix_normalizes_to_matched():
+    legacy = _record({"OutcomeValidity [GEval]": {"score": 0.1, "success": False}})
+    refactor = _record({"OutcomeValidity": {"score": 0.1, "success": False}})
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert any("OutcomeValidity" in d.field for d in b[cr.MATCHED])
+
+
+def test_normalize_score_key_strips_suffix():
+    assert cr.normalize_score_key("ToolInvocation [GEval]") == "ToolInvocation"
+    assert cr.normalize_score_key("ChecklistScore") == "ChecklistScore"
+
+
+def test_grounding_value_diff_is_intended():
+    legacy = _record({"GroundingAccuracy": 3.0})
+    refactor = _record({"GroundingAccuracy": 5.0})
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert any("GroundingAccuracy" in d.field for d in b[cr.INTENDED])
+
+
+def test_status_flip_is_regression():
+    legacy = _record({}, status="success")
+    refactor = _record({}, status="failed")
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert any(d.field == "status" for d in b[cr.REGRESSION])
+
+
+def test_legacy_null_status_is_intended():
+    legacy = _record({}, status=None)
+    refactor = _record({}, status="success")
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert any(d.field == "status" for d in b[cr.INTENDED])
+
+
+def test_dropped_non_allowlisted_metric_is_regression():
+    legacy = _record({"OutcomeValidity": {"score": 0.1, "success": False}})
+    refactor = _record({})
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert any("OutcomeValidity" in d.field for d in b[cr.REGRESSION])
+
+
+def test_dropped_checklist_metric_is_intended():
+    legacy = _record({"Check: do a thing-": {"score": 0.1, "success": False}})
+    refactor = _record({"Check: do a thing": {"score": 0.1, "success": False}})
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert len(b[cr.INTENDED]) >= 2  # one missing on each side
+
+
+def test_mcp_gated_metric_missing_is_intended():
+    legacy = _record({"ToolInvocation": {"score": 0.5, "success": True}})
+    refactor = _record({})
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert any("ToolInvocation" in d.field for d in b[cr.INTENDED])
+
+
+def test_non_allowlisted_value_diff_is_regression():
+    legacy = _record({"OutcomeValidity": {"score": 0.1, "success": False}})
+    refactor = _record({"OutcomeValidity": {"score": 0.9, "success": True}})
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert any("OutcomeValidity" in d.field for d in b[cr.REGRESSION])
+
+
+def test_output_whitespace_normalized_matches():
+    legacy = _record({}, output="hello   world\n")
+    refactor = _record({}, output="hello world")
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not any(d.field == "output" for d in b[cr.REGRESSION])
+
+
+def test_output_material_diff_is_regression():
+    legacy = _record({}, output="apply manifest A")
+    refactor = _record({}, output="apply manifest B")
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert any(d.field == "output" for d in b[cr.REGRESSION])
+
+
+def test_trajectory_presence_delta_is_intended():
+    legacy = _record({}, trajectory=[{"type": "user_input"}])
+    refactor = _record({}, trajectory=[])
+    comp = cr.compare_records(legacy, refactor, "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert any(d.field == "trajectory" for d in b[cr.INTENDED])
+
+
+def test_identical_records_all_matched():
+    rec = _record({"OutcomeValidity": {"score": 0.1, "success": False}})
+    comp = cr.compare_records(rec, dict(rec), "t")
+    b = _buckets(comp)
+    assert not b[cr.REGRESSION]
+    assert not b[cr.INTENDED]
+
+
+def test_align_by_name():
+    legacy = [{"name": "b"}, {"name": "a"}]
+    refactor = [{"name": "a"}, {"name": "b"}]
+    aligned = cr.align_records(legacy, refactor)
+    pairs = {nm: (lr["name"], rr["name"]) for nm, lr, rr in aligned}
+    assert pairs["a"] == ("a", "a")
+    assert pairs["b"] == ("b", "b")
+
+
+def test_missing_task_is_regression():
+    legacy = [_record({}, name="only_legacy")]
+    refactor = []
+    comps = cr.compare(legacy, refactor)
+    assert cr.has_regression(comps)
+
+
+def test_non_list_input_raises():
+    with pytest.raises(cr.CompareError):
+        cr.align_records({"not": "a list"}, [])
+
+
+def test_has_regression_and_exit_semantics():
+    clean = cr.compare([_record({})], [_record({})])
+    assert not cr.has_regression(clean)
+    flipped = cr.compare(
+        [_record({}, status="success")], [_record({}, status="failed")]
+    )
+    assert cr.has_regression(flipped)


### PR DESCRIPTION
A droppable comparison harness that runs the same task through both entrypoints — `pkg/evaluator/evaluate.py` and `python -m devops_bench` — and diffs the two `results.json`, so the refactored pipeline can be checked against the prior one. Local scaffolding, not intended to land upstream.

- `scripts/compare_legacy_vs_refactor.sh` + `scripts/compare_results.py`: a deterministic mock-Ollama regression gate that diffs the two result files and classifies each delta as matched / intended / regression.
- `scripts/run_compare.sh`: a task- and agent-agnostic real-infra comparison (task file as `$1`; agent selected entirely by env) used to compare gemini or openclaw on real GKE.
- `complextasks/secret-rotation/agent-rules.md`: operator brief consumed by the secret-rotation comparison.
- `pkg/agents/runner/{gcli,openclaw}.py`: the prior openclaw path now uses `oc`'s built-in `main` agent so it runs on a stock `oc` (the `operator` agent isn't configured there).