### PR TITLE
feat(foundation): align Layer-1 (k8s/models/tasks) for the Stage 2/3 stack

### DIFF
--- a/devops_bench/k8s/__init__.py
+++ b/devops_bench/k8s/__init__.py
@@ -15,6 +15,6 @@
 """Reusable Kubernetes primitives: kubectl wrappers and wait/poll conditions."""
 
 from devops_bench.k8s.conditions import poll_until
-from devops_bench.k8s.kubectl import apply, get_resource, rollout_status, wait
+from devops_bench.k8s.kubectl import apply, get_json, rollout_status, scale, wait
 
-__all__ = ["apply", "get_resource", "poll_until", "rollout_status", "wait"]
+__all__ = ["apply", "get_json", "poll_until", "rollout_status", "scale", "wait"]

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -23,8 +23,9 @@ from devops_bench.core.subprocess import CompletedProcess, run
 
 __all__ = [
     "apply",
-    "get_resource",
+    "get_json",
     "rollout_status",
+    "scale",
     "wait",
 ]
 
@@ -118,7 +119,7 @@ def wait(
     return _run_kubectl(argv, kubeconfig)
 
 
-def get_resource(
+def get_json(
     resource_type: str,
     name: str | None = None,
     *,
@@ -176,6 +177,31 @@ def apply(
         SubprocessError: If kubectl exits non-zero or times out.
     """
     argv = ["kubectl", "apply", "-f", path, *_namespace_args(namespace)]
+    return _run_kubectl(argv, kubeconfig)
+
+
+def scale(
+    resource: str,
+    replicas: int,
+    *,
+    namespace: str | None = None,
+    kubeconfig: KubeconfigSource = None,
+) -> CompletedProcess:
+    """Set the replica count of a resource via ``kubectl scale``.
+
+    Args:
+        resource: Resource reference, e.g. ``"deployment/web"``.
+        replicas: Desired replica count.
+        namespace: Optional namespace (``-n``).
+        kubeconfig: Kubeconfig path or context-like object.
+
+    Returns:
+        The completed process.
+
+    Raises:
+        SubprocessError: If kubectl exits non-zero or times out.
+    """
+    argv = ["kubectl", "scale", f"--replicas={replicas}", resource, *_namespace_args(namespace)]
     return _run_kubectl(argv, kubeconfig)
 
 

--- a/devops_bench/models/__init__.py
+++ b/devops_bench/models/__init__.py
@@ -14,9 +14,9 @@
 
 """LLM provider clients and the provider-selection factory.
 
-Each provider has an adapter module named by model family (``gemini``,
-``claude``; ``ollama`` is the runtime exception). A provider's SDK is imported
-only when its adapter is constructed, so a missing SDK surfaces as
+Each provider has an adapter module named after its canonical key
+(``gemini``/``anthropic``/``ollama``). A provider's SDK is imported only when its
+adapter is constructed, so a missing SDK surfaces as
 :class:`MissingDependencyError` at construction time, not on import.
 """
 

--- a/devops_bench/models/anthropic.py
+++ b/devops_bench/models/anthropic.py
@@ -15,8 +15,8 @@
 """Anthropic (Claude) adapter for the LLM client interface.
 
 Claude is reachable through three backends; this adapter selects one from the
-environment so the ``claude`` provider key (alias ``anthropic``) names the model
-family rather than a single transport:
+environment so the ``anthropic`` provider key names the model family rather than
+a single transport:
 
 - ``api`` — the first-party Anthropic API (``AsyncAnthropic``), the canonical
   default, selected when ``AGENT_API_KEY``/``ANTHROPIC_API_KEY`` is set.
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover - exercised only without the SDK
     AsyncAnthropicBedrock = None
     AsyncAnthropicVertex = None
 
-__all__ = ["ClaudeClientAdapter"]
+__all__ = ["AnthropicClientAdapter"]
 
 _DEFAULT_MAX_TOKENS = 16000
 
@@ -57,11 +57,11 @@ _DEFAULT_MODELS = {
 }
 _BACKENDS = frozenset({"api", "vertex", "bedrock"})
 
-_log = get_logger("models.claude")
+_log = get_logger("models.anthropic")
 
 
-@MODELS.register("claude")
-class ClaudeClientAdapter(LLMClient):
+@MODELS.register("anthropic")
+class AnthropicClientAdapter(LLMClient):
     """Adapter for the Anthropic SDK across its three backends.
 
     The backend (first-party API, Vertex AI, or Bedrock) is chosen from the
@@ -138,7 +138,7 @@ class ClaudeClientAdapter(LLMClient):
             return AsyncAnthropicBedrock(aws_region=first_env("AWS_REGION", "AWS_DEFAULT_REGION"))
         # vertex
         return AsyncAnthropicVertex(
-            region=get_env("GCP_VERTEX_LOCATION", "global"),
+            region=get_env("GCP_VERTEX_LOCATION", "us-central1"),
             project_id=get_env("GCP_PROJECT_ID"),
         )
 

--- a/devops_bench/models/base.py
+++ b/devops_bench/models/base.py
@@ -27,10 +27,10 @@ __all__ = ["LLMClient", "MODELS", "get_model"]
 
 MODELS: Registry[type[LLMClient]] = Registry("models")
 
-# Adapter modules are named by model family (``gemini``, ``claude``) and
-# self-register under that canonical key via ``@MODELS.register``; ``ollama`` is
-# the runtime exception. Company/runtime names are accepted as aliases here.
-_ALIASES = {"google": "gemini", "anthropic": "claude"}
+# Provider keys that do not match their adapter module name. Each adapter module
+# is named after its canonical provider key and self-registers under it via
+# ``@MODELS.register``; aliases are resolved to that canonical key here.
+_ALIASES = {"google": "gemini"}
 
 
 class LLMClient(ABC):
@@ -104,7 +104,7 @@ def get_model(
 
     Args:
         provider: Registry key such as ``"gemini"``/``"google"``,
-            ``"claude"``/``"anthropic"``, or ``"ollama"``. Case-insensitive.
+            ``"anthropic"``, or ``"ollama"``. Case-insensitive.
         model_name: Optional model override passed to the adapter; when omitted
             the adapter reads ``AGENT_MODEL`` (or its own default).
         **kwargs: Extra keyword arguments forwarded to the adapter constructor.

--- a/devops_bench/models/gemini.py
+++ b/devops_bench/models/gemini.py
@@ -137,13 +137,13 @@ class GeminiClientAdapter(LLMClient):
 
     def __init__(self, model_name: str | None = None) -> None:
         if genai is None:
-            raise MissingDependencyError("the Gemini model adapter", "google-genai")
+            raise MissingDependencyError("the Gemini model adapter", "gemini")
 
         if not model_name:
             model_name = get_env("AGENT_MODEL", "gemini-3.1-pro-preview")
 
         project_id = get_env("GCP_PROJECT_ID")
-        location = get_env("GCP_VERTEX_LOCATION", "global")
+        location = get_env("GCP_VERTEX_LOCATION", "us-central1")
         api_key = get_env("AGENT_API_KEY")
 
         if api_key:

--- a/devops_bench/models/ollama.py
+++ b/devops_bench/models/ollama.py
@@ -53,7 +53,7 @@ class OllamaClientAdapter(LLMClient):
 
     def __init__(self, model_name: str | None = None, base_url: str | None = None) -> None:
         if AsyncOpenAI is None:
-            raise MissingDependencyError("the Ollama model adapter", "openai")
+            raise MissingDependencyError("the Ollama model adapter", "ollama")
 
         if not model_name:
             model_name = get_env("AGENT_MODEL", _DEFAULT_MODEL)

--- a/devops_bench/tasks/__init__.py
+++ b/devops_bench/tasks/__init__.py
@@ -14,7 +14,7 @@
 
 """Task contracts: the typed schema and loaders for benchmark tasks."""
 
-from devops_bench.tasks.loader import FileSystemTaskLoader, TaskLoader
+from devops_bench.tasks.loader import FileSystemTaskLoader, TaskLoader, load_tasks
 from devops_bench.tasks.schema import Constraint, DocumentationEntry, Task
 
 __all__ = [
@@ -23,4 +23,5 @@ __all__ = [
     "DocumentationEntry",
     "TaskLoader",
     "FileSystemTaskLoader",
+    "load_tasks",
 ]

--- a/devops_bench/tasks/loader.py
+++ b/devops_bench/tasks/loader.py
@@ -17,8 +17,8 @@
 from __future__ import annotations
 
 import json
+import os
 from abc import ABC, abstractmethod
-from pathlib import Path
 from typing import Any
 
 from ruamel.yaml import YAML
@@ -30,6 +30,7 @@ __all__ = [
     "TaskLoader",
     "FileSystemTaskLoader",
     "load_from_tasks_dir",
+    "load_tasks",
 ]
 
 _log = get_logger("tasks.loader")
@@ -60,7 +61,7 @@ def _sort_key(task: Task) -> tuple[int, int | str]:
     return (0, int(text)) if text.isdigit() else (1, text)
 
 
-def _load_yaml_task(path: Path, name_default: str) -> Task | None:
+def _load_yaml_task(path: str, name_default: str) -> Task | None:
     """Read one YAML spec file into a Task, or None if it is not a mapping.
 
     Args:
@@ -70,7 +71,8 @@ def _load_yaml_task(path: Path, name_default: str) -> Task | None:
     Returns:
         The parsed task, or ``None`` when the document is not a mapping.
     """
-    content = safe_parse_yaml(path.read_text())
+    with open(path) as stream:
+        content = safe_parse_yaml(stream.read())
     if not isinstance(content, dict):
         return None
     return Task.from_dict(content, name_default=name_default)
@@ -94,21 +96,20 @@ def load_from_tasks_dir(dir_path: str) -> list[Task]:
     Raises:
         ConfigError: If ``dir_path`` does not exist.
     """
-    root_dir = Path(dir_path)
-    if not root_dir.exists():
+    if not os.path.exists(dir_path):
         raise ConfigError(f"tasks directory not found at {dir_path}")
 
     tasks: list[Task] = []
     seen_ids: set[str] = set()
-    for current, dirs, files in root_dir.walk():
+    for root, dirs, files in os.walk(dir_path):
         # Sort dirs in place to ensure deterministic ordering during walk.
         dirs.sort()
         if _TASK_FILE not in files:
             continue
 
-        yaml_path = current / _TASK_FILE
+        yaml_path = os.path.join(root, _TASK_FILE)
         try:
-            task = _load_yaml_task(yaml_path, name_default=current.name)
+            task = _load_yaml_task(yaml_path, name_default=os.path.basename(root))
             if task is not None:
                 if task.id and task.id in seen_ids:
                     _log.warning("duplicate task id %r at %s", task.id, yaml_path)
@@ -140,15 +141,15 @@ def _load_single_file(path: str) -> list[Task]:
             Unlike directory loads (which log and skip), single-file loads
             always surface a clean ``ConfigError``.
     """
-    spec = Path(path)
-    name_default = spec.stem
+    name_default = os.path.splitext(os.path.basename(path))[0]
 
     try:
-        if spec.suffix in (".yaml", ".yml"):
-            task = _load_yaml_task(spec, name_default=name_default)
+        if path.endswith((".yaml", ".yml")):
+            task = _load_yaml_task(path, name_default=name_default)
             return [task] if task is not None else []
 
-        raw = json.loads(spec.read_text())
+        with open(path) as f:
+            raw = json.load(f)
 
         if isinstance(raw, dict):
             return [Task.from_dict(raw, name_default=name_default)]
@@ -200,9 +201,25 @@ class FileSystemTaskLoader(TaskLoader):
         Raises:
             ConfigError: If ``source`` does not exist.
         """
-        spec = Path(source)
-        if spec.is_dir():
+        if os.path.isdir(source):
             return load_from_tasks_dir(source)
-        if not spec.exists():
+        if not os.path.exists(source):
             raise ConfigError(f"task spec not found at {source}")
         return _load_single_file(source)
+
+
+def load_tasks(source: str) -> list[Task]:
+    """Load task contracts from a directory or a single spec file.
+
+    Convenience wrapper over :class:`FileSystemTaskLoader`.
+
+    Args:
+        source: A tasks directory or a single spec file.
+
+    Returns:
+        The loaded tasks.
+
+    Raises:
+        ConfigError: If ``source`` does not exist.
+    """
+    return FileSystemTaskLoader().load_tasks(source)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,10 @@ dependencies = [
 # Provider SDKs are optional: install only the extras for the providers you use.
 # Extra names match the keys accepted by ``get_model`` / ``AGENT_PROVIDER``.
 [project.optional-dependencies]
-google-genai = ["google-genai>=2.6.0"]
+gemini = ["google-genai>=2.6.0"]
 anthropic = ["anthropic>=0.104.1"]
-openai = ["openai>=1.0.0"]
-all = ["devops-bench[google-genai,anthropic,openai]"]
+ollama = ["openai>=1.0.0"]
+all = ["devops-bench[gemini,anthropic,ollama]"]
 
 [tool.hatch.version]
 path = "devops_bench/__init__.py"

--- a/tests/unit/k8s/test_k8s_kubectl.py
+++ b/tests/unit/k8s/test_k8s_kubectl.py
@@ -76,14 +76,14 @@ def test_wait_custom_condition_without_optionals(mocker):
     assert mock_run.call_args.kwargs["extra_env"] is None
 
 
-def test_get_resource_parses_output_and_builds_argv(mocker):
+def test_get_json_parses_output_and_builds_argv(mocker):
     payload = {"items": [{"status": {"phase": "Running"}}]}
     mock_run = mocker.patch(
         "devops_bench.k8s.kubectl.run",
         return_value=_completed(stdout=json.dumps(payload)),
     )
 
-    result = kubectl.get_resource("pods", selector="app=web", namespace="default")
+    result = kubectl.get_json("pods", selector="app=web", namespace="default")
 
     assert result == payload
     argv = mock_run.call_args.args[0]
@@ -100,14 +100,14 @@ def test_get_resource_parses_output_and_builds_argv(mocker):
     ]
 
 
-def test_get_resource_with_name(mocker):
+def test_get_json_with_name(mocker):
     payload = {"status": {"readyReplicas": 3}}
     mock_run = mocker.patch(
         "devops_bench.k8s.kubectl.run",
         return_value=_completed(stdout=json.dumps(payload)),
     )
 
-    result = kubectl.get_resource("deployment", "my-dep")
+    result = kubectl.get_json("deployment", "my-dep")
 
     assert result == payload
     argv = mock_run.call_args.args[0]
@@ -121,6 +121,15 @@ def test_apply_builds_argv(mocker):
 
     argv = mock_run.call_args.args[0]
     assert argv == ["kubectl", "apply", "-f", "/manifests/app.yaml", "-n", "staging"]
+
+
+def test_scale_builds_argv(mocker):
+    mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
+
+    kubectl.scale("deployment/web", 5)
+
+    argv = mock_run.call_args.args[0]
+    assert argv == ["kubectl", "scale", "--replicas=5", "deployment/web"]
 
 
 def test_rollout_status_with_timeout(mocker):
@@ -165,7 +174,7 @@ def test_kubeconfig_from_cluster_info(mocker):
     mock_run = mocker.patch("devops_bench.k8s.kubectl.run", return_value=_completed())
     cluster = ClusterInfo(name="c1", kubeconfig_path="/cluster/kc")
 
-    kubectl.wait("pod", timeout_sec=10, kubeconfig=cluster)
+    kubectl.scale("deployment/web", 2, kubeconfig=cluster)
 
     assert mock_run.call_args.kwargs["extra_env"] == {"KUBECONFIG": "/cluster/kc"}
 
@@ -179,14 +188,14 @@ def test_run_context_without_cluster_omits_kubeconfig(mocker):
     assert mock_run.call_args.kwargs["extra_env"] is None
 
 
-def test_get_resource_propagates_invalid_json(mocker):
+def test_get_json_propagates_invalid_json(mocker):
     mocker.patch(
         "devops_bench.k8s.kubectl.run",
         return_value=_completed(stdout="not json"),
     )
 
     with pytest.raises(json.JSONDecodeError):
-        kubectl.get_resource("pods")
+        kubectl.get_json("pods")
 
 
 def test_wait_propagates_subprocess_error(mocker):

--- a/tests/unit/models/test_models_anthropic.py
+++ b/tests/unit/models/test_models_anthropic.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the Claude adapter and its backend selection."""
+"""Tests for the Anthropic (Claude) adapter and its backend selection."""
 
 from __future__ import annotations
 
@@ -24,8 +24,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 from devops_bench.core.errors import ConfigError, MissingDependencyError
-from devops_bench.models import claude
-from devops_bench.models.claude import ClaudeClientAdapter
+from devops_bench.models import anthropic
+from devops_bench.models.anthropic import AnthropicClientAdapter
 
 
 def _make_tool(name, description, input_schema):
@@ -36,79 +36,79 @@ def _make_tool(name, description, input_schema):
 
 
 def test_init_selects_vertex_from_project(mocker):
-    client_cls = mocker.patch.object(claude, "AsyncAnthropicVertex")
+    client_cls = mocker.patch.object(anthropic, "AsyncAnthropicVertex")
     mocker.patch.dict(
         os.environ, {"GCP_PROJECT_ID": "proj", "GCP_VERTEX_LOCATION": "us-east5"}, clear=True
     )
 
-    adapter = ClaudeClientAdapter()
+    adapter = AnthropicClientAdapter()
 
     client_cls.assert_called_once_with(region="us-east5", project_id="proj")
     assert adapter.model_name == "claude-sonnet-4-5@20250929"
 
 
 def test_init_defaults_to_vertex_and_warns(mocker):
-    mocker.patch.object(claude, "AsyncAnthropicVertex")
-    warn = mocker.patch.object(claude._log, "warning")
+    mocker.patch.object(anthropic, "AsyncAnthropicVertex")
+    warn = mocker.patch.object(anthropic._log, "warning")
     mocker.patch.dict(os.environ, {}, clear=True)
 
-    adapter = ClaudeClientAdapter()
+    adapter = AnthropicClientAdapter()
 
     warn.assert_called_once()
     assert adapter.model_name == "claude-sonnet-4-5@20250929"
 
 
 def test_init_selects_api_from_key(mocker):
-    client_cls = mocker.patch.object(claude, "AsyncAnthropic")
+    client_cls = mocker.patch.object(anthropic, "AsyncAnthropic")
     mocker.patch.dict(os.environ, {"AGENT_API_KEY": "sk-test"}, clear=True)
 
-    adapter = ClaudeClientAdapter()
+    adapter = AnthropicClientAdapter()
 
     client_cls.assert_called_once_with(api_key="sk-test")
     assert adapter.model_name == "claude-sonnet-4-5"
 
 
 def test_init_api_key_takes_precedence_over_project(mocker):
-    api_cls = mocker.patch.object(claude, "AsyncAnthropic")
-    vertex_cls = mocker.patch.object(claude, "AsyncAnthropicVertex")
+    api_cls = mocker.patch.object(anthropic, "AsyncAnthropic")
+    vertex_cls = mocker.patch.object(anthropic, "AsyncAnthropicVertex")
     mocker.patch.dict(
         os.environ, {"AGENT_API_KEY": "sk-test", "GCP_PROJECT_ID": "proj"}, clear=True
     )
 
-    ClaudeClientAdapter()
+    AnthropicClientAdapter()
 
     api_cls.assert_called_once()
     vertex_cls.assert_not_called()
 
 
 def test_init_selects_bedrock_from_aws_region(mocker):
-    client_cls = mocker.patch.object(claude, "AsyncAnthropicBedrock")
+    client_cls = mocker.patch.object(anthropic, "AsyncAnthropicBedrock")
     mocker.patch.dict(
         os.environ, {"AWS_REGION": "us-west-2", "AGENT_MODEL": "anthropic.claude-x"}, clear=True
     )
 
-    adapter = ClaudeClientAdapter()
+    adapter = AnthropicClientAdapter()
 
     client_cls.assert_called_once_with(aws_region="us-west-2")
     assert adapter.model_name == "anthropic.claude-x"
 
 
 def test_init_bedrock_requires_model(mocker):
-    mocker.patch.object(claude, "AsyncAnthropicBedrock")
+    mocker.patch.object(anthropic, "AsyncAnthropicBedrock")
     mocker.patch.dict(os.environ, {"AWS_REGION": "us-west-2"}, clear=True)
 
     with pytest.raises(ConfigError):
-        ClaudeClientAdapter()
+        AnthropicClientAdapter()
 
 
 def test_init_backend_override_forces_vertex(mocker):
-    mocker.patch.object(claude, "AsyncAnthropic")
-    vertex_cls = mocker.patch.object(claude, "AsyncAnthropicVertex")
+    mocker.patch.object(anthropic, "AsyncAnthropic")
+    vertex_cls = mocker.patch.object(anthropic, "AsyncAnthropicVertex")
     mocker.patch.dict(
         os.environ, {"AGENT_API_KEY": "sk-test", "ANTHROPIC_BACKEND": "vertex"}, clear=True
     )
 
-    ClaudeClientAdapter()
+    AnthropicClientAdapter()
 
     vertex_cls.assert_called_once()
 
@@ -117,22 +117,22 @@ def test_init_backend_override_invalid_raises(mocker):
     mocker.patch.dict(os.environ, {"ANTHROPIC_BACKEND": "nope"}, clear=True)
 
     with pytest.raises(ConfigError):
-        ClaudeClientAdapter()
+        AnthropicClientAdapter()
 
 
 def test_init_without_sdk_raises(mocker):
-    mocker.patch.object(claude, "AsyncAnthropic", None)
+    mocker.patch.object(anthropic, "AsyncAnthropic", None)
 
     with pytest.raises(MissingDependencyError):
-        ClaudeClientAdapter()
+        AnthropicClientAdapter()
 
 
 # --- format_tools -------------------------------------------------------------
 
 
 def test_format_tools_shape(mocker):
-    mocker.patch.object(claude, "AsyncAnthropicVertex")
-    adapter = ClaudeClientAdapter()
+    mocker.patch.object(anthropic, "AsyncAnthropicVertex")
+    adapter = AnthropicClientAdapter()
     schema = {"type": "object", "properties": {}}
 
     result = adapter.format_tools([_make_tool("t", "d", schema)])
@@ -144,8 +144,8 @@ def test_format_tools_shape(mocker):
 
 
 def test_extract_function_calls(mocker):
-    mocker.patch.object(claude, "AsyncAnthropicVertex")
-    adapter = ClaudeClientAdapter()
+    mocker.patch.object(anthropic, "AsyncAnthropicVertex")
+    adapter = AnthropicClientAdapter()
 
     response = SimpleNamespace(
         content=[
@@ -163,8 +163,8 @@ def test_extract_function_calls(mocker):
 
 
 def test_get_text_content_concatenates(mocker):
-    mocker.patch.object(claude, "AsyncAnthropicVertex")
-    adapter = ClaudeClientAdapter()
+    mocker.patch.object(anthropic, "AsyncAnthropicVertex")
+    adapter = AnthropicClientAdapter()
 
     response = SimpleNamespace(
         content=[
@@ -181,12 +181,12 @@ def test_get_text_content_concatenates(mocker):
 
 
 def test_generate_content_passes_max_tokens_and_system(mocker):
-    client = mocker.patch.object(claude, "AsyncAnthropicVertex").return_value
+    client = mocker.patch.object(anthropic, "AsyncAnthropicVertex").return_value
     create = AsyncMock(return_value="resp")
     client.messages.create = create
     mocker.patch.dict(os.environ, {}, clear=True)
 
-    adapter = ClaudeClientAdapter()
+    adapter = AnthropicClientAdapter()
     tools = adapter.format_tools([_make_tool("t", "d", {"type": "object"})])
 
     result = asyncio.run(
@@ -204,24 +204,24 @@ def test_generate_content_passes_max_tokens_and_system(mocker):
 
 
 def test_generate_content_default_max_tokens(mocker):
-    client = mocker.patch.object(claude, "AsyncAnthropicVertex").return_value
+    client = mocker.patch.object(anthropic, "AsyncAnthropicVertex").return_value
     create = AsyncMock(return_value="resp")
     client.messages.create = create
     mocker.patch.dict(os.environ, {}, clear=True)
 
-    adapter = ClaudeClientAdapter()
+    adapter = AnthropicClientAdapter()
     asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], [], None))
 
     assert create.await_args.kwargs["max_tokens"] == 16000
 
 
 def test_generate_content_env_overrides_max_tokens(mocker):
-    client = mocker.patch.object(claude, "AsyncAnthropicVertex").return_value
+    client = mocker.patch.object(anthropic, "AsyncAnthropicVertex").return_value
     create = AsyncMock(return_value="resp")
     client.messages.create = create
     mocker.patch.dict(os.environ, {"AGENT_MAX_TOKENS": "12345"}, clear=True)
 
-    adapter = ClaudeClientAdapter()
+    adapter = AnthropicClientAdapter()
     asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], [], None))
 
     assert adapter.max_tokens == 12345
@@ -229,12 +229,12 @@ def test_generate_content_env_overrides_max_tokens(mocker):
 
 
 def test_generate_content_arg_overrides_env_max_tokens(mocker):
-    client = mocker.patch.object(claude, "AsyncAnthropicVertex").return_value
+    client = mocker.patch.object(anthropic, "AsyncAnthropicVertex").return_value
     create = AsyncMock(return_value="resp")
     client.messages.create = create
     mocker.patch.dict(os.environ, {"AGENT_MAX_TOKENS": "12345"}, clear=True)
 
-    adapter = ClaudeClientAdapter(max_tokens=999)
+    adapter = AnthropicClientAdapter(max_tokens=999)
     asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], [], None))
 
     assert adapter.max_tokens == 999
@@ -242,30 +242,30 @@ def test_generate_content_arg_overrides_env_max_tokens(mocker):
 
 
 def test_generate_content_omits_system_when_empty(mocker):
-    client = mocker.patch.object(claude, "AsyncAnthropicVertex").return_value
+    client = mocker.patch.object(anthropic, "AsyncAnthropicVertex").return_value
     create = AsyncMock(return_value="resp")
     client.messages.create = create
 
-    adapter = ClaudeClientAdapter()
+    adapter = AnthropicClientAdapter()
     asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], [], None))
 
     assert "system" not in create.await_args.kwargs
 
 
 def test_generate_content_omits_tools_when_empty(mocker):
-    client = mocker.patch.object(claude, "AsyncAnthropicVertex").return_value
+    client = mocker.patch.object(anthropic, "AsyncAnthropicVertex").return_value
     create = AsyncMock(return_value="resp")
     client.messages.create = create
 
-    adapter = ClaudeClientAdapter()
+    adapter = AnthropicClientAdapter()
     asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], [], "sys"))
 
     assert "tools" not in create.await_args.kwargs
 
 
 def test_convert_messages_tool_calls_and_results(mocker):
-    mocker.patch.object(claude, "AsyncAnthropicVertex")
-    adapter = ClaudeClientAdapter()
+    mocker.patch.object(anthropic, "AsyncAnthropicVertex")
+    adapter = AnthropicClientAdapter()
 
     contents = [
         {"role": "user", "content": "do it"},
@@ -295,8 +295,8 @@ def test_convert_messages_tool_calls_and_results(mocker):
 
 
 def test_convert_messages_groups_parallel_tool_results(mocker):
-    mocker.patch.object(claude, "AsyncAnthropicVertex")
-    adapter = ClaudeClientAdapter()
+    mocker.patch.object(anthropic, "AsyncAnthropicVertex")
+    adapter = AnthropicClientAdapter()
 
     contents = [
         {"role": "user", "content": "do it"},

--- a/tests/unit/models/test_models_base.py
+++ b/tests/unit/models/test_models_base.py
@@ -26,10 +26,10 @@ from devops_bench.models.base import MODELS, LLMClient, get_model
 
 def test_registry_has_known_providers():
     # Importing the adapter modules registers them under their canonical keys.
-    from devops_bench.models import claude, gemini, ollama  # noqa: F401
+    from devops_bench.models import anthropic, gemini, ollama  # noqa: F401
 
     assert MODELS.get("gemini") is gemini.GeminiClientAdapter
-    assert MODELS.get("claude") is claude.ClaudeClientAdapter
+    assert MODELS.get("anthropic") is anthropic.AnthropicClientAdapter
     assert MODELS.get("ollama") is ollama.OllamaClientAdapter
 
 
@@ -52,22 +52,13 @@ def test_get_model_resolves_google_alias(mocker):
     assert isinstance(client, gemini.GeminiClientAdapter)
 
 
-def test_get_model_returns_claude_adapter(mocker):
-    from devops_bench.models import claude
+def test_get_model_returns_anthropic_adapter(mocker):
+    from devops_bench.models import anthropic
 
-    mocker.patch.object(claude, "AsyncAnthropicVertex")
-    client = get_model(provider="claude")
-
-    assert isinstance(client, claude.ClaudeClientAdapter)
-
-
-def test_get_model_resolves_anthropic_alias(mocker):
-    from devops_bench.models import claude
-
-    mocker.patch.object(claude, "AsyncAnthropicVertex")
+    mocker.patch.object(anthropic, "AsyncAnthropicVertex")
     client = get_model(provider="anthropic")
 
-    assert isinstance(client, claude.ClaudeClientAdapter)
+    assert isinstance(client, anthropic.AnthropicClientAdapter)
 
 
 def test_get_model_returns_ollama_adapter(mocker):
@@ -80,12 +71,12 @@ def test_get_model_returns_ollama_adapter(mocker):
 
 
 def test_get_model_is_case_insensitive(mocker):
-    from devops_bench.models import claude
+    from devops_bench.models import anthropic
 
-    mocker.patch.object(claude, "AsyncAnthropicVertex")
-    client = get_model(provider="CLAUDE")
+    mocker.patch.object(anthropic, "AsyncAnthropicVertex")
+    client = get_model(provider="ANTHROPIC")
 
-    assert isinstance(client, claude.ClaudeClientAdapter)
+    assert isinstance(client, anthropic.AnthropicClientAdapter)
 
 
 def test_get_model_defaults_to_gemini(mocker):
@@ -99,13 +90,13 @@ def test_get_model_defaults_to_gemini(mocker):
 
 
 def test_get_model_reads_provider_from_env(mocker):
-    from devops_bench.models import claude
+    from devops_bench.models import anthropic
 
-    mocker.patch.object(claude, "AsyncAnthropicVertex")
-    mocker.patch.dict(os.environ, {"AGENT_PROVIDER": "claude"}, clear=True)
+    mocker.patch.object(anthropic, "AsyncAnthropicVertex")
+    mocker.patch.dict(os.environ, {"AGENT_PROVIDER": "anthropic"}, clear=True)
     client = get_model()
 
-    assert isinstance(client, claude.ClaudeClientAdapter)
+    assert isinstance(client, anthropic.AnthropicClientAdapter)
 
 
 def test_get_model_passes_model_name(mocker):
@@ -118,7 +109,7 @@ def test_get_model_passes_model_name(mocker):
 
 
 def test_get_model_unknown_provider_raises(mocker):
-    from devops_bench.models import claude, gemini  # noqa: F401
+    from devops_bench.models import anthropic, gemini  # noqa: F401
 
     with pytest.raises(NotRegisteredError):
         get_model(provider="does-not-exist")

--- a/tests/unit/tasks/test_tasks_loader.py
+++ b/tests/unit/tasks/test_tasks_loader.py
@@ -16,7 +16,7 @@
 
 import json
 import logging
-from pathlib import Path
+import os
 
 import pytest
 
@@ -25,27 +25,29 @@ from devops_bench.tasks.loader import (
     FileSystemTaskLoader,
     TaskLoader,
     load_from_tasks_dir,
+    load_tasks,
 )
 
 
-def _write(path: Path, content: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content)
+def _write(path: str, content: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
 
 
 def test_load_from_tasks_dir_recursive_and_ordered(tmp_path):
     # id 2 lives under a directory that sorts before id 1, so a correct
     # loader must sort by id rather than discovery order.
     _write(
-        tmp_path / "aaa" / "task-two" / "task.yaml",
+        os.path.join(str(tmp_path), "aaa", "task-two", "task.yaml"),
         'task_id: 2\nname: "task-two"\nprompt: "Two"\nexpected_output: "E2"\n',
     )
     _write(
-        tmp_path / "zzz" / "task-one" / "task.yaml",
+        os.path.join(str(tmp_path), "zzz", "task-one", "task.yaml"),
         'task_id: 1\nname: "task-one"\nprompt: "One"\nexpected_output: "E1"\n',
     )
 
-    tasks = FileSystemTaskLoader().load_tasks(str(tmp_path))
+    tasks = load_tasks(str(tmp_path))
     assert len(tasks) == 2
     assert tasks[0].id == "1"
     assert tasks[0].name == "task-one"
@@ -54,8 +56,8 @@ def test_load_from_tasks_dir_recursive_and_ordered(tmp_path):
 
 
 def test_numeric_ids_sort_by_value_not_lexically(tmp_path):
-    _write(tmp_path / "a" / "task.yaml", 'task_id: 10\nname: "ten"\n')
-    _write(tmp_path / "b" / "task.yaml", 'task_id: 2\nname: "two"\n')
+    _write(os.path.join(str(tmp_path), "a", "task.yaml"), 'task_id: 10\nname: "ten"\n')
+    _write(os.path.join(str(tmp_path), "b", "task.yaml"), 'task_id: 2\nname: "two"\n')
 
     tasks = load_from_tasks_dir(str(tmp_path))
     assert [t.name for t in tasks] == ["two", "ten"]
@@ -63,15 +65,15 @@ def test_numeric_ids_sort_by_value_not_lexically(tmp_path):
 
 def test_load_from_tasks_dir_subdir_scope(tmp_path):
     _write(
-        tmp_path / "gcp" / "task-gcp" / "task.yaml",
+        os.path.join(str(tmp_path), "gcp", "task-gcp", "task.yaml"),
         'task_id: 1\nname: "task-gcp"\nprompt: "GCP"\nexpected_output: "G"\n',
     )
     _write(
-        tmp_path / "generic" / "task-generic" / "task.yaml",
+        os.path.join(str(tmp_path), "generic", "task-generic", "task.yaml"),
         'task_id: 2\nname: "task-generic"\nprompt: "Generic"\nexpected_output: "X"\n',
     )
 
-    scoped = load_from_tasks_dir(str(tmp_path / "generic"))
+    scoped = load_from_tasks_dir(os.path.join(str(tmp_path), "generic"))
     assert len(scoped) == 1
     assert scoped[0].name == "task-generic"
 
@@ -79,7 +81,7 @@ def test_load_from_tasks_dir_subdir_scope(tmp_path):
 def test_field_defaults_missing_id_and_name(tmp_path):
     # No task_id and no name -> empty id and the directory basename.
     _write(
-        tmp_path / "the-dir-name" / "task.yaml",
+        os.path.join(str(tmp_path), "the-dir-name", "task.yaml"),
         'prompt: "  padded prompt  "\nexpected_output: "  padded  "\n',
     )
 
@@ -93,7 +95,7 @@ def test_field_defaults_missing_id_and_name(tmp_path):
 
 def test_goal_alias_in_dir_load(tmp_path):
     _write(
-        tmp_path / "alias" / "task.yaml",
+        os.path.join(str(tmp_path), "alias", "task.yaml"),
         'task_id: 5\ngoal: "  goal driven  "\n',
     )
     tasks = load_from_tasks_dir(str(tmp_path))
@@ -121,7 +123,7 @@ documentation:
 
 
 def test_documentation_parsed_on_load(tmp_path):
-    _write(tmp_path / "doc" / "task.yaml", _DOC_YAML)
+    _write(os.path.join(str(tmp_path), "doc", "task.yaml"), _DOC_YAML)
     docs = load_from_tasks_dir(str(tmp_path))[0].documentation
     assert len(docs) == 2
 
@@ -150,7 +152,7 @@ def test_invalid_task_is_skipped_with_warning(tmp_path, caplog):
         '      - text: "x"\n'
         "        critical: yes\n"
     )
-    _write(tmp_path / "d" / "task.yaml", yaml_text)
+    _write(os.path.join(str(tmp_path), "d", "task.yaml"), yaml_text)
     with caplog.at_level(logging.WARNING, logger="devops_bench.tasks.loader"):
         tasks = load_from_tasks_dir(str(tmp_path))
     assert tasks == []
@@ -161,7 +163,7 @@ def test_yaml_1_2_booleans_stay_strings(tmp_path):
     # ``yes``/``no``/``off`` are plain strings under YAML 1.2; only
     # ``true``/``false`` are booleans.
     _write(
-        tmp_path / "t" / "task.yaml",
+        os.path.join(str(tmp_path), "t", "task.yaml"),
         'task_id: 1\ninfrastructure:\n  a: yes\n  b: "no"\n  c: true\n',
     )
     infra = load_from_tasks_dir(str(tmp_path))[0].infrastructure
@@ -171,9 +173,9 @@ def test_yaml_1_2_booleans_stay_strings(tmp_path):
 
 
 def test_load_single_yaml_file(tmp_path):
-    path = tmp_path / "case.yaml"
+    path = os.path.join(str(tmp_path), "case.yaml")
     _write(path, 'task_id: 11\nname: "single"\nprompt: "  hi  "\nexpected_output: "out"\n')
-    tasks = FileSystemTaskLoader().load_tasks(str(path))
+    tasks = load_tasks(path)
     assert len(tasks) == 1
     assert tasks[0].id == "11"
     assert tasks[0].name == "single"
@@ -181,12 +183,12 @@ def test_load_single_yaml_file(tmp_path):
 
 
 def test_load_single_json_file_object_with_goal_alias(tmp_path):
-    path = tmp_path / "case.json"
+    path = os.path.join(str(tmp_path), "case.json")
     _write(
         path,
         json.dumps({"task_id": 4, "name": "json-case", "goal": "json goal"}),
     )
-    tasks = FileSystemTaskLoader().load_tasks(str(path))
+    tasks = load_tasks(path)
     assert len(tasks) == 1
     assert tasks[0].id == "4"
     assert tasks[0].name == "json-case"
@@ -194,7 +196,7 @@ def test_load_single_json_file_object_with_goal_alias(tmp_path):
 
 
 def test_load_single_json_file_list(tmp_path):
-    path = tmp_path / "cases.json"
+    path = os.path.join(str(tmp_path), "cases.json")
     _write(
         path,
         json.dumps(
@@ -204,7 +206,7 @@ def test_load_single_json_file_list(tmp_path):
             ]
         ),
     )
-    tasks = FileSystemTaskLoader().load_tasks(str(path))
+    tasks = load_tasks(path)
     assert [t.name for t in tasks] == ["a", "b"]
     assert tasks[0].prompt == "ia"
     assert tasks[1].prompt == "gb"
@@ -213,41 +215,41 @@ def test_load_single_json_file_list(tmp_path):
 def test_single_file_malformed_yaml_raises_config_error(tmp_path):
     # A single malformed YAML spec surfaces a clean ConfigError rather than
     # leaking the underlying parser error.
-    path = tmp_path / "broken.yaml"
+    path = os.path.join(str(tmp_path), "broken.yaml")
     _write(path, "[unterminated")
     with pytest.raises(ConfigError):
-        FileSystemTaskLoader().load_tasks(str(path))
+        load_tasks(path)
 
 
 def test_single_file_json_list_non_dict_element_raises_config_error(tmp_path):
     # A JSON list whose elements are not all objects is rejected with a clean
     # ConfigError instead of crashing inside Task.from_dict.
-    path = tmp_path / "cases.json"
+    path = os.path.join(str(tmp_path), "cases.json")
     _write(path, json.dumps([{"task_id": 1}, 5]))
     with pytest.raises(ConfigError):
-        FileSystemTaskLoader().load_tasks(str(path))
+        load_tasks(path)
 
 
 def test_missing_directory_raises_config_error(tmp_path):
-    missing = tmp_path / "definitely-does-not-exist-xyz-123"
+    missing = os.path.join(str(tmp_path), "definitely-does-not-exist-xyz-123")
     with pytest.raises(ConfigError):
-        load_from_tasks_dir(str(missing))
+        load_from_tasks_dir(missing)
 
 
-def test_missing_directory_via_loader_raises_config_error(tmp_path):
-    missing = tmp_path / "definitely-does-not-exist-xyz-456"
+def test_missing_directory_via_load_tasks_raises_config_error(tmp_path):
+    missing = os.path.join(str(tmp_path), "definitely-does-not-exist-xyz-456")
     with pytest.raises(ConfigError):
-        FileSystemTaskLoader().load_tasks(str(missing))
+        load_tasks(missing)
 
 
 def test_parse_error_is_logged_and_skipped(tmp_path, caplog):
     # A valid task plus one with malformed YAML; the bad one is skipped.
     _write(
-        tmp_path / "good" / "task.yaml",
+        os.path.join(str(tmp_path), "good", "task.yaml"),
         'task_id: 1\nname: "good"\nprompt: "p"\nexpected_output: "e"\n',
     )
     _write(
-        tmp_path / "bad" / "task.yaml",
+        os.path.join(str(tmp_path), "bad", "task.yaml"),
         "task_id: 2\nname: [unterminated\n",
     )
 
@@ -262,11 +264,11 @@ def test_duplicate_task_id_logs_warning(tmp_path, caplog):
     # Two task.yaml with the same explicit task_id: the duplicate is logged as
     # a warning but both are still loaded (directory loading stays resilient).
     _write(
-        tmp_path / "first" / "task.yaml",
+        os.path.join(str(tmp_path), "first", "task.yaml"),
         'task_id: 7\nname: "first"\nprompt: "p"\n',
     )
     _write(
-        tmp_path / "second" / "task.yaml",
+        os.path.join(str(tmp_path), "second", "task.yaml"),
         'task_id: 7\nname: "second"\nprompt: "q"\n',
     )
 
@@ -287,6 +289,6 @@ def test_task_loader_cannot_be_instantiated():
 
 
 def test_filesystem_task_loader_loads_directory(tmp_path):
-    _write(tmp_path / "t" / "task.yaml", 'task_id: 1\nname: "t"\nprompt: "p"\n')
+    _write(os.path.join(str(tmp_path), "t", "task.yaml"), 'task_id: 1\nname: "t"\nprompt: "p"\n')
     tasks = FileSystemTaskLoader().load_tasks(str(tmp_path))
     assert [t.name for t in tasks] == ["t"]

--- a/uv.lock
+++ b/uv.lock
@@ -470,10 +470,10 @@ all = [
 anthropic = [
     { name = "anthropic" },
 ]
-google-genai = [
+gemini = [
     { name = "google-genai" },
 ]
-openai = [
+ollama = [
     { name = "openai" },
 ]
 
@@ -492,15 +492,15 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.104.1" },
     { name = "deepeval", specifier = ">=4.0.3" },
     { name = "google-genai", marker = "extra == 'all'", specifier = ">=2.6.0" },
-    { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=2.6.0" },
+    { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=2.6.0" },
     { name = "mcp", specifier = ">=1.27.1" },
     { name = "openai", marker = "extra == 'all'", specifier = ">=1.0.0" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'ollama'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
 ]
-provides-extras = ["all", "anthropic", "google-genai", "openai"]
+provides-extras = ["all", "anthropic", "gemini", "ollama"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1479,16 +1479,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.2"
+version = "2.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Aligns the shared foundation the Stage 2/3 stack builds on:

- k8s: add `get_json` and `scale`; drop the now-unused `get_resource`.
- models: the Anthropic client lives in `models/anthropic.py`; small
  `base` / `gemini` / `ollama` refinements.
- tasks: `loader` refinements.
- provider extras keyed by the `get_model` / `AGENT_PROVIDER` name
  (`gemini`, `anthropic`, `ollama`).

This lets the Stage 2/3 stack (#113–#124) rebase onto and merge into main.