### PR TITLE
feat: per-run isolation for parallel runs (legacy pkg pipeline)

### DIFF
--- a/.agents/skills/devops-bench-review/SKILL.md
+++ b/.agents/skills/devops-bench-review/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: devops-bench-review
+description: >
+  Use when the user asks for a comprehensive review of devops-bench changes —
+  e.g. "review this PR", "review the workspace", "review my changes", "is this
+  task parallel-safe", "review this new task/stack/doc", "will this break under
+  the parallel matrix". Reviews a PR (number/URL) or the current working tree
+  across four lenses — correctness, parallel-safety across the eval matrix axes,
+  task/stack conventions, and docs conventions — and returns ranked, actionable
+  findings. The parallel-safety lens is the emphasis: it hunts for shared state
+  that makes a task fail when many runs execute at once. This skill is
+  review-only: it analyzes statically and may run unit tests, linting, and
+  formatting checks, but it NEVER runs benchmark evals or provisions infra.
+---
+
+# devops-bench comprehensive review
+
+Review either a **GitHub PR** or the **current workspace** for devops-bench, then
+return ranked findings a maintainer would act on. The defining lens here — beyond
+ordinary correctness — is **parallel-safety**: this repo runs an eval matrix
+(Task × Model × AgentConfig) where many evaluations execute concurrently on one
+host, and the most common way a new task/stack/script is "correct alone but wrong
+in the matrix" is that it touches a resource shared across runs.
+
+**Read these first when the change touches tasks, TF stacks, or run isolation —
+they are the source of truth; don't reconstruct them from memory:**
+- `docs/parallel-evals.md` — per-run isolation model, the **parallel-safety
+  matrix**, the **failure-mode -> fix** table, and the **known-issues** appendix.
+- `docs/bastion.md` — bastion architecture, provisioning, per-run isolation.
+- The isolation primitive itself: `devops_bench/core/run_env.py` (`RunEnv`) and
+  its legacy mirror `pkg/runenv.py`. Confirm what it actually isolates before
+  asserting a collision is or isn't covered.
+- Governing **agent-instruction files** — whichever your harness uses (`CLAUDE.md`,
+  `AGENTS.md`, `GEMINI.md`), at user level and at the repo root, plus any in a
+  directory that is an ancestor of a changed file — quote the exact rule when you
+  flag a violation.
+
+Work the phases in order. Default to **precision**: every finding should name a
+concrete failure (inputs/state -> wrong outcome), not a style preference.
+
+---
+
+## Scope & guardrails — review only, never run evals
+
+This skill **analyzes and reports**. It does **not** execute the benchmark, and it
+finds parallel-run hazards by **reading and reasoning** about the task/stack/
+scripts — never by launching runs to observe a collision.
+
+**May run** (only to validate the code under review):
+- Unit / integration tests for the changed code (`pytest` / the repo's runner).
+- Linting (`ruff`) and formatting **checks** (e.g. `ruff format --check`) — report
+  violations; do not reformat or modify files as part of a review.
+
+**Must NOT run — out of scope, stop and report instead:**
+- Benchmark evaluations or the eval matrix: `pkg/evaluator/evaluate.py`,
+  `python -m devops_bench`, `scripts/bastion/run_matrix*.sh`, or any agent/judge
+  invocation.
+- Infrastructure provisioning or teardown: `tofu`/`terraform apply|destroy|plan|
+  init`, `gcloud ... create/delete`, `kind create/delete cluster`, `kubectl
+  apply/delete`.
+- Anything that spends cloud resources or calls a model/agent API.
+
+If reviewing a change would seem to *require* running it (e.g. "does this task
+actually pass?"), do not run it — report what static analysis shows and state that
+an actual eval run is out of scope for this skill.
+
+---
+
+## Phase 0 — Scope the target and gather the diff
+
+Determine the target from the user's request:
+
+- **A PR** (number or URL): use `gh`, not local git.
+  - `gh pr view <target> --json title,body,author,baseRefName,headRefName,state,additions,deletions,changedFiles,labels`
+  - `gh pr diff <target>`
+  - When an angle needs surrounding code, Read the file in this checkout if it
+    matches the PR branch, else fetch with `git show <ref>:<path>` / `gh`.
+- **The current workspace** ("review my changes / the workspace"):
+  - `git diff @{upstream}...HEAD` (or `git diff main...HEAD` / `git diff HEAD~1`),
+    and also `git diff HEAD` when there are uncommitted changes — review is often
+    run pre-commit. Treat the union as scope.
+
+The diff is the review scope. For each touched function, also Read the enclosing
+function — bugs on unchanged lines of a touched function are in scope (the change
+re-exposes or fails to fix them).
+
+If the change references another PR's mechanism (e.g. "works with the parallel
+isolation from PR #N"), fetch that PR's relevant files too, so you review the
+**interaction**, not the change in isolation.
+
+---
+
+## Phase 1 — Classify what changed, then route to lenses
+
+Bucket each changed file so you apply the right lens (a PR often spans several):
+
+- **Task spec** — `complextasks/*/task.yaml`, `tasks/**/task.yaml` -> Lens C + B.
+- **TF stack / module** — `tf/prebuilt/**`, `tf/modules/**`, `*.tf`, seed/setup
+  `scripts/*.sh` -> Lens B (heavily) + C + A.
+- **Harness / deployer / agent code** — `devops_bench/**`, `pkg/**`,
+  `deployers/**` -> Lens A + B + E + F.
+- **Docs** — `*.md`, `README`, `docs/**` -> Lens D.
+
+Always run Lens A (correctness) and Lens B (parallel-safety) on anything
+executable; run B on any task/stack because that is where matrix collisions live.
+
+---
+
+## Phase 2 — Review lenses
+
+Run the relevant lenses below. Collect candidate findings with `file`, `line`, a
+one-line `summary`, and a concrete `failure_scenario`. Pass through every
+candidate with a nameable failure — verification (Phase 3) is where uncertain
+ones get cut, not here.
+
+### Lens A — correctness
+
+- **Line-by-line:** inverted/wrong conditions, off-by-one, null/undefined deref,
+  missing `await`, falsy-zero checks, wrong-variable copy-paste, swallowed errors,
+  unescaped regex/shell metachars, `set -euo pipefail` gaps in bash.
+- **Removed behavior:** for each deleted/replaced line, name the invariant it
+  enforced and find where it is re-established; a dropped guard/validation/error
+  path or deleted test covering a real case is a finding.
+- **Cross-file:** for each changed function, Grep its callers and callees — does a
+  new precondition, changed return shape, new exception, or timing/ordering
+  dependency break a call site?
+
+If the changed code has unit/integration tests, you **may** run them (and `ruff`)
+to corroborate a finding — see Scope & guardrails. Do not run anything that
+provisions infra or starts an eval.
+
+### Lens B — parallel-safety across the matrix axes (the emphasis)
+
+The eval matrix runs **Task × Model × AgentConfig** concurrently, often N on one
+host. `RunEnv` gives each run its own isolation; a change is unsafe when it
+introduces state shared *outside* that isolation. Establish this **by static
+analysis** — read the stack/scripts/prompt and reason about shared state; do not
+run concurrent evals to find out. First ground yourself in what isolation actually
+covers (verify against `run_env.py` / `docs/parallel-evals.md`, don't assume):
+
+**Per-run isolation covers:** `KUBECONFIG`, `CLOUDSDK_CONFIG`, `TF_DATA_DIR` (+ TF
+state beside it), a run-token-prefixed **cluster name** (short token, prefixed and
+clamped to GKE's 40-char limit), per-run **results dir** (run id appended), and
+`OPENCLAW_STATE_DIR` (sessions/auth/memory) while sharing `OPENCLAW_CONFIG_PATH`.
+
+**Isolation does NOT cover:** `$HOME` and paths under it, the shared
+`tf/prebuilt/<stack>` working dir (`.terraform.lock.hcl`), project-global GCP
+resource names that a stack hardcodes, IAM bindings on shared service accounts,
+`task_id`, host capacity (disk/inotify/ports), and anything an **agent** creates
+at runtime.
+
+**Reason per axis — the same collision can be safe on one axis and fatal on
+another.** For each shared-state suspect, ask which axis triggers it:
+
+- **Task axis** (different tasks, same model/config, concurrently): collides only
+  if the shared name is **fixed across tasks** or **project-global**. A resource
+  whose name is *distinct per task* (e.g. `~/taskA-repo.git` vs `~/taskB-repo.git`)
+  is safe here.
+- **Model / AgentConfig axis** (same task, different model/config): the **same
+  task runs more than once**, so any task-fixed `$HOME`/global name collides — even
+  one that was safe on the task axis. `rm -rf` of a shared path becomes a race.
+- **Repeated same combo / N-on-one-host:** cluster names derived from run id are
+  safe *only because the prior run tore down first* — do not run two of the same
+  combo at once; and host resources (kind clusters, disk, inotify, ports) **sum**
+  across all concurrent runs.
+
+**Shared-state checklist — flag any of these in changed code:**
+
+1. **`$HOME` / process-global paths.** Bare repos (`~/*-repo.git`), fixed temp
+   files, `~/.kube/config`, fixed dirs. `HOME` is **not** isolated. Check: is the
+   path task-distinct AND per-run? Is it hardcoded in the **prompt** with no
+   template token (prompt only templates `{{CLUSTER_NAME}}`, `{{NAMESPACE}}`,
+   `{{PROJECT_ID}}`, etc. — there is no `{{REPO_PATH}}`)? Does a seed/setup script
+   `rm -rf` it (a wipe race under the model/config axis)?
+2. **Cluster / resource names not flowing through the run token.** Names must
+   derive from the harness-supplied (already-prefixed) `cluster_name`. Watch
+   **length** (token + base + any stack suffix vs the 40-char GKE limit) and
+   **truncations that drop the discriminator** — e.g. a stack that appends
+   `-east`/`-west` to a name the gke module then truncates with
+   `substr(cluster_name, 0, 15)` collapses both to one node-SA `account_id`.
+3. **Project-global GCP names not random-suffixed.** Compare against the
+   secret-rotation pattern (appends a `random_id` suffix to `sa-*` /
+   `db-credentials-*` so concurrent runs coexist). Known offender: the gke module
+   node SA `gke-nodes-<cluster>` is deterministic, not suffixed -> `409 already
+   exists` on re-run after a failed teardown (see the known-issues appendix).
+4. **IAM bindings on a shared service account.** A stack that grants a project
+   role (e.g. `roles/container.admin`) to the shared `openclaw-vm-sa` via
+   `google_project_iam_member` in its own TF state: concurrent GKE tasks each
+   "own" that binding, and the first `tofu destroy` strips it from the SA while the
+   others are still running -> mid-run auth loss.
+5. **`task_id` uniqueness.** A new task must not reuse an existing `task_id`
+   (`grep -rn '^task_id' complextasks/ tasks/`). Duplicates make per-task scoring
+   ambiguous when both run in one matrix.
+6. **Agent-created resources & host capacity.** If the task design relies on the
+   agent creating clusters/resources at runtime, their names are agent-chosen
+   (un-prefixed -> cross-run collision risk) and they multiply host load. Sum the
+   per-task disk/inotify/cluster counts across a realistic concurrent batch and
+   flag if the single-run README sizing is exceeded.
+7. **Provisioner env inheritance.** A `local-exec` seed/setup script is only
+   isolated if it inherits the run-scoped `KUBECONFIG`/`CLOUDSDK_CONFIG` — verify
+   it doesn't re-point them at `~/.kube/config` or a global gcloud config.
+8. **Agent/runner parallel-safety.** Legacy arm + gemini CLI is **not**
+   parallel-safe (shared `~/.gemini` trajectory dir); parallel gemini must use the
+   refactored arm. Flag changes that reintroduce shared-session assumptions.
+
+For each parallel finding, **state which axis triggers it** and whether it's
+already covered by `RunEnv` — that is the distinction maintainers act on.
+
+### Lens C — task & stack conventions
+
+- `task.yaml`: unique `task_id`; `name`; `infrastructure` (`deployer`, `stack`,
+  `teardown`); a prompt that uses template tokens rather than hardcoded
+  project/cluster/namespace values; `expected_output` as discoverable critical
+  requirements (nothing in-cluster should *name* the fix — the agent must discover
+  it).
+- **Solvability:** there is a real path to success (a manual-solve in the README
+  or an equivalent), and the fault is injected from outside the cluster. Assess
+  this by reading the stack/scripts — do not provision to check.
+- **Substrate parity:** kind stacks declare `kubeconfig_path`/`cluster_name`/
+  `location` and emit `cluster_location = "local"`; GKE stacks return
+  `cluster_name`/`cluster_location` the deployer expects. New stack variables the
+  harness must set (beyond what the kind/gcp variable resolvers inject) are a
+  red flag — the resolver won't populate them.
+- **Idempotency / teardown:** `teardown: true` actually destroys everything the
+  stack and its scripts create; re-apply after a failed run isn't blocked by
+  orphans.
+
+### Lens D — docs conventions
+
+Apply the repo's documentation conventions:
+- Organize as **scope + user-guide**; GitHub-flavored markdown.
+- **Not journal-like** — no migration history, no "why this lives here", no diary
+  of what changed.
+- No **contradictions or duplication** with existing docs; put caveats in a
+  **known-issues appendix** rather than scattering them.
+- **No model scores / result tallies** in docs (those are tracked separately);
+  results-interpretation and formatting guidance is fine.
+- Convert relative dates to absolute; keep examples runnable.
+
+### Lens E — reuse / simplification / efficiency / altitude
+
+- **Reuse:** new code re-implementing an existing helper (Grep shared/utility
+  modules and adjacent files; name the helper to call).
+- **Simplification:** redundant/derivable state, copy-paste variants, dead code.
+- **Efficiency:** redundant I/O, sequential work that could be independent,
+  blocking work added to a hot path; closures capturing large scopes.
+- **Altitude:** special cases bolted onto shared infrastructure where generalizing
+  the underlying mechanism is the deeper fix (e.g. fixing repo-path isolation once
+  in `RunEnv` + a prompt token, instead of per-task patches).
+
+### Lens F — code conventions (agent-instruction files)
+
+For Python, enforce the docstring rules from the governing agent-instruction file
+(e.g. the user's Google-style rules: purpose; `Args`/
+`Returns`/`Attributes`; `Raises`; concise, no implementation narration). Flag a
+convention violation only when you can quote the exact rule and the exact line.
+
+---
+
+## Phase 3 — Verify candidates
+
+Dedup candidates that point at the same line/mechanism. For each survivor, decide
+one of three states (run an independent verifier pass for non-obvious ones — a
+sub-task/subagent if your harness supports one, otherwise re-check it yourself;
+for parallel-safety, the verifier should try to *refute* by finding the isolation
+that already covers it — by reading code, not by running evals):
+
+- **CONFIRMED** — name the inputs/state and the wrong output/crash; quote the line.
+- **PLAUSIBLE** — mechanism is real, trigger depends on env/config/composition
+  (common for parallel findings: "fires only if the batch also contains task X").
+  State what would confirm it.
+- **REFUTED** — guarded elsewhere or factually wrong; quote the proof (e.g. the
+  resolver that injects the per-run value, or the `count = ... != "" ? 1 : 0`).
+
+Keep CONFIRMED and PLAUSIBLE. Correctness bugs outrank cleanup/altitude/docs when
+trimming.
+
+---
+
+## Phase 4 — Present the review
+
+Do **not** dump raw JSON. Write a readable review:
+
+1. **Overview** — 2–3 sentences on what the change does and how it interacts with
+   the parallel-isolation model.
+2. **Findings**, most-severe first, each as
+   `file:line — summary (failure scenario)`. For parallel findings, state the
+   **triggering axis** and whether `RunEnv` already covers it.
+3. **Cleared** — a short list of things you checked and found safe (so the author
+   knows the coverage), e.g. "cluster name + KUBECONFIG isolation inherited from
+   RunEnv ok".
+4. **Systemic note** (when applicable) — if several findings share a root cause,
+   recommend the seam-level fix once rather than per-site patches.
+
+Scale effort to the ask: a quick "is this parallel-safe?" wants the B-lens
+checklist and a verdict; "comprehensive review" wants all lenses and a fuller
+findings list. If nothing survives verification, say so plainly. Remember the
+scope guardrail: present findings; never run the benchmark to produce them.

--- a/.agents/skills/run-eval/SKILL.md
+++ b/.agents/skills/run-eval/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: run-eval
+description: >
+  Use when the user wants to run a single evaluation — one Task on one Model with
+  one AgentConfig — on the GKE eval bastion or this host, e.g. "run secret-rotation
+  on gemini-3.1-pro-preview", "run one eval", "evaluate <task> with <model>", "kick
+  off a single eval run", "run this task once and watch it". Drives the whole
+  lifecycle for that one run: gather the spec + credentials, ensure a clean runner,
+  launch it detached, monitor with recovery, then summarize and diagnose. For more
+  than one Task/Model/AgentConfig combo, use `run-parallel-evals` instead. Inherits
+  the same recovery (RESUME_STAMP re-attach) and opt-in hands-off / self-healing
+  modes, which it reuses from the parallel skill's reference files.
+---
+
+# Run a single eval
+
+Orchestrate **one** eval run (one Task × one Model × one AgentConfig) end to end:
+set up env + credentials, ensure a clean runner, launch the run detached, babysit it
+with recovery, then deliver a result summary with failure analysis.
+
+## Relationship to `run-parallel-evals`
+
+A single run **is a 1×1×1 matrix** — it uses the exact same wrappers
+(`scripts/bastion/run_matrix.sh`, `run_matrix_legacy.sh`, `_matrix_lib.sh`) with one
+task, one model, one config. So this skill does **not** add scripts or new recovery
+machinery; it reuses the parallel skill's. The only difference is a leaner front-end:
+no concurrency (`MAX_PARALLEL`), no combo-count math, and no cross-combo
+parallel-safety pre-flight.
+
+**Reused as-is from `run-parallel-evals` (read there, don't duplicate):**
+- `.agents/skills/run-parallel-evals/SKILL.md` — *Harness portability*, *Execution
+  mode*, **Phase 2** (credentials), **Phase 3** (clean environment), the **Phase 5**
+  infra-flake-vs-real-failure classification, and the **Phase 6** scoring mechanics.
+- `docs/bastion.md` — bastion architecture, provisioning, per-run isolation. If
+  `docs/parallel-evals.md` is present, it is the fuller operational runbook +
+  failure-mode table; otherwise the classification inline in the parallel skill's
+  Phases 5–6 is the source of truth.
+
+This file states only what is **specific to a single run**. When a phase below says
+"same as the parallel skill," go read that phase there.
+
+**If the user actually wants more than one combo** (multiple tasks/models/configs, a
+comparison, a matrix), stop and use `run-parallel-evals` instead — it adds the
+concurrency, combo math, and cross-combo parallel-safety this skill deliberately omits.
+
+---
+
+## Modes & progressive disclosure
+
+Keep context lean: **this file is the standard single run** (Phases 1–6, you drive
+directly). The recovery/hands-off and self-healing capabilities live in the **parallel
+skill's** `references/` — read them only when the request calls for them:
+
+| If the user wants… | Read (when you reach it) | Default |
+|---|---|---|
+| A normal single run | nothing extra — Phases 1–6 below | — |
+| A long / hands-off run that "must not stop", "watch it", "stay alive" | `.agents/skills/run-parallel-evals/references/resilient-monitoring.md` — tiered-subagent monitoring + API-error recovery + keepalive. For one combo it degenerates to **one** analyzer + the keepalive loop. Read **before Phase 4** of any real (non-`DRY_RUN`) launch. | **on** for real runs |
+| "unlimited", "keep going until it passes", "auto-fix and restart", self-healing | `.agents/skills/run-parallel-evals/references/unlimited-mode.md` — diagnose → fix in a worktree → re-sync → restart the run → repeat (capped). | **off** — explicit opt-in only |
+
+Resolve the mode in Phase 1. If neither special mode applies, ignore the reference files.
+
+---
+
+## Harness portability & execution mode
+
+This skill is **agent/harness-agnostic** and **local by default; remote is opt-in** —
+identical to the parallel skill. Rather than duplicate them, see the *Harness
+portability* and *Execution mode* sections in
+`.agents/skills/run-parallel-evals/SKILL.md`. The essentials:
+
+- It needs only a **shell on the runner host** — *this host* by default (local
+  `nohup`, no ssh/sync, outputs in `~/matrix-runs/<stamp>`), or set **`BENCH_REMOTE=1`**
+  (+ the `BASTION_*` env) to sync to the bastion and run there over ssh.
+- Tool names like `Agent` / `ScheduleWakeup` are **examples** — substitute your
+  harness's equivalent (sub-task, scheduler, durable state, ask-the-user).
+- The snippets below show the **remote** form `ssh <bastion> '<cmd>'`; in **local
+  mode drop the `ssh <bastion>` wrapper** — the paths are the same on this host.
+- Durable run state lives on the runner host (`RESUME_STAMP`), so even a bare harness
+  (one shell, no sub-tasks) can drive and re-attach to a run.
+
+---
+
+## Phase 1 — Gather the single-run spec
+
+**First, always ask: local or remote?** (local runs on this host, the default; remote
+sets `BENCH_REMOTE=1` + the `BASTION_*` connection env.) Then pin down exactly the one
+run. Ask the user (your harness's clarify path) for anything not given; don't guess on
+the dimensions that cost a cluster + time. You need:
+
+1. **Task** — one `*/task.yaml` path (`MATRIX_TASKS="complextasks/secret-rotation/task.yaml"`).
+2. **Model** — one model (`MATRIX_MODELS="gemini-3.1-pro-preview"`).
+3. **Agent config** — refactored arm only: one `MATRIX_AGENT_CONFIGS`, e.g.
+   `gcli+mcp+skills` or `oc+mcp+skills` (`oc|gcli` `[+mcp][+skills]`).
+4. **Arm** — refactored (`run_matrix.sh`) **or** legacy (`run_matrix_legacy.sh`,
+   oc-only). One run = one arm.
+5. **Auth mode** — API-key vs **Vertex/ADC** (`BENCH_VERTEX=1`). If unsure, recommend
+   Vertex (no key handling, VM-SA ADC).
+
+State the **rough wall-clock** (≈25–40 min for an infra-bearing task like
+secret-rotation; less for a lightweight task) so the user can confirm before you spend
+a cluster. Then run with `DRY_RUN=1` to show the expanded (single) combo before the
+real launch.
+
+**Single-run safety (much lighter than the matrix pre-flight):**
+- **Never launch a second run of the same task+model+config concurrently** —
+  run-id-derived cluster names are reused (safe only because the prior run tore down
+  first). Different task/model/config is fine to run alongside.
+- If the task is **infra-bearing**, skim its stack/scripts (or run the
+  `devops-bench-review` skill on it) for self-collisions that bite even one run — e.g.
+  it seeds a fixed `$HOME` repo (`~/<task>-repo.git`) and `rm -rf`s it, or grants the
+  shared VM SA a project role it then revokes on teardown. The cross-*combo* hazards
+  the parallel skill lists (node-SA prefix collapse, duplicate `task_id`s, host
+  capacity across `MAX_PARALLEL`) don't apply to a single run.
+
+Note: **legacy + gemini CLI is not parallel-safe**, but a single run is not parallel,
+so either arm is fine here.
+
+---
+
+## Phase 2 — Credentials & environment
+
+**Same as the parallel skill's Phase 2** — see
+`.agents/skills/run-parallel-evals/SKILL.md`. In brief:
+
+- **Remote mode only:** export the connection env (`BASTION_USE_GCPNODE=1`,
+  `BASTION_VM`, `BASTION_ZONE`, `BASTION_PROJECT`, `GCP_PROJECT_ID`). Skip for local.
+- **API-key mode:** the runner sources `~/secrets.env` (must export `AGENT_API_KEY`,
+  `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `JUDGE_API_KEY`). Check names only — **never
+  print key values**; ask the user for a missing key (or have them paste with `!`).
+- **Vertex mode (`BENCH_VERTEX=1`):** no keys. Verify VM-SA roles, gemini
+  folder-trust (`security.folderTrust.enabled=false`), and for the **legacy oc** arm
+  the `google-vertex` provider (`scripts/bastion/configure-oc.sh --vertex` once). The
+  default `JUDGE_MODEL=gemini-3.1-pro` **404s on Vertex** — set
+  `JUDGE_MODEL=gemini-3.1-pro-preview` and `AGENT_PROVIDER=google-vertex`.
+- For legacy capabilities run `configure-oc.sh --mcp --skills` (or
+  `--no-mcp --no-skills`) once before launching.
+
+---
+
+## Phase 3 — Connect and ensure a clean environment
+
+**Same as the parallel skill's Phase 3.** Even for one run this matters — a stale
+process or a leftover GCP resource from a prior aborted run will `409` your launch.
+
+1. **Connectivity:** `ssh <bastion> 'echo OK; oc --version; gemini --version'`
+   (transient `exit 255` is a gcpnode blip — retry).
+2. **No stale processes:**
+   `ssh <bastion> 'pgrep -af "matrix-runner|evaluate.py|devops_bench|oc agent" | grep -v pgrep'`.
+3. **No leftover GCP resources** for this run's shape (clusters, `gke-nodes-*` SAs,
+   `sa-secret-rotation-*`, `db-credentials`) — Phase-3 `gcloud` checks in the parallel
+   skill. Delete confirmed orphans, **especially `gke-nodes-*` SAs**.
+4. **Prereqs present:** `~/gke-mcp`, `~/oc-skills/` (if skills), `~/devops-bench/.venv`;
+   else `scripts/bastion/vm-setup.sh`.
+
+---
+
+## Phase 4 — Launch the single run (detached)
+
+> **Hands-off run? (default for real runs)** Read
+> `.agents/skills/run-parallel-evals/references/resilient-monitoring.md` first and run
+> the keepalive + recovery loop (for one combo: one monitor tick, one analyzer on
+> finish). The inline path below is the direct foreground form.
+
+Drive the wrapper with the **single** task/model/config — a 1×1×1 matrix. By default
+it runs locally (detached `nohup`); with `BENCH_REMOTE=1` it syncs to the bastion and
+launches detached over ssh, then polls. Run it as a **background job** so you keep
+control. Example (Vertex, refactored arm):
+
+```bash
+# local by default; prefix BENCH_REMOTE=1 (+ BASTION_* env) to run on the bastion
+BENCH_VERTEX=1 AGENT_PROVIDER=google-vertex \
+JUDGE_PROVIDER=google JUDGE_MODEL=gemini-3.1-pro-preview \
+MATRIX_TASKS="complextasks/secret-rotation/task.yaml" \
+MATRIX_MODELS="gemini-3.1-pro-preview" \
+MATRIX_AGENT_CONFIGS="gcli+mcp+skills" \
+RESULTS_DIR="results/<label>" \
+  scripts/bastion/run_matrix.sh
+```
+
+(Legacy arm: `run_matrix_legacy.sh`, oc-only, no `MATRIX_AGENT_CONFIGS`. `MAX_PARALLEL`
+is irrelevant for one combo — leave it default.)
+
+**Capture the `STAMP`** the wrapper prints (`RESUME_STAMP=<stamp>`) — it's your handle
+for monitoring, retry, and re-attach. Record it in durable state (task list or notes
+file) so you survive a context reset. Outputs live on the runner host at
+`~/matrix-runs/<stamp>/<rid>/` (`run.log`, `status`); `~/matrix-runs/<stamp>/.done`
+appears when it finishes. **If your poller dies, the run continues** (detached) —
+re-attach with `RESUME_STAMP=<stamp>` and the same command.
+
+---
+
+## Phase 5 — Monitor + recover
+
+Check on an interval (every ~3–5 min for an infra-bearing task); **don't busy-poll**.
+
+```bash
+ssh <bastion> 'd=~/matrix-runs/<stamp>/*/; \
+  echo "status=$(cat $d/status 2>/dev/null || echo running) \
+        last=$(tail -1 $d/run.log 2>/dev/null | cut -c1-80)"; \
+  test -f ~/matrix-runs/<stamp>/.done && echo ALL_DONE'
+```
+
+Classify the run:
+- **Running** — no `status` file, runner process alive. Leave it.
+- **Finished** — `status` is `exit=<rc>`. `rc=0` ran to completion (score in Phase 6);
+  `rc!=0` the harness errored (diagnose in Phase 6).
+- **Aborted / flaked** — no `status` **and** no live process, or an **infra** error in
+  `run.log`. Retry case.
+
+**Infra flake vs real failure** — use the parallel skill's Phase-5 classification
+(`.agents/skills/run-parallel-evals/SKILL.md`):
+- **Infra flake → clean + retry:** tofu/provision failure, `409 already exists`
+  (orphaned `gke-nodes-*` SA), GKE quota/transient API error, SSH/relay drop, node-pool
+  timeout.
+- **Real failure → do NOT retry, analyze:** auth/config errors (`No API key`, `401`,
+  Vertex `404`, missing `--approval-mode`), or the agent ran but scored low (model
+  capability), or task-logic failure.
+
+**Retry procedure** (cap 2; log every retry):
+1. Kill any lingering process for the run on the VM.
+2. `rm -rf ~/matrix-runs/<stamp>/<rid>`.
+3. Clean its leaked GCP resources: cluster (`c<hash>-eval`), `gke-nodes-<hash>` SA, any
+   `sa-secret-rotation-*` / `db-credentials-*` (Phase-3 commands).
+4. Re-launch the **same single run** (new `STAMP`, `SKIP_SYNC=1` after a real sync).
+   Track the new stamp.
+
+If the detached runner itself died (no `.done`, no live process), re-attach with
+`RESUME_STAMP`; if truly dead, relaunch.
+
+> **Unlimited / self-healing mode?** Only if the user opted in: a *real* (non-flake)
+> failure from a task/code bug is not the end — read
+> `.agents/skills/run-parallel-evals/references/unlimited-mode.md` and follow
+> diagnose → fix → re-sync → restart instead of just reporting it.
+
+**Keepalive (hands-off run):** under a harness that may classify the session done,
+never emit a completion / `result:` / "done" line until the run is terminal **and**
+summarized; each tick emit a one-line `still working: running / done / flaked` status
+and schedule the next wake (see `resilient-monitoring.md`).
+
+---
+
+## Phase 6 — Summarize the result + diagnose
+
+When the run has a terminal `status` (or `.done`), pull results (the wrapper does this
+on normal exit; else `RESUME_STAMP=<stamp>` re-run to pull) and report:
+
+**task · model · agent-config · arm · auth-mode · exit · score · #MCP-tool-calls ·
+pass/fail checks.** Scoring mechanics are the **same as the parallel skill's Phase 6**:
+
+```bash
+grep -c 'Pass Rate: 100.0%' <run>/run.log   # passed checks
+grep -c 'Pass Rate: 0.0%'   <run>/run.log   # failed checks
+grep -oiE 'mcp_[a-z0-9_-]+|run_shell_command|activate_skill' <run>/run.log | sort | uniq -c
+```
+`results.json` is a **list** of per-criterion objects (`{name, score, success,
+reason}`); refactored nests under `run_<ts>_<rid>/results.json`, legacy copies
+`results/run_<ts>_<rid>` into the run dir. Beware grep false positives (bare
+`401`/`quota` match terraform output) — anchor on `invalid_api_key`,
+`ProviderAuthError`, `No API key`, `^OK$`.
+
+**If the run did not pass / errored**, give an analysis: what happened (quote the
+decisive log line, redacting secrets), the **root cause** (map to the failure table /
+parallel-skill Phase 6 — e.g. `exit -1` = **timeout** not crash; Vertex `404` = wrong
+location/model), **model vs harness** (clean trajectory + low score = model; early
+abort / auth error = harness/config), and the **concrete fix / next step**.
+
+Then **verify teardown is clean** (Phase-3 GCP checks — zero leftover cluster /
+`gke-nodes-*` / `sa-secret-rotation-*` / `db-credentials-*`) and report any residue.
+
+**Record any new failure mode** (same as the parallel skill) — a symptom → root cause →
+fix row in the failure-mode table for an operational flake, or a known-issues bullet for
+a structural gap, in `docs/bastion.md` (or `docs/parallel-evals.md` if present).
+Terse, no duplication, follow the docs conventions (scope + user-guide, GFM, no model
+scores).
+
+End with: the run's exit, score, pass/fail checks, and — if it didn't pass — the root
+cause + fix.
+
+---
+
+## Guardrails
+
+- One run still costs a real GKE cluster + ~25–40 min. Confirm scale and use
+  `DRY_RUN=1` first.
+- Never print or commit API keys; redact secrets in summaries.
+- Never launch a second run of the **same** task+model+config concurrently (cluster
+  name reuse).
+- Always confirm clean teardown — orphaned `gke-nodes-*` SAs silently `409` the next run.
+- Cap retries (≤2) and surface a persistent failure rather than looping.
+- Capture every **new** failure mode in the docs appendix (Phase 6) so learnings accrue.
+- Prefer leaving the run detached + re-attaching via `RESUME_STAMP` over a fragile
+  foreground SSH session.
+- **Hands-off run:** don't let an idle/completion classifier stop the job mid-run —
+  emit periodic progress, signal completion only when the run is terminal and summarized.
+- **Progressive disclosure:** read a `references/*.md` file only when its mode applies.
+- **Wrong tool?** If the request grows to multiple combos, switch to `run-parallel-evals`.

--- a/.agents/skills/run-parallel-evals/SKILL.md
+++ b/.agents/skills/run-parallel-evals/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: run-parallel-evals
+description: >
+  Use when the user wants to run a parallel evaluation matrix (Task × Model ×
+  AgentConfig) on the GKE eval bastion — e.g. "run a parallel eval matrix",
+  "run these evals on the bastion", "run the matrix for <tasks/models>",
+  "kick off a Vertex eval run", "compare legacy vs refactored on the bastion".
+  Drives the whole lifecycle: gather the matrix spec + credentials, set up the
+  bastion cleanly, launch the detached run, monitor and retry infra flakes, then
+  summarize results and diagnose failures. Supports delegated tiered-subagent monitoring and an opt-in unlimited/self-healing mode, loaded from reference files only when requested.
+---
+
+# Run parallel evals on the bastion
+
+Orchestrate a parallel eval-matrix run on the GCE bastion end to end. You set up
+env + credentials, ensure a clean VM, launch the matrix detached, babysit it
+(retrying infra flakes), then deliver a results summary with failure analysis.
+
+**Read these first — they are the source of truth; do not duplicate their content
+from memory:**
+- `docs/parallel-evals.md` — the runbook: env vars, Vertex/ADC setup, MCP setup,
+  isolation, the **operational runbook**, and the **failure-mode → fix table**.
+- `docs/bastion.md` — bastion architecture, provisioning, per-run isolation.
+
+The scripts you drive: `scripts/bastion/run_matrix.sh` (refactored arm),
+`scripts/bastion/run_matrix_legacy.sh` (legacy/oc arm), and the shared
+`scripts/bastion/_matrix_lib.sh`. `DRY_RUN=1` previews any matrix without
+provisioning — use it to validate the expansion before a real run.
+
+Work through the phases in order. Don't skip the clean-environment or
+credentials phases — they are the most common cause of wasted multi-hour runs.
+
+
+---
+
+## Modes & progressive disclosure
+
+Keep context lean: **this file is the standard run** (Phases 1–6, you drive
+directly). Two heavier capabilities live in `references/` — read them **only** when
+the request calls for them, and don't pull both in for a plain run.
+
+| If the user wants… | Read (when you reach it) | Default |
+|---|---|---|
+| A normal matrix run | nothing extra — Phases 1–6 below | — |
+| A long / hands-off run that "must not stop", "monitor with subagents", "stay alive" | `references/resilient-monitoring.md` — tiered-subagent monitoring + API-error recovery + background-classifier keepalive. Read **before Phase 5** of any real (non-`DRY_RUN`) launch. | **on** for real runs |
+| "unlimited", "keep going until it finishes", "auto-fix and restart", self-healing | `references/unlimited-mode.md` — diagnose → fix in a worktree → re-sync → restart failed combos → repeat. | **off** — explicit opt-in only |
+
+Resolve the mode in Phase 1 (ask if it's ambiguous for a long/expensive matrix). If
+neither special mode applies, ignore the reference files entirely.
+
+
+---
+
+## Harness portability
+
+This skill is **agent/harness-agnostic** — it runs under any coding agent (Claude
+Code, Antigravity/Gemini, Codex, …). It needs only a **shell on the runner host** — local by default, or `ssh` to the
+bastion in remote mode (Antigravity: the `run_command` tool); everything else is an optimization. Map each capability used below to
+whatever your harness provides, and degrade gracefully if it lacks one:
+
+| Capability | Claude Code | Antigravity | Other / fallback |
+|---|---|---|---|
+| Sub-task | `Agent` | `invoke_subagent` | subagent/`task`; else inline |
+| Model tiers | Haiku / Sonnet / Opus | `/models` (Flash / Pro) | mini / standard |
+| Background run | `run_in_background` | `manage_task` | async; else poll |
+| Timer / wake | `ScheduleWakeup` | `schedule` | scheduler; else `sleep` |
+| Durable state | task list | Artifacts / `write_to_file` | notes file |
+| Isolated worktree | `EnterWorktree` | `run_command` | `git worktree add` |
+| Ask the user | `AskUserQuestion` | `ask_question` | ask in chat |
+| Keepalive | progress, no early "done" | same | same |
+
+Each cell names **one primitive** — assume your harness chains the supporting
+calls (args, follow-ups, file reads) from it; the full Antigravity set is in the
+footnote below.
+
+Throughout this skill and its `references/`, tool names like `Agent` or
+`ScheduleWakeup` are **examples**, not requirements — substitute your harness's
+equivalent. Durable run state lives on the **bastion** (`RESUME_STAMP`), so even a
+bare harness (one shell, no sub-tasks, no scheduler) can drive a run by polling.
+
+**Antigravity tools** (the actual agent tool set, confirmed from a live Antigravity instance — the public [hooks docs](https://antigravity.google/docs/hooks) render client-side): files `view_file` · `list_dir` · `grep_search` · `write_to_file` · `replace_file_content` · `multi_replace_file_content`; exec `run_command` · `ask_permission` · `list_permissions`; web `search_web` · `read_url_content`; subagents/background `invoke_subagent` · `define_subagent` · `manage_subagents` · `send_message` · `manage_task` · `schedule`; interaction `ask_question` · `generate_image`. Hooks match these by tool name on `PreToolUse` / `PostToolUse` (config in `.agents/hooks.json`).
+
+---
+
+## Execution mode
+
+**Local by default; remote is opt-in.** The matrix runs on the **runner host** —
+the machine where you invoke the wrapper. By default that's *this host* (local
+`nohup`, no ssh/sync, outputs in `~/matrix-runs/<stamp>`). Set **`BENCH_REMOTE=1`**
+(plus the `BASTION_*` connection env) to sync the tree to the bastion and run
+there over ssh, pulling results back.
+
+**Command convention:** the snippets below show the **remote** form,
+`ssh <bastion> '<cmd>'`. In **local mode, drop the `ssh <bastion>` wrapper** and
+run `<cmd>` directly — the paths (`~/secrets.env`, `~/.kube`,
+`~/matrix-runs/<stamp>`) are the same, just on this host. `RESUME_STAMP` and
+`DRY_RUN` behave identically in both modes.
+
+---
+
+## Phase 1 — Gather the matrix spec
+
+**First, always ask: local or remote?** (see *Execution mode*) — local runs on
+this host (default); remote sets `BENCH_REMOTE=1` + the `BASTION_*` connection
+env. Then determine exactly what to run. Ask the user (your harness's clarify path — see *Harness portability*) for
+anything not given;
+do not guess on dimensions that cost clusters/time. You need:
+
+1. **Tasks** — `MATRIX_TASKS` (space-separated `*/task.yaml` paths, or `ALL`).
+2. **Models** — `MATRIX_MODELS` (e.g. `gemini-3.1-pro-preview gemini-3.5-flash`).
+3. **Agent configs** — refactored arm only: `MATRIX_AGENT_CONFIGS`, each
+   `oc|gcli` `[+mcp][+skills]` (e.g. `gcli+mcp+skills oc+mcp+skills`).
+4. **Arm(s)** — refactored (`run_matrix.sh`), legacy (`run_matrix_legacy.sh`,
+   oc-only), or both in parallel.
+5. **Auth mode** — API-key vs **Vertex/ADC** (`BENCH_VERTEX=1`). If unsure,
+   recommend Vertex (no key handling, VM-SA ADC).
+6. **Concurrency** — `MAX_PARALLEL` (default 3). Each combo provisions its own
+   cluster; mind project quota. Count combos = tasks × models × configs.
+
+Compute and **state the combo count and rough wall-clock** (≈25–40 min/combo for
+infra-bearing tasks like secret-rotation) before launching, so the user can
+confirm scale. Then run with `DRY_RUN=1` and show the expanded matrix.
+
+Note the parallel-safety rule (see `docs/parallel-evals.md`): **legacy + gemini
+CLI is not parallel-safe** — for parallel gemini, use the refactored arm.
+
+**Pre-flight the matrix tasks for parallel hazards** before a real run — a doomed
+combo wastes a cluster + ~30 min. Skim each selected task's stack/scripts (or run
+the `devops-bench-review` skill on it) against the per-run isolation gaps in
+`docs/parallel-evals.md` (known-issues appendix). The ones that bite a matrix:
+- a task that seeds a fixed `$HOME` repo (`~/<task>-repo.git`) and `rm -rf`s it —
+  unsafe once the matrix repeats that task across models/configs;
+- a multi-cluster stack whose node-SA name collapses under the run-token prefix;
+- a per-task stack that grants a project role to the shared VM SA (teardown
+  clobber across concurrent GKE combos);
+- duplicate `task_id`s among the selected tasks (ambiguous reporting);
+- host capacity: sum kind clusters / disk / inotify across `MAX_PARALLEL`.
+
+Never run two of the **same** combo at once — run-id-derived cluster names are
+reused (safe only because the prior run tore down first).
+
+---
+
+## Phase 2 — Credentials & environment
+
+Set the **connection env** (**remote mode only** — same as `sync-to-bastion.sh`;
+skip it entirely for a local run):
+
+```bash
+export BASTION_USE_GCPNODE=1 BASTION_VM=bench-bastion \
+       BASTION_ZONE=us-central1-a BASTION_PROJECT=<proj> GCP_PROJECT_ID=<proj>
+```
+
+**API-key mode:** the remote runner sources `~/secrets.env` on the VM, which must
+export `AGENT_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `JUDGE_API_KEY`.
+Check it exists and has the needed keys (names only — **never print key values**):
+
+```bash
+ssh <bastion> 'grep -oE "^[A-Z_]+=" ~/secrets.env | sort -u'
+```
+
+If a required key is missing, **ask the user for it** (your harness's clarify path) (or have
+them paste it with the `!` prefix so it isn't echoed), then append it to
+`~/secrets.env` on the VM. Treat keys as secrets: don't log them, don't commit
+them, redact in any summary.
+
+**Vertex mode (`BENCH_VERTEX=1`):** no API keys needed. Verify prereqs instead:
+- VM SA has `roles/aiplatform.user` (+ `container.admin`, `secretmanager.admin`).
+- gemini folder-trust: `~/.gemini/settings.json` has
+  `security.folderTrust.enabled=false` (else MCP won't load). `vm-setup.sh` sets
+  it; if absent, run `vm-setup.sh` or write it.
+- For the **legacy oc** arm on Vertex: the `google-vertex` provider must be
+  registered — run `scripts/bastion/configure-oc.sh --vertex` once.
+- `_matrix_lib.sh` defaults `JUDGE_MODEL=gemini-3.1-pro`, which **404s on
+  Vertex** — always set `JUDGE_MODEL=gemini-3.1-pro-preview` and
+  `AGENT_PROVIDER=google-vertex`. Location is `global` (handled by `BENCH_VERTEX`).
+
+If the legacy arm needs capabilities, run `configure-oc.sh --mcp --skills`
+(or `--no-mcp --no-skills` for a clean no-capability run) once before launching.
+
+---
+
+## Phase 3 — Connect and ensure a clean environment
+
+1. **Connectivity:** `ssh <bastion> 'echo OK; oc --version; gemini --version'`.
+   Transient `exit 255` is a gcpnode/cert blip — retry a couple times.
+2. **No stale processes:** check for and kill leftover runners/agents from prior
+   aborted runs:
+   ```bash
+   ssh <bastion> 'pgrep -af "matrix-runner|evaluate.py|devops_bench|oc agent" | grep -v pgrep'
+   ```
+3. **No leftover GCP resources** (a prior failed teardown can `409` your run):
+   ```bash
+   gcloud container clusters list --project <proj>
+   gcloud iam service-accounts list --project <proj> | grep -E 'gke-nodes-|sa-secret-rotation-'
+   gcloud secrets list --project <proj> | grep db-credentials
+   ```
+   If anything is left over, confirm it isn't from another active run, then delete
+   it — **especially the easy-to-miss `gke-nodes-*` SAs** (their orphaning is a
+   known bug; see `docs/parallel-evals.md`).
+4. **Prereqs present:** `~/gke-mcp` (executable), `~/oc-skills/` (if using skills),
+   `~/devops-bench/.venv`. If missing, run `scripts/bastion/vm-setup.sh`.
+
+---
+
+## Phase 4 — Launch the matrix (detached)
+
+By default the wrappers run the matrix **locally** (detached `nohup` on this
+host). With `BENCH_REMOTE=1` they sync the working tree to the bastion, upload a
+runner, and launch it detached over ssh, then poll. To run **both arms in parallel**: sync
+once, then start each wrapper with `SKIP_SYNC=1`, staggered ~5s so their
+second-resolution `STAMP`s differ.
+
+Run each wrapper as a **background job** so you keep control to monitor. Build the
+env from Phase 1–2, e.g. Vertex refactored:
+
+```bash
+# local by default; prefix BENCH_REMOTE=1 (+ BASTION_* env) to run on the bastion
+BENCH_VERTEX=1 AGENT_PROVIDER=google-vertex \
+JUDGE_PROVIDER=google JUDGE_MODEL=gemini-3.1-pro-preview \
+MAX_PARALLEL=<n> MATRIX_TASKS="..." MATRIX_MODELS="..." \
+MATRIX_AGENT_CONFIGS="..." RESULTS_DIR="results/<label>" \
+  scripts/bastion/run_matrix.sh
+```
+
+**Capture the `STAMP`** each wrapper prints (`RESUME_STAMP=<stamp>`). It is your
+handle for monitoring, retry, and re-attach. Record it (and the combo list) in durable state (a
+task list or a notes file) so you survive a context reset. Outputs live on the runner host at
+`~/matrix-runs/<stamp>/<rid>/` (`run.log`, `status`); a `~/matrix-runs/<stamp>/.done`
+marker appears when all combos finish.
+
+If your poller dies, the run continues (detached on the runner host) — re-attach
+with `RESUME_STAMP=<stamp>` and the same command.
+
+---
+
+## Phase 5 — Monitor periodically + retry infra flakes
+
+> **Long or hands-off run? (default for real runs)** Read
+> `references/resilient-monitoring.md` and delegate polling/analysis to tiered
+> subagents — a cheap model (Haiku / Flash-low) polls, a mid model (Sonnet /
+> Flash-medium) analyzes finished combos, you supervise and re-spawn on API errors.
+> It also covers keeping the background job from being classified as finished
+> mid-run. The inline steps below are the direct (small-matrix / foreground) path.
+
+Check progress on an interval (every ~3–5 min for infra-bearing tasks). **Don't
+busy-poll**; sleep between checks. Per tick, inspect each combo:
+
+```bash
+ssh <bastion> 'for d in ~/matrix-runs/<stamp>/*/; do
+  echo "$(basename $d): status=$(cat $d/status 2>/dev/null || echo running) \
+        last=$(tail -1 $d/run.log 2>/dev/null | cut -c1-80)"; done
+ssh <bastion> 'test -f ~/matrix-runs/<stamp>/.done && echo ALL_DONE'
+```
+
+Classify each combo:
+- **Running** — no `status` file, runner process alive. Leave it.
+- **Finished** — `status` is `exit=<rc>`. `rc=0` = ran to completion (score
+  separately); `rc!=0` = the harness errored (diagnose in Phase 6).
+- **Aborted / flaked** — no `status` **and** no live process, or `run.log` shows
+  an **infra** error. This is the retry case.
+
+**Distinguish infra flake from real failure** (consult the failure-mode table in
+`docs/parallel-evals.md`):
+- **Infra flake → clean + retry:** tofu apply/provision failure, `409 already
+  exists` (orphaned `gke-nodes-*` SA), GKE quota/transient API error, SSH/relay
+  drop that killed the runner, node pool creation timeout.
+- **Real failure → do NOT retry, analyze:** auth/config errors (`No API key`,
+  `401`, Vertex `404`, missing `--approval-mode`), agent ran but scored low
+  (model capability), task-logic failures. Retrying won't help; fix config or
+  report.
+
+**Retry procedure** for a flaked combo (cap at 2 retries; log every retry —
+never silently drop a combo):
+1. Kill any lingering process for that combo on the VM.
+2. Delete its remote run dir: `rm -rf ~/matrix-runs/<stamp>/<rid>`.
+3. Clean leaked GCP resources for it: its cluster (`c<hash>-eval`), the matching
+   `gke-nodes-<hash>` SA, and any `sa-secret-rotation-*` / `db-credentials-*`
+   left behind (Phase 3 commands).
+4. Re-launch **just that combo** as a fresh single-combo matrix (same task/model/
+   config, new `STAMP`, `SKIP_SYNC=1`). Track the new stamp.
+
+If the **whole** detached runner died (no `.done`, no live process, partial
+combos), re-attach with `RESUME_STAMP`; if that shows it's truly dead, relaunch
+the unfinished combos.
+
+> **Unlimited / self-healing mode?** If (and only if) the user opted in, a *real*
+> (non-flake) failure caused by a task/code bug is not the end — read
+> `references/unlimited-mode.md` and follow diagnose → fix → re-sync → restart
+> instead of just reporting it.
+
+---
+
+## Phase 6 — Summarize results + diagnose failures
+
+When every combo has a terminal `status` (or `.done` is present), pull results
+(the wrapper does this on its normal exit; otherwise `RESUME_STAMP=<stamp>` re-run
+to pull) and produce a **comprehensive summary**.
+
+For each combo report: **task · model · agent-config · arm · auth-mode · exit ·
+score · #MCP-tool-calls · pass/fail checks**. Read scores from the pulled
+results:
+
+```bash
+# per-check pass/fail
+grep -c 'Pass Rate: 100.0%' <combo>/run.log   # passed
+grep -c 'Pass Rate: 0.0%'   <combo>/run.log   # failed
+# tool usage (MCP shows as mcp_<server>_<tool>)
+grep -oiE 'mcp_[a-z0-9_-]+|run_shell_command|activate_skill' <combo>/run.log | sort | uniq -c
+```
+`results.json` is a **list** of per-criterion objects (`{name, score, success,
+reason}`). Refactored results nest under `run_<ts>_<rid>/results.json`; legacy
+writes `results/run_<ts>_<rid>` copied into the combo dir.
+
+Beware grep false positives: bare `401`/`quota` match terraform output
+(`92401222`, `cpu_cfs_quota`). Anchor on `invalid_api_key`, `ProviderAuthError`,
+`No API key`, `^OK$`.
+
+**For every non-passing / errored combo, give an analysis:**
+- What happened (quote the decisive log line, redacting secrets).
+- **Root cause** — map it to an entry in the `docs/parallel-evals.md` failure
+  table where possible (e.g. `exit -1` = a **timeout**, not a crash;
+  `No API key` under isolation = the sqlite-store vs `GOOGLE_CLOUD_API_KEY`
+  marker issue; Vertex `404` = wrong location/model).
+- **Whether it's the model or the harness** — a clean trajectory with a low score
+  is the model; an early abort/auth error is the harness/config.
+- **Concrete fix or next step**, and whether a retry would help.
+
+Then **verify teardown is clean** (Phase 3 GCP checks — zero leftover clusters /
+`gke-nodes-*` / `sa-secret-rotation-*` / `db-credentials-*`) and report any
+residue you couldn't remove.
+
+**Record any new failure mode** — this capture step is part of the run, not
+optional. If a combo failed in a way **not** already in the
+`docs/parallel-evals.md` failure-mode table or known-issues appendix (or the
+`docs/bastion.md` appendix for bastion-host / VM-SA issues), append it so the next
+run benefits:
+- a **symptom → root cause → fix** row in the failure-mode table for an
+  operational flake;
+- a known-issues bullet/row for a **structural** gap (isolation, naming, capacity).
+
+Keep it terse, don't duplicate an existing entry, and follow the docs conventions
+(scope + user-guide, GFM, not journal-like, no model scores).
+
+End with: total combos, passed/failed counts, best performer, the headline score
+table, and the list of failures with their root cause + fix.
+
+---
+
+## Guardrails
+
+- Each combo costs a real GKE cluster + ~25–40 min. Confirm the combo count with
+  the user before launching a large matrix; use `DRY_RUN=1` first.
+- Never print or commit API keys; redact secrets in summaries.
+- Always confirm clean teardown — orphaned `gke-nodes-*` SAs silently break the
+  next run with `409`.
+- Cap retries (≤2/combo) and surface anything still failing rather than looping.
+- Capture every **new** failure mode in the `docs/parallel-evals.md` /
+  `docs/bastion.md` appendices (see Phase 6) so learnings accrue across runs.
+- Prefer leaving the run detached + re-attaching via `RESUME_STAMP` over holding a
+  fragile foreground SSH session.
+- **Don't let an idle timeout / completion classifier stop the job mid-run** (if
+  your harness has one). A long detached
+  matrix has quiet stretches; never emit a completion / `result:` / "done" /
+  "failed" line until *every* combo is terminal and summarized. Each check-in, emit
+  a one-line "still working: N running / M done / K flaked" status and schedule the
+  next wake (see `references/resilient-monitoring.md`) rather than going silent.
+- **Progressive disclosure:** read a `references/*.md` file only when its mode
+  applies; don't load both for a plain run.

--- a/.agents/skills/run-parallel-evals/references/resilient-monitoring.md
+++ b/.agents/skills/run-parallel-evals/references/resilient-monitoring.md
@@ -1,0 +1,81 @@
+# Resilient monitoring — tiered sub-tasks + recovery
+
+Load this for a **real, long, or hands-off** matrix run (the default once you
+actually launch one). Goal: the run survives quiet stretches, sub-task failures, and
+local drops, and — on harnesses that have one — the session is never marked
+"finished" while combos are still going.
+
+This is **harness-agnostic** (see *Harness portability* in `SKILL.md`): the roles
+below are capabilities, with Claude Code tools named only as examples. The **runner host**
+(this machine in local mode, the bastion when `BENCH_REMOTE`) **is the source of
+truth** — every combo's state lives in `~/matrix-runs/<stamp>/<rid>/`
+(`status`, `run.log`) plus the pulled results. Helper sub-tasks are disposable readers
+of that state: losing one loses nothing, because a fresh one re-reads the same
+`RESUME_STAMP`. If your harness has **no** sub-tasks at all, do the monitor/analyzer
+steps inline yourself — the loop still works, just on one model.
+
+## Roles & model tiers
+
+| Role | Model tier | Cadence | Job |
+|---|---|---|---|
+| **Supervisor** | your **main/session** model | every ~5 min while combos run; longer when idle | dispatch + re-spawn helpers, decide retries, keep the session alive, never go silent |
+| **Monitor** | a **low** tier (Claude Haiku · Gemini Flash · Codex mini · …) | each tick | shell to the runner host (local, or `ssh <bastion>` when `BENCH_REMOTE`), read each combo's `status` + `run.log` tail, return a one-line-per-combo digest + an overall `running / done / flaked / .done` summary. No analysis, no log dumps. |
+| **Analyzer** | a **mid** tier (Claude Sonnet · Gemini Flash/Pro · Codex standard · …) | once per finished combo (or a small batch) | pull + read that combo's `results.json` + `run.log`; return scores + pass/fail checks + a root-cause digest if it failed |
+
+Run the monitor/analyzer as **sub-tasks that can shell out on the runner host**
+(local shell, or `ssh` / `gcloud` to the bastion in remote mode) — Claude Code: the `Agent` tool with `model:` + `subagent_type: general-purpose`;
+other harnesses: their subagent/delegation mechanism. Give each the connection env
+(`BASTION_*`, project) and the `RESUME_STAMP`, and tell it to **return a compact
+digest, not raw logs** — that keeps the supervisor's context clean (progressive
+disclosure applies to tool output too).
+
+## Supervision loop
+
+1. Launch the matrix detached (Phase 4) and capture `RESUME_STAMP`; record the stamp +
+   combo list in **durable state** (a task list or a notes file) so a context reset
+   can resume.
+2. Start the **monitor** — as a **background** sub-task if your harness supports one,
+   else a short foreground check each tick.
+3. Each supervisor tick:
+   - Read the monitor's latest digest; emit a one-line status to the user (keepalive).
+   - Newly `exit=0` combos → dispatch an **analyzer** (in parallel across them).
+   - **Flaked** combos → Phase-5 retry procedure (cap 2); or, in unlimited mode, the
+     `references/unlimited-mode.md` loop.
+   - `.done` present **and** every combo has an analyzer result → go to Phase 6.
+   - Otherwise **schedule the next wake** (a timer/cron, ~5 min while active; 20–30
+     min if genuinely idle) and end the turn — do **not** busy-loop. No scheduler?
+     `sleep` between checks in a loop.
+
+## Recovery — sub-task stuck / API error
+
+- A sub-task that dies on a terminal API error comes back as an error / empty result.
+  Either way **re-spawn a fresh one** pointed at the same `RESUME_STAMP` — no state is
+  lost.
+- Cap re-spawns (≤3 per role per tick). If a role keeps dying, **fall back to doing
+  that check yourself** (one shell digest) so the run still advances, and note the
+  degradation.
+- Whole detached runner died on the VM (no `.done`, no live process) → re-attach with
+  `RESUME_STAMP`; if truly dead, relaunch the unfinished combos.
+- Local/SSH `exit 255` is a transient relay blip — retry; the detached run is fine.
+
+## Keep the session alive (if your harness can stop it)
+
+Some harnesses watch the session and may mark it done — or time it out — during quiet
+stretches (Claude Code's background job list classifies from your message text). When
+running under one:
+- **Never** signal completion (Claude Code: a `result:` / "done" / "failed" line)
+  until *every* combo is terminal and summarized.
+- Each tick, emit a short `still working: N running / M done / K flaked` line so the
+  session stays classified as active.
+- Re-engage via a timer rather than blocking, so you don't go silent. Ask the user to
+  unblock only for a genuine blocker (e.g. a missing API key you can't supply) — and
+  in unlimited mode, avoid even that by deciding sanely.
+
+Harnesses without such a classifier can ignore this section — but emitting periodic
+progress is still good practice.
+
+## Cost discipline
+
+Poll with the cheap monitor (frequent), analyze with the mid tier (per-finish only),
+spend the main model rarely (supervise/decide). Never analyze a combo twice; prefer
+one batched analyzer when several combos finish together.

--- a/.agents/skills/run-parallel-evals/references/unlimited-mode.md
+++ b/.agents/skills/run-parallel-evals/references/unlimited-mode.md
@@ -1,0 +1,66 @@
+# Unlimited / self-healing mode
+
+Load this **only** when the user explicitly opted in ("unlimited", "keep going until
+it finishes", "auto-fix and restart", "self-healing"). It turns a *real* (non-flake)
+failure caused by a **task or code bug** into: diagnose → fix → re-sync → restart the
+failed combos → continue, until the whole matrix reaches a terminal-acceptable state.
+It builds on `references/resilient-monitoring.md` (reuse that loop + recovery +
+keepalive); this file only adds the fix-and-restart behavior. It is **harness-
+agnostic** — see *Harness portability* in `SKILL.md` for the capability mapping
+(isolated worktree, durable state, sub-tasks); tool names here are examples.
+
+## Classify before you "fix" — fixing the wrong thing corrupts the eval
+
+- **Infra flake** → retry, no code change (Phase-5 retry procedure).
+- **Model capability** (clean trajectory, low score — the agent ran but did the task
+  badly) → **do NOT fix.** That's a real result; record it and move on.
+- **Task / stack / harness bug** (the combo cannot succeed regardless of model:
+  broken stack, bad prompt template, wrong `expected_output`, missing var, or a
+  parallel-safety collision from the known-issues appendix) → **the fixable class.**
+
+When unsure, prefer recording over fixing; only fix when you can name the bug **and**
+the change that resolves it.
+
+## The loop
+
+1. **Isolate.** Make changes in an isolated git worktree / branch (Claude Code:
+   `EnterWorktree`; else `git worktree add` + a branch), never the shared checkout.
+   Branch off the arm under test.
+2. **Diagnose** the failing combo with the review checks (the `devops-bench-review`
+   skill if your harness loaded it, plus the `docs/parallel-evals.md` failure table).
+   Name the bug and the minimal fix.
+3. **Fix**, scoped to that bug — don't refactor unrelated code. Run the unit tests /
+   `ruff` locally if they cover it (never run an eval to "test" a fix).
+4. **Log** the fix in a running changelog (durable state — a notes file or task list):
+   combo, symptom, root cause, the change, commit sha.
+5. **Re-sync (remote only).** In `BENCH_REMOTE` mode, push the working tree to the
+   bastion (`scripts/bastion/sync-to-bastion.sh`; `SKIP_SYNC=1` only after a real
+   sync). In local mode the edits are already in place — skip this.
+6. **Restart only the failed combo(s)** as fresh single-combo matrices (new stamp),
+   after cleaning their leaked GCP resources (cluster, `gke-nodes-*` SA, secrets).
+7. **Continue** the resilient-monitoring loop over the remaining + restarted combos.
+
+## Guardrails (so "unlimited" still terminates safely)
+
+- **Cap fix attempts per combo** (default 3). After that, stop fixing it, mark it
+  blocked, and keep going on the rest — never loop one combo forever.
+- **Scope every change**; commit each fix separately with a clear message; keep the
+  changelog for human review at the end.
+- **Local commits only.** Do **not** push to or merge shared branches (main, the arm
+  branches) unless the user said so — surface the branch/diff for review instead.
+- **Self-check risky fixes** with the review checks before restarting — especially
+  parallel-safety fixes, since you're about to run them concurrently.
+- **Budget awareness.** Each restart costs a cluster + ~25–40 min. Track combos
+  fixed/remaining; if a token or wall-clock budget was given, respect it and report
+  where you stopped.
+- **Checkpoint** stamp + per-combo state + fix log in durable state every tick so a
+  context reset resumes mid-flight.
+- **Keepalive** as in resilient-monitoring: don't signal completion until the whole
+  matrix is done.
+
+## Done condition + final report
+
+Finish when every combo is terminal-acceptable: **passed**, recorded as a genuine
+**model-capability** result, or **blocked** after the fix-attempt cap. Then deliver
+the Phase-6 summary **plus** the fix changelog (each bug → change → commit) and the
+list of still-blocked combos with why.

--- a/.claude/skills/devops-bench-review
+++ b/.claude/skills/devops-bench-review
@@ -1,0 +1,1 @@
+../../.agents/skills/devops-bench-review

--- a/.claude/skills/run-eval
+++ b/.claude/skills/run-eval
@@ -1,0 +1,1 @@
+../../.agents/skills/run-eval

--- a/.claude/skills/run-parallel-evals
+++ b/.claude/skills/run-parallel-evals
@@ -1,0 +1,1 @@
+../../.agents/skills/run-parallel-evals

--- a/complextasks/secret-rotation/agent-rules.md
+++ b/complextasks/secret-rotation/agent-rules.md
@@ -1,0 +1,43 @@
+# Operator rules — SRE agent
+
+You are an SRE/DevOps engineer operating directly on a live GKE cluster and live
+GCP APIs. Follow these rules at all times while carrying out the assigned
+operation.
+
+## Execution
+
+1. **Act, don't advise.** Apply every change yourself through your tools — GKE
+   MCP tools, `kubectl`, and `gcloud`. Do NOT emit bash scripts, manifests, or
+   step-by-step instructions for a human to run. The operation is complete only
+   when you have performed it via tool calls.
+2. **Discover before you act.** Prefer the GKE MCP tools
+   (`mcp_gke_list_clusters`, `mcp_gke_get_cluster`, `mcp_gke_get_kubeconfig`,
+   `mcp_gke_list_namespaces`, `mcp_gke_query_logs`) to locate and inspect the
+   target cluster, namespace, secrets, and consuming workloads. Confirm you are
+   pointed at the correct cluster and namespace before making any change.
+
+## Safety and availability
+
+3. **Zero downtime is mandatory.** Keep services available throughout. Use
+   rolling restarts; never delete-then-recreate workloads in a way that drops
+   capacity. Check pod readiness and health between every step and wait for
+   rollouts to reach a healthy steady state before continuing.
+4. **Verify each step before the next.** Do not assume success. Confirm the new
+   secret version has synced into the namespace and is actually being consumed by
+   the running pods before treating the rotation as done.
+5. **Fail safe.** If you detect any degradation — failing readiness probes,
+   crash loops, error spikes in logs, broken connectivity — pause immediately.
+   Roll back to the last known-good state. Do not push forward blindly hoping it
+   recovers.
+6. **Destroy last.** Only revoke or disable the compromised credential AFTER the
+   rotation is verified successful and the new credential is confirmed in active
+   use. Never revoke the old credential while it could still be serving traffic.
+
+## Scope and discipline
+
+7. **Idempotent and least-privilege.** Scope every action to the target
+   namespace and the specific resources involved. Re-running a step must not
+   cause harm. Do not touch unrelated namespaces, clusters, or secrets.
+8. **Report at the end.** Produce a brief final summary covering: what you
+   changed, the verification evidence at each checkpoint (readiness, sync
+   status, log signals), and the final state of the old and new credentials.

--- a/deployers/gcp/gcp_deployer.py
+++ b/deployers/gcp/gcp_deployer.py
@@ -31,17 +31,28 @@ class GCPDeployer(Deployer):
         env["PATH"] = f"{self.bin_dir}:{env.get('PATH', '')}"
         return env
 
+    def _state_marker_path(self) -> Path:
+        """Path of the "did we create this cluster?" marker.
+
+        Placed under the per-run dir (``BENCH_RUN_DIR``) when isolation is
+        active so concurrent runs do not clobber each other's marker; falls back
+        to ``/tmp`` for single runs.
+        """
+        base = os.environ.get("BENCH_RUN_DIR", "").strip() or "/tmp"
+        return Path(base) / f"{self.project}-{self.location}-{self.cluster_name}_created"
+
     def up(self) -> None:
         # Check if cluster exists
         check_cmd = [
-            "gcloud", "container", "clusters", "describe", self.cluster_name, 
+            "gcloud", "container", "clusters", "describe", self.cluster_name,
             "--project", self.project, "--location", self.location
         ]
         print(f"Checking if cluster exists: {' '.join(check_cmd)}")
         result = subprocess.run(check_cmd, capture_output=True, text=True)
-        
-        state_file = Path(f"/tmp/{self.project}-{self.location}-{self.cluster_name}_created")
-        
+
+        state_file = self._state_marker_path()
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+
         if result.returncode == 0:
             print(f"Cluster {self.cluster_name} already exists. Getting credentials.")
             get_cred_cmd = [
@@ -74,7 +85,7 @@ class GCPDeployer(Deployer):
             state_file.write_text("true")
 
     def down(self) -> None:
-        state_file = Path(f"/tmp/{self.project}-{self.location}-{self.cluster_name}_created")
+        state_file = self._state_marker_path()
         created_by_us = True
         if state_file.exists():
             created_by_us = state_file.read_text().strip() == "true"

--- a/deployers/tf/tf_deployer.py
+++ b/deployers/tf/tf_deployer.py
@@ -34,6 +34,23 @@ class TFDeployer(Deployer):
 
         self.variables = variables or {}
 
+    @staticmethod
+    def _state_flags() -> list:
+        """Return ``-state`` flags placing per-run state beside ``TF_DATA_DIR``.
+
+        When ``TF_DATA_DIR`` is set (the parallel-isolation path keys it to a
+        per-run ``<run>/tf-data`` dir), the local state file is written to
+        ``<run>/terraform.tfstate`` — the *parent* of ``TF_DATA_DIR``, NOT
+        inside it. ``<TF_DATA_DIR>/terraform.tfstate`` is OpenTofu's reserved
+        backend-state path; writing the resource state there makes a later
+        ``tofu init``/``output`` fail with "does not support state version 4".
+        Empty when ``TF_DATA_DIR`` is unset (default in-dir state).
+        """
+        tf_data_dir = os.environ.get("TF_DATA_DIR", "").strip()
+        if not tf_data_dir:
+            return []
+        return ["-state", str(Path(tf_data_dir).resolve().parent / "terraform.tfstate")]
+
     def _run_cmd(
         self, cmd: list, cwd: str, capture: bool = False
     ) -> subprocess.CompletedProcess:
@@ -56,7 +73,7 @@ class TFDeployer(Deployer):
 
         self._run_cmd(["tofu", "init", "-input=false"], cwd=self.tf_dir)
 
-        cmd = ["tofu", "apply", "-auto-approve", "-input=false"]
+        cmd = ["tofu", "apply", "-auto-approve", "-input=false", *self._state_flags()]
         for k, v in self.variables.items():
             cmd.extend(["-var", f"{k}={v}"])
 
@@ -74,7 +91,7 @@ class TFDeployer(Deployer):
 
         self._run_cmd(["tofu", "init", "-input=false"], cwd=self.tf_dir)
 
-        cmd = ["tofu", "destroy", "-auto-approve", "-input=false"]
+        cmd = ["tofu", "destroy", "-auto-approve", "-input=false", *self._state_flags()]
         for k, v in self.variables.items():
             cmd.extend(["-var", f"{k}={v}"])
 
@@ -84,7 +101,9 @@ class TFDeployer(Deployer):
         self._run_cmd(["tofu", "init", "-input=false"], cwd=self.tf_dir)
 
         result = self._run_cmd(
-            ["tofu", "output", "-json"], cwd=self.tf_dir, capture=True
+            ["tofu", "output", "-json", *self._state_flags()],
+            cwd=self.tf_dir,
+            capture=True,
         )
         outputs = json.loads(result.stdout)
 

--- a/docs/bastion.md
+++ b/docs/bastion.md
@@ -155,6 +155,53 @@ don't need it (see [`docs/parallel-evals.md`](./parallel-evals.md)).
   model key lives in openclaw's config on the VM (per your chosen API-key auth);
   promoting it to Secret Manager is a tracked follow-up.
 
+## Parallel & matrix runs (legacy vs refactored)
+
+Both pipeline arms can run **concurrently on the bastion**, each provisioning its
+own cluster, via per-run isolation (`--parallel` / `BENCH_PARALLEL=true`): each run
+gets its own `KUBECONFIG`, `CLOUDSDK_CONFIG`, `TF_DATA_DIR`, OpenTofu state, and a
+run-unique cluster name. The secret-rotation stack also random-suffixes its
+project-global GCP names, so parallel runs may share a `NAMESPACE` — the per-run
+bump above is only needed when several runs reuse one cluster.
+
+> **[`docs/parallel-evals.md`](./parallel-evals.md) is the canonical parallel-eval
+> runbook** — Vertex/ADC mode, gemini-CLI MCP setup, `run_matrix.sh` /
+> `run_matrix_legacy.sh` matrix orchestration, MCP + skills wiring, the
+> parallel-safety matrix, and a failure-mode → fix table. The rest of this section
+> is just the bastion quickstart; use that doc for everything else.
+
+Launch the two arms manually with **distinct `RUN_ID`** and the same agent/judge key:
+
+```bash
+source ~/secrets.env   # GEMINI_API_KEY (mirrored to GOOGLE/AGENT/JUDGE_API_KEY)
+scripts/bastion/configure-oc.sh --mcp --skills   # one-time: wire the LEGACY arm's global oc config
+
+common=( GCP_PROJECT_ID=<proj> GKE_CLUSTER_NAME=secret-rot GCP_LOCATION=us-central1-a
+         AGENT_PROVIDER=google AGENT_MODEL=gemini-3.1-pro-preview
+         JUDGE_PROVIDER=google JUDGE_MODEL=gemini-3.1-pro-preview
+         BENCH_PARALLEL=true BENCH_NO_TEARDOWN=true BENCH_USE_MCP=true
+         AGENT_TARGET=oc OPENCLAW_BIN=oc OPENCLAW_AGENT=main )
+
+# Arm A — legacy (MCP+skills from the GLOBAL ~/.openclaw config set above)
+env "${common[@]}" RUN_ID=legacy-$(date +%s) \
+    BENCH_AGENT_TYPE=cli OPENCLAW_LOCAL=true \
+    python3 pkg/evaluator/evaluate.py complextasks/secret-rotation/task.yaml &
+
+# Arm B — refactored (MCP+skills via env -> isolated openclaw.json)
+env "${common[@]}" RUN_ID=refac-$(date +%s) \
+    BENCH_AGENT_TYPE=openclaw AGENT_MCP_SERVER="$HOME/gke-mcp" AGENT_SKILLS_PATHS="$HOME/oc-skills" \
+    python3 -m devops_bench --parallel complextasks/secret-rotation/task.yaml \
+      --project <proj> --cluster secret-rot --results-root results/refac &
+wait
+# then: python3 scripts/compare_results.py --legacy <A>/results.json --refactor <B>/results.json
+```
+
+For the full matrix (Task × Model × AgentConfig) use `scripts/bastion/run_matrix.sh`
+(refactored) or `scripts/bastion/run_matrix_legacy.sh` (legacy, oc-only) — local by
+default, `BENCH_REMOTE=1` to sync + run on the bastion. See
+`docs/parallel-evals.md` for the matrix CUJs, the parallel-safety rules (legacy +
+gemini CLI is not parallel-safe), resume-after-drop, and Vertex setup.
+
 ## Known issues (appendix)
 
 Record issues found while using the bastion here, so they live in one place.
@@ -164,3 +211,6 @@ Record issues found while using the bastion here, so they live in one place.
 | Bastion SA is owner-equivalent (`editor` + `projectIamAdmin` + `serviceAccountAdmin`). | Anything running as the SA can grant itself any role and impersonate any SA. | Sandbox/non-prod projects only; scope down with `sa_roles`. Follow-up: ship a least-privilege default. |
 | Agent model key stored in openclaw's on-VM config. | Key sits in plaintext on the VM. | Keep the VM IAP-only. Follow-up: promote to Secret Manager. |
 | Static VM bills continuously. | Cost accrues while the VM exists. | `tofu destroy` (or stop the instance) when idle. |
+| Shared OpenTofu working directory. | Per-run isolation covers `TF_DATA_DIR` + state, but both arms run `tofu` in the same `tf/prebuilt/<stack>` dir, so `.terraform.lock.hcl` is shared. | Benign in practice (identical provider locks). Follow-up: per-run copy of the stack dir. |
+| Shared VM-SA project IAM bindings clobber under concurrent GKE tasks. | A per-task GKE stack that grants a project role (e.g. `roles/container.admin`) to the shared VM SA via `google_project_iam_member` "owns" that binding in its own TF state; the first `tofu destroy` strips it while sibling runs still need it → mid-run `container.*` 403. | Don't manage shared-SA project bindings from per-task stacks; grant out-of-band (or use a role the stacks don't manage). Affects any concurrent GKE-task batch. |
+| Host capacity sums across concurrent runs (kind tasks). | Per-task READMEs size disk/inotify/clusters for **one** run; N concurrent kind runs use ~N×, and tasks where the agent spins up extra clusters use more (those get agent-chosen, **un-prefixed** names → docker-daemon collision risk). | Size the bastion for the concurrent batch, not a single run; avoid agent-side cluster creation in large matrices. See `docs/parallel-evals.md` for the per-run isolation gaps. |

--- a/docs/parallel-evals.md
+++ b/docs/parallel-evals.md
@@ -1,0 +1,390 @@
+# Parallel evals on the bastion — runbook
+
+How to run the eval matrix (Task × Model × AgentConfig) **in parallel** on the
+GCE bastion, against either the **API-key** endpoints or **Vertex AI** (the VM
+service account's ADC), for both the **legacy** (`pkg/evaluator`) and
+**refactored** (`devops_bench`) arms, with a troubleshooting table for the
+non-obvious failure modes.
+
+This is the operational companion to [`docs/bastion.md`](./bastion.md), which
+covers the bastion's architecture, provisioning, and the per-run isolation
+design. Read that first for the *why*; read this for the *how* and the *gotchas*.
+
+---
+
+## TL;DR
+
+```bash
+# Remote (bastion) mode: BENCH_REMOTE + connection env (gcpnode/IAP, same as
+# sync-to-bastion.sh). Omit BOTH to run the whole matrix LOCALLY on this host.
+export BENCH_REMOTE=1
+export BASTION_USE_GCPNODE=1 BASTION_VM=bench-bastion \
+       BASTION_ZONE=us-central1-a BASTION_PROJECT=<proj> GCP_PROJECT_ID=<proj>
+
+# --- API-key mode (secrets.env supplies GEMINI_API_KEY etc.) ---
+MATRIX_TASKS="complextasks/secret-rotation/task.yaml" \
+MATRIX_MODELS="gemini-3.1-pro-preview" \
+MATRIX_AGENT_CONFIGS="gcli+mcp+skills" \
+  scripts/bastion/run_matrix.sh                       # refactored arm
+MATRIX_MODELS="gemini-3.1-pro-preview" \
+  scripts/bastion/run_matrix_legacy.sh                # legacy arm (oc only)
+
+# --- Vertex mode (VM-SA ADC, no API keys) ---
+# one-time per bastion: vm-setup.sh (gemini folder-trust) + configure-oc.sh --vertex
+BENCH_VERTEX=1 AGENT_PROVIDER=google-vertex \
+JUDGE_PROVIDER=google JUDGE_MODEL=gemini-3.1-pro-preview \
+MATRIX_TASKS="complextasks/secret-rotation/task.yaml" \
+MATRIX_MODELS="gemini-3.5-flash" \
+MATRIX_AGENT_CONFIGS="gcli+mcp+skills" \
+  scripts/bastion/run_matrix.sh
+
+# Re-attach after a dropped laptop / SSH (the run continues detached on the VM):
+RESUME_STAMP=<stamp-printed-at-launch> scripts/bastion/run_matrix.sh
+```
+
+`DRY_RUN=1` prints the expanded matrix + per-combo env without provisioning.
+
+---
+
+## Mental model
+
+A **combo** is one `(task, model, agent-config, arm)` tuple. The matrix expands
+`MATRIX_TASKS × MATRIX_MODELS × MATRIX_AGENT_CONFIGS` into combos, then runs them
+concurrently (capped by `MAX_PARALLEL`). **Each combo provisions and tears down
+its own GKE cluster** and writes to its own results dir, so combos never share
+mutable infra or agent state.
+
+- `scripts/bastion/run_matrix.sh` — **refactored** arm (`python -m devops_bench`).
+  Capabilities (MCP/skills) are wired **per-run via env**, so each combo is fully
+  independent. Agent configs: `oc | gcli` `[+mcp][+skills]`.
+- `scripts/bastion/run_matrix_legacy.sh` — **legacy** arm (`pkg/evaluator/evaluate.py`).
+  Hard-wired to `AGENT_TARGET=oc`; capabilities come from the **global**
+  `~/.openclaw` config (set once with `configure-oc.sh`).
+- `scripts/bastion/_matrix_lib.sh` — shared library both wrappers source. It
+  builds the remote runner, uploads it, launches it **detached under `nohup`**,
+  polls for a `.done` marker, and pulls results back. Not run directly.
+
+The local process only **orchestrates**: it generates a runner script, `scp`s it
+to the VM, starts it with `nohup`, then polls. If your laptop sleeps or SSH
+drops, the run keeps going on the VM — re-attach with `RESUME_STAMP`.
+
+---
+
+## Identity & auth
+
+The agent and judge run **as the bastion VM service account** via ambient ADC
+(metadata server). Infra stacks grant the runner *nothing* (no per-run runner SA,
+no project IAM binding) — see `docs/bastion.md` "Identity model: BYO credentials".
+Ensure the VM SA is broad enough **once, out of band**:
+
+```bash
+gcloud projects add-iam-policy-binding <proj> \
+  --member="serviceAccount:<vm-sa>@<proj>.iam.gserviceaccount.com" \
+  --role="roles/container.admin"      # + roles/secretmanager.admin, roles/aiplatform.user (Vertex)
+```
+
+`roles/container.admin` is required for the ExternalSecrets operator's cluster
+RBAC; `roles/aiplatform.user` is required for Vertex.
+
+### API-key mode (default)
+
+The remote runner sources `~/secrets.env`, which exports `AGENT_API_KEY`,
+`GEMINI_API_KEY`, `GOOGLE_API_KEY`, `JUDGE_API_KEY`. Agents and judges use the
+generativelanguage / Anthropic API-key endpoints.
+
+### Vertex mode (`BENCH_VERTEX=1`)
+
+Runs agents **and** judges against Vertex AI via the VM-SA's ADC instead of API
+keys. `_matrix_lib.sh` does this when `BENCH_VERTEX` is set: it **unsets every API
+key** sourced from `secrets.env` and exports the Vertex env.
+
+| Variable | Value | Why |
+|---|---|---|
+| `GOOGLE_GENAI_USE_VERTEXAI` | `true` | gemini CLI + google-genai pick Vertex |
+| `GOOGLE_CLOUD_PROJECT` | `<GCP_PROJECT_ID>` | Vertex project |
+| `GOOGLE_CLOUD_LOCATION` | `global` | gemini CLI / oc transport location |
+| `GCP_VERTEX_LOCATION` | `global` | the judges' location (`models/gemini.py`, `evaluate.py`) |
+| `GOOGLE_CLOUD_API_KEY` | `gcp-vertex-credentials` | the **oc** ADC marker (see below) |
+
+Plus set `AGENT_PROVIDER=google-vertex` at the wrapper so the legacy oc model id
+becomes `google-vertex/<model>`.
+
+**Location must be `global`.** The `gemini-3.x *-preview` models **404 on regional
+endpoints** (e.g. `us-central1`). The refactored judge already defaults to
+`global`; the **legacy judge defaults to `us-central1`**, so `GCP_VERTEX_LOCATION=global`
+is mandatory in Vertex mode.
+
+**Judge model must exist on Vertex.** `gemini-3.1-pro` **404s** on Vertex; use
+`JUDGE_MODEL=gemini-3.1-pro-preview`. (The `_matrix_lib.sh` default is
+`gemini-3.1-pro`, so always override it for Vertex.)
+
+#### oc → Vertex auth (the tricky one)
+
+OpenClaw (`oc`) has a built-in `google-vertex` provider, but two config steps are
+required — a *missing token* is **not** the blocker:
+
+1. The provider entry in `~/.openclaw/openclaw.json` must include
+   `"api": "google-vertex"` (and `"baseUrl": "https://{location}-aiplatform.googleapis.com"`).
+   **Without `api`, oc routes the provider through the OpenAI transport** and
+   sends the credential marker to `platform.openai.com` → `401 Incorrect API key`.
+2. The provider needs the literal ADC marker `gcp-vertex-credentials` as its api
+   key. oc's `google-vertex` transport treats that marker as "use ADC" and reads
+   the real token from `google-auth-library` → **metadata-server ADC** at request
+   time (auto-refresh; no ~1h token-paste expiry).
+
+`scripts/bastion/configure-oc.sh --vertex` does both idempotently (registers the
+provider + models, allowlists `google-vertex/<model>` for the agent, pastes the
+marker).
+
+**Marker portability under isolation.** `oc models auth paste-api-key` stores the
+marker only in the **global** agent sqlite auth store
+(`~/.openclaw/agents/main/agent/openclaw-agent.sqlite`). Parallel runs set their
+own empty `OPENCLAW_STATE_DIR`, so they **don't see it** and fail with
+`No API key found for provider "google-vertex"`. The portable fix (what
+`BENCH_VERTEX` does) is to export `GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials` —
+oc's env-based auth resolver picks up the marker with no per-agent store. The
+gemini CLI and the google-genai judge **ignore** `GOOGLE_CLOUD_API_KEY` when ADC
+is configured, so it's safe to set globally.
+
+#### gemini CLI → Vertex
+
+Just the env above (`GOOGLE_GENAI_USE_VERTEXAI=true`, project, `GOOGLE_CLOUD_LOCATION=global`,
+API keys unset). No marker needed. Confirmed working against `gemini-3.5-flash`
+and the `-preview` models.
+
+---
+
+## Agent capabilities (MCP + skills)
+
+### OpenClaw (legacy + refactored `oc` config)
+
+- **Refactored arm**: reads `AGENT_MCP_SERVER` (the `gke-mcp` binary) and
+  `AGENT_SKILLS_PATHS`, writes an *isolated* `openclaw.json`, materializes skills
+  per-run. Fully independent across combos.
+- **Legacy arm**: uses only the **global** `~/.openclaw` config. Wire it with
+  `scripts/bastion/configure-oc.sh --mcp --skills` (or `--no-mcp --no-skills` for
+  a clean "no capabilities" run). The agent profile is `main`.
+
+### Gemini CLI (refactored `gcli` config) — headless MCP requirements
+
+Making the gemini CLI actually **load and execute** MCP tools (e.g. gke-mcp) in
+headless runs needs **two** things — `--skip-trust` alone is **not** enough:
+
+1. **User-level** `~/.gemini/settings.json` with `security.folderTrust.enabled=false`.
+   MCP servers are suppressed in *untrusted* folders; the agent's per-run temp cwd
+   is untrusted, and a workspace-level setting is **ignored when the folder is
+   untrusted** (chicken-and-egg). `--skip-trust` ("trust this session") does **not**
+   lift the MCP gate. Set once — `scripts/bastion/vm-setup.sh` does this.
+2. **`--approval-mode yolo`** in the argv (in `_build_argv`). Without an approval
+   mode, MCP tool calls block on interactive confirmation and the run hangs until
+   timeout. It's the modern replacement for the deprecated `--allowed-tools`.
+
+Notes:
+- MCP servers come from the workspace `.gemini/settings.json` `mcpServers` and
+  stay available even with `--extensions=` — that flag only disables gemini
+  *extensions*, which are distinct from MCP servers.
+- Disable extensions with `--extensions=` (long form). `-e=` / `-e=""` **print
+  help and exit non-zero** on gemini ≥ 0.47 (argv bypasses the shell, so the
+  literal quotes reach the parser), and `-e none` loads an extension named "none".
+- MCP tools surface in the trajectory as `mcp_<server>_<tool>`
+  (e.g. `mcp_default_list_clusters`).
+- `gke-mcp` runs as a stdio MCP server by default (no subcommand needed) and
+  exposed 34 tools in testing (`list_clusters`, `get_k8s_resource`,
+  `patch_k8s_resource`, `get_k8s_logs`, `get_kubeconfig`, …).
+
+---
+
+## Parallel-safety matrix
+
+| Agent | Refactored arm | Legacy arm |
+|---|---|---|
+| OpenClaw (`oc`) | ✅ parallel-safe | ✅ parallel-safe |
+| Gemini CLI (`gemini`) | ✅ parallel-safe | ❌ **not** parallel-safe |
+
+The **refactored** gemini agent runs in a per-run temp cwd with its own
+`.gemini/settings.json` + skills and reconstructs the trajectory from process
+**stdout** (`--output-format stream-json`), so concurrent runs are independent.
+The **legacy** gemini runner reads the trajectory from the shared
+`~/.gemini/tmp/.../chats` dir keyed by a short session id, which can pick the
+wrong run's trajectory under concurrency — hence `run_matrix_legacy.sh` is
+hard-wired to `oc`. For parallel gemini, use the refactored matrix.
+
+---
+
+## Per-run isolation (what keeps combos apart)
+
+- **OpenTofu**: per-run `TF_DATA_DIR`; state file written *beside* it (never at the
+  reserved `<TF_DATA_DIR>/terraform.tfstate`).
+- **Cluster name**: derived deterministically from the run id (e.g.
+  `<hash>-eval`), so re-running the *same* combo reuses the name — safe **only
+  because** the prior run tore down first. Don't run two of the *same* combo at once.
+- **OpenClaw state**: each run gets its own `OPENCLAW_STATE_DIR` (isolated
+  sessions/auth store) while sharing the global `OPENCLAW_CONFIG_PATH`.
+- **Gemini CLI**: per-run temp cwd holds `.gemini/settings.json`, `skills/`,
+  `GEMINI.md`; the user-level `~/.gemini` is untouched.
+- **Secret-rotation stack**: appends a `random_id` suffix to project-global GCP
+  names (`sa-<ns>-<rand>`, `db-credentials-<ns>-<rand>`), so concurrent runs can
+  share a namespace. **No distinct `NAMESPACE` per run is required.**
+
+---
+
+## Operational runbook
+
+### Launch
+
+Run a wrapper with the matrix env. **By default it runs locally** on the current
+host (no ssh/sync). With `BENCH_REMOTE=1` it syncs your working tree to the VM
+(unless `SKIP_SYNC=1`), uploads the runner, and launches it detached over ssh.
+Either way it prints a `RESUME_STAMP`. To launch **both arms truly in parallel**, sync once then start
+each wrapper with `SKIP_SYNC=1` (staggered by a couple seconds so their
+second-resolution `STAMP`s differ).
+
+### Monitor (without blocking the run)
+
+The run is detached; polling is read-only. Useful checks against the remote
+`~/matrix-runs/<stamp>/<rid>/run.log`:
+
+```bash
+# progress
+ssh <bastion> 'ls ~/matrix-runs/<stamp>/*/status 2>/dev/null | wc -l'
+# auth failures during the agent phase
+grep -icE 'No API key|ProviderAuthError|invalid_api_key' run.log
+# MCP / tool usage
+grep -oiE 'mcp_[a-z0-9_-]+|run_shell_command|activate_skill' run.log | sort | uniq -c
+# deepeval outcome
+grep -c 'Pass Rate: 100.0%' run.log    # passed checks
+```
+
+⚠️ **Grep false positives.** Naive `grep -E '401|quota'` matches terraform output
+like `92401222` and `cpu_cfs_quota`. Anchor patterns (`invalid_api_key`,
+`ProviderAuthError`, `^OK$`) instead of bare numbers.
+
+### Verify isolation
+
+Each combo should have a **distinct** cluster, node SA, secret-rotation SA, and
+secret. Cross-check the `c<hash>-eval` cluster names + `gke-nodes-<hash>` SAs in
+the logs are unique per combo.
+
+### Teardown checklist
+
+Each combo tears down its own cluster. After a run (especially a *failed* one),
+confirm nothing leaked — the node SAs are the easy-to-miss part:
+
+```bash
+gcloud container clusters list --project <proj>
+gcloud iam service-accounts list --project <proj> | grep -E 'gke-nodes-|sa-secret-rotation-'
+gcloud secrets list --project <proj> | grep db-credentials
+```
+
+---
+
+## Failure modes & fixes
+
+| Symptom | Root cause | Fix |
+|---|---|---|
+| Detached runner never starts; empty `<stamp>.out` | `nohup ... > ~/matrix-runs/<stamp>.out` redirect target dir didn't exist | `mkdir -p` the output dir **before** the redirect (done in `_matrix_lib.sh`) |
+| Two parallel matrices clobber each other's runner | shared `/tmp/matrix-runner.sh` | per-stamp runner path `/tmp/matrix-runner-<stamp>.sh` (done) |
+| `gemini subprocess error: ... exit code -1` | **timeout**, not a crash — `core.subprocess.run` returns `-1` on `TimeoutExpired` | find what's hanging (usually MCP approval); raise `AGENT_TIMEOUT_SEC` only after |
+| gemini exits -1 immediately, prints help | argv had literal `-e=""` (quotes reach parser; argv bypasses shell) | use `--extensions=` long form |
+| gemini run hangs to timeout with MCP configured | no approval mode → MCP tool calls block on confirmation | `--approval-mode yolo` |
+| gemini `mcp list` shows server `Disabled`; model writes its own MCP client | untrusted per-run cwd suppresses MCP; `--skip-trust` doesn't lift it | user-level `~/.gemini/settings.json` `security.folderTrust.enabled=false` |
+| oc `google-vertex` → `401 Incorrect API key` (sent to platform.openai.com) | provider config lacks `"api":"google-vertex"` → OpenAI transport | add `api` + `baseUrl` (or `configure-oc.sh --vertex`) |
+| oc `No API key found for provider "google-vertex"` under parallel runs | marker only in global sqlite store; isolated `OPENCLAW_STATE_DIR` can't see it | export `GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials` (portable; `BENCH_VERTEX` does this) |
+| Vertex `404 Publisher model ... not found` | regional endpoint, or non-`-preview` model id | `GOOGLE_CLOUD_LOCATION=global` + `GCP_VERTEX_LOCATION=global`; use `gemini-3.1-pro-preview` |
+| Judge silently fails / 404 on Vertex | legacy judge defaults to `us-central1`; `JUDGE_MODEL` default `gemini-3.1-pro` invalid on Vertex | set `GCP_VERTEX_LOCATION=global` and `JUDGE_MODEL=gemini-3.1-pro-preview` |
+| Standalone test sees stale code (`-e=""` after it was fixed) | bastion venv has an **installed** `devops_bench`; `python3 /tmp/x.py` imports it, not the synced source | run with `PYTHONPATH=$HOME/devops-bench`, or `python -m devops_bench` from the source dir (what the matrix does) |
+| Cluster re-create `409 already exists` (node SA) | `gke-nodes-<cluster>` SA is **not** random-suffixed; a failed teardown orphans it | delete orphan `gke-nodes-*` SAs; durable fix tracked (see below) |
+| SSH `exit 255` mid-run | transient gcpnode/cert blip | retry; the detached run is unaffected, re-attach with `RESUME_STAMP` |
+
+### SSH / environment gotchas
+
+- Bastion over gcpnode: host
+  `nic0.<vm>.<zone>.c.<proj>.internal.gcpnode.com`, user `<you>_google_com`; set
+  `BASTION_USE_GCPNODE=1`. Don't force SSH `ControlMaster`/`ControlPath=none`
+  (breaks the user's ssh config → yubikey re-taps).
+- Always pass keepalive (`-o ServerAliveInterval` / `-o ServerAliveCountMax` /
+  `-o ConnectTimeout`) so a hung relay fails fast; the matrix scripts already do.
+- Run long jobs under `nohup` (the matrix does). macOS has **no `timeout`**
+  command — rely on SSH keepalive caps.
+
+---
+
+## Interpreting scores
+
+A score reflects **model capability on the task**, not the harness — once a run
+reaches the agent phase with working auth and tools, a low score is the model, not
+infra. Use this to triage: a clean trajectory with a low score is a model result;
+an early abort or an auth/tool error is a harness/config problem to fix and retry.
+(Concrete per-model/run scores are tracked separately, not in this doc.)
+
+---
+
+## Results layout
+
+```
+results/<RESULTS_DIR-or-matrix>/<stamp>/<rid>/
+  status                                   # "exit=<rc>"
+  run.log                                  # full combo stdout (tofu + agent + judge)
+  run_<ts>_<rid>/results.json              # refactored: nested
+  results.json                             # legacy: copied in from results/run_<ts>_<rid>
+```
+
+`results.json` is a **list** of per-criterion objects (`{name, score, success,
+reason, ...}`). The per-check pass/fail also appears as DeepEval
+`Pass Rate: 100.0% / 0.0%` lines in `run.log`.
+
+---
+
+## Reproducing a bastion from scratch
+
+```bash
+# 1. provision + ship code (see docs/bastion.md §1–3), then on the VM:
+scripts/bastion/vm-setup.sh           # installs gemini CLI; sets ~/.gemini folder-trust=false
+# 2. for Vertex/ADC legacy runs, register the oc google-vertex provider:
+scripts/bastion/configure-oc.sh --vertex [--mcp --skills | --no-mcp --no-skills]
+# 3. ensure the VM SA has container.admin + secretmanager.admin + aiplatform.user
+```
+
+After that, the TL;DR commands at the top work with no manual config.
+
+---
+
+## Known issues (appendix)
+
+Append issues found while running parallel evals here, so they live in one place.
+
+- **Shared OpenTofu working dir**: per-run isolation covers `TF_DATA_DIR` + state,
+  but both arms run `tofu` in the same `tf/prebuilt/<stack>` dir, so
+  `.terraform.lock.hcl` is shared (benign in practice; a per-run copy of the stack
+  dir is the robust fix).
+- **Node-SA orphaning**: `tf/modules/gke` node SA name `gke-nodes-<cluster>` is
+  deterministic, **not** random-suffixed, so a failed teardown orphans it and a
+  re-run hits `409 already exists`. Durable fix (random suffix /
+  `create_ignore_already_exists` / always clean `gke-nodes-*`) is still open.
+- **Node-SA name not prefix-safe for multi-cluster stacks**: beyond the orphaning
+  above, `gke-nodes-${substr(cluster_name, 0, 15)}` keeps only the first 15 chars,
+  so a stack that creates two clusters by appending a suffix (e.g. `-east`/`-west`)
+  collapses **both** node SAs to one `account_id` once the run-token prefix
+  (`<8-char-token>-`) pushes the suffix past char 15 — `apply` fails with a
+  duplicate / `409` service account *within a single run*. Multi-cluster GKE tasks
+  aren't parallel-safe until the SA name carries the discriminator (or a random
+  suffix).
+- **`$HOME` / GitOps state is not isolated**: `RunEnv` isolates `KUBECONFIG`,
+  `CLOUDSDK_CONFIG`, `TF_DATA_DIR`, the cluster name, the results dir, and
+  `OPENCLAW_STATE_DIR` — but **not `$HOME`**. A task that seeds a fixed bare repo
+  under `$HOME` (e.g. `~/<task>-repo.git`) and `rm -rf`s it in setup shares that
+  path across runs of the **same task** (the Model/AgentConfig axis): a wipe race
+  and cross-run pushes. Distinct per-task names keep it safe on the **Task axis**
+  only, and there is no `{{REPO_PATH}}` prompt token to make the path per-run.
+  Robust fix: a `RunEnv`-provided per-run repo dir + a prompt token.
+- **`task_id` collisions break matrix reporting**: per-run results dirs are unique,
+  but `task_id` is the logical key in aggregated reports — two tasks sharing an id
+  (has happened: new complex tasks reused ids already held by `tasks/gcp/*`) make
+  per-task scoring ambiguous when both run in one matrix. Enforce a unique
+  `task_id` at authoring time (the `devops-bench-review` skill checks this).
+- **Cluster-name length budget**: the run token (`<8-char-token>-`) is prepended
+  and the result is clamped to GKE's 40-char limit, so a stack that appends its own
+  suffix (`-east`) can overflow — or get clamped so the suffix is dropped — for
+  longer `GKE_CLUSTER_NAME`s. Keep base names short and budget for token + suffix.
+- For symptom → root-cause → fix entries, see [Failure modes & fixes](#failure-modes--fixes)
+  above; add new ones there as they're found.

--- a/pkg/agents/runner/gcli.py
+++ b/pkg/agents/runner/gcli.py
@@ -134,9 +134,10 @@ def run_cli_agent(agent_target, prompt, context, bench_use_mcp=True, system_inst
         use_stdin = False
     elif "openclaw" in agent_target or "oc" in agent_target:
         # Which oc agent profile to run (`oc agent --agent <name>`). Defaults to
-        # "operator" (the configured DevOps operator agent the benchmark has used so
-        # far); override with OPENCLAW_AGENT, e.g. OPENCLAW_AGENT=main for oc's default.
-        oc_agent = (os.environ.get("OPENCLAW_AGENT") or "operator").strip() or "operator"
+        # "main" (modern openclaw's default agent id; older builds used "operator").
+        # Override with OPENCLAW_AGENT. Matches the refactored arm's default so the
+        # two arms target the same profile unless explicitly told otherwise.
+        oc_agent = (os.environ.get("OPENCLAW_AGENT") or "main").strip() or "main"
         # When the agent, harness, and (kind) cluster are co-located on one host,
         # run oc locally instead of SSHing to the GCE VM.
         if os.environ.get("OPENCLAW_LOCAL", "false").lower() == "true":

--- a/pkg/agents/runner/openclaw.py
+++ b/pkg/agents/runner/openclaw.py
@@ -3,6 +3,7 @@ import os
 import re
 import shlex
 import subprocess
+import tempfile
 import time
 import getpass
 from deepeval.tracing import observe
@@ -13,19 +14,27 @@ from deepeval.tracing import observe
 # code) and add noise to the text the judge grades, so strip them first.
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
+# Default oc agent profile (override with OPENCLAW_AGENT) and shared config path.
+_DEFAULT_AGENT_NAME = "main"
+_DEFAULT_CONFIG_PATH = "~/.openclaw/openclaw.json"
+
 
 def _strip_ansi(text):
     return _ANSI_RE.sub("", text)
 
 
+def _resolve_agent_name(explicit):
+    """Pick the oc agent profile: explicit arg, OPENCLAW_AGENT env, then 'main'."""
+    return explicit or os.environ.get("OPENCLAW_AGENT") or _DEFAULT_AGENT_NAME
+
+
 def _oc_model_id():
     """Resolve the OpenClaw model id from the harness env (AGENT_MODEL/AGENT_PROVIDER).
 
-    `oc agent` has no per-invocation model flag, so the model is selected by running
-    `oc models set <id>` before the agent turn (see `_oc_set_model_cmd`). Returns oc's
-    'provider/model' id (e.g. 'google/gemini-3.1-pro-preview'), or "" when AGENT_MODEL
-    is unset (we then leave oc's configured default untouched — preserving prior
-    behavior).
+    The model is passed per-run via ``oc agent --model`` (see `_oc_model_flag`),
+    not the global `oc models set`. Returns oc's 'provider/model' id (e.g.
+    'google/gemini-3.1-pro-preview'), or "" when AGENT_MODEL is unset (oc's
+    configured default is then left untouched — preserving prior behavior).
     """
     model = os.environ.get("AGENT_MODEL", "").strip()
     if not model:
@@ -38,17 +47,17 @@ def _oc_model_id():
     return model
 
 
-def _oc_set_model_cmd(oc_bin, sep):
-    """Shell fragment that points oc at AGENT_MODEL before the agent runs, or "".
+def _oc_model_flag():
+    """Return ``--model <id> `` for ``oc agent``, or "" when AGENT_MODEL is unset.
 
-    `oc models set <id>` persists the default model in oc's config; the harness
-    re-sets it every run, so it stays driven by AGENT_MODEL. `sep` joins it to the
-    following command (e.g. " && " for the SSH chain, "; " for the local one).
+    The model is selected per-run via ``oc agent --model`` (not the global
+    ``oc models set``), so nothing mutates the shared oc config — concurrent
+    runs neither race on it nor pollute each other's default model.
     """
     model_id = _oc_model_id()
     if not model_id:
         return ""
-    return f"{oc_bin} models set {shlex.quote(model_id)}{sep}"
+    return f"--model {shlex.quote(model_id)} "
 
 
 def _parse_openclaw_session(session_content):
@@ -99,20 +108,35 @@ def _parse_openclaw_session(session_content):
 
 
 @observe()
-def run_openclaw_agent(prompt, context=None, agent_name="main"):
+def run_openclaw_agent(prompt, context=None, agent_name=None):
     """Runs OpenClaw agent on GCE VM via SSH."""
     current_user = getpass.getuser()
     project_id = os.environ.get("GCP_PROJECT_ID", "simrankaurk-gke-dev")
+    agent_name = _resolve_agent_name(agent_name)
 
     ssh_user = os.environ.get("OPENCLAW_SSH_USER", f"{current_user}_google_com")
     vm_host = os.environ.get("OPENCLAW_VM_HOST", f"nic0.claw-ubuntu.us-central1-a.c.{project_id}.internal.gcpnode.com")
     ssh_key = os.environ.get("OPENCLAW_SSH_KEY", os.path.expanduser("~/.ssh/google_compute_engine"))
 
+    # Parallel isolation: when RUN_ID is set, isolate the remote oc state
+    # (sessions/memory/commitments) per run via a remote OPENCLAW_STATE_DIR while
+    # sharing OPENCLAW_CONFIG_PATH; the empty state dir needs no session wipe.
+    run_id = os.environ.get("RUN_ID")
+    if run_id:
+        safe = re.sub(r"[^A-Za-z0-9_-]", "-", run_id)
+        remote_config = os.environ.get("OPENCLAW_CONFIG_PATH") or "$HOME/.openclaw/openclaw.json"
+        setup = (
+            f'export OPENCLAW_STATE_DIR="$HOME/.openclaw-runs/{safe}/openclaw-state" '
+            f'OPENCLAW_CONFIG_PATH="{remote_config}" && '
+        )
+    else:
+        setup = "rm -rf ~/.openclaw/agents/" + shlex.quote(agent_name) + "/sessions/* && "
+
     # We use --local and --agent as discovered by the user
     # We also use single quotes for the prompt, assuming it doesn't contain single quotes.
     # For safety, we should escape single quotes if possible, but let's keep it simple first.
-    set_model = _oc_set_model_cmd("~/bin/oc", " && ")
-    remote_command = f"rm -rf ~/.openclaw/agents/{agent_name}/sessions/* && export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && source \"$NVM_DIR/nvm.sh\" && {set_model}~/bin/oc --log-level debug agent --local --agent {agent_name} -m '{prompt}'"
+    model_flag = _oc_model_flag()
+    remote_command = f"{setup}export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && source \"$NVM_DIR/nvm.sh\" && ~/bin/oc --log-level debug agent --local --agent {agent_name} {model_flag}-m '{prompt}'"
 
     ssh_cmd = [
         "ssh",
@@ -173,25 +197,45 @@ def run_openclaw_agent(prompt, context=None, agent_name="main"):
 
 
 @observe()
-def run_openclaw_agent_local(prompt, context=None, agent_name="operator"):
+def run_openclaw_agent_local(prompt, context=None, agent_name=None):
     """Runs OpenClaw agent locally via subprocess (no SSH).
 
     Used when the harness, the kind cluster, and the agent are co-located on the
     same host (e.g. running the eval directly on the runner VM). Selected by
     setting OPENCLAW_LOCAL=true. The SSH-based runner remains the default.
+
+    Parallel isolation: when RUN_ID is set, the run gets its own
+    OPENCLAW_STATE_DIR (isolated sessions/memory/commitments) while sharing
+    OPENCLAW_CONFIG_PATH; the empty state dir needs no session wipe and the
+    model is selected per-run with ``oc agent --model``.
     """
+    agent_name = _resolve_agent_name(agent_name)
     oc_bin = os.environ.get("OPENCLAW_BIN", os.path.expanduser("~/bin/oc"))
     sessions_glob = os.path.expanduser(f"~/.openclaw/agents/{agent_name}/sessions")
 
-    # Mirror the remote command: clear prior sessions, load nvm, run the agent.
-    # shlex.quote everything interpolated into the shell string — prompts contain
-    # single quotes and newlines, which would otherwise break shell parsing.
+    run_id = os.environ.get("RUN_ID")
+    isolation_env = {}
+    wipe_frag = f"rm -rf {shlex.quote(sessions_glob)}/* 2>/dev/null; "
+    if run_id:
+        base = os.environ.get("BENCH_RUN_DIR") or os.path.join(
+            tempfile.gettempdir(), "devops-bench-runs", run_id
+        )
+        isolation_env = {
+            "OPENCLAW_STATE_DIR": os.path.join(base, "openclaw-state"),
+            "OPENCLAW_CONFIG_PATH": os.path.expanduser(
+                os.environ.get("OPENCLAW_CONFIG_PATH") or _DEFAULT_CONFIG_PATH
+            ),
+        }
+        wipe_frag = ""  # isolated state dir starts empty
+
+    # Mirror the remote command: load nvm, run the agent. shlex.quote everything
+    # interpolated into the shell string — prompts contain single quotes and
+    # newlines, which would otherwise break shell parsing.
     local_command = (
-        f"rm -rf {shlex.quote(sessions_glob)}/* 2>/dev/null; "
+        f"{wipe_frag}"
         "export NVM_DIR=\"$HOME/.nvm\"; [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"; "
-        f"{_oc_set_model_cmd(shlex.quote(oc_bin), '; ')}"
         f"{shlex.quote(oc_bin)} --log-level debug agent --local "
-        f"--agent {shlex.quote(agent_name)} -m {shlex.quote(prompt)}"
+        f"--agent {shlex.quote(agent_name)} {_oc_model_flag()}-m {shlex.quote(prompt)}"
     )
 
     start_time = time.time()
@@ -203,6 +247,7 @@ def run_openclaw_agent_local(prompt, context=None, agent_name="operator"):
             capture_output=True,
             text=True,
             check=True,
+            env={**os.environ, **isolation_env} if isolation_env else None,
         )
         latency = time.time() - start_time
         output = _strip_ansi(result.stdout)

--- a/pkg/evaluator/evaluate.py
+++ b/pkg/evaluator/evaluate.py
@@ -34,13 +34,14 @@ from pkg.agents.runner.api.llm_adapters import (
 
 from pkg.agents.runner.api.api import run_api_agent
 from pkg.agents.runner.gcli import run_cli_agent
+from pkg.runenv import RunEnv, parallel_enabled
 from pkg.evaluator.loader import (
     load_from_tasks_dir,
     safe_parse_yaml,
     parse_documentation_from_yaml,
 )
 import threading
-from pkg.manager.manager import ScenarioManager
+from pkg.manager.manager import ScenarioManager, pick_free_port
 from deployers.factory import get_deployer
 
 
@@ -306,6 +307,13 @@ def load_configuration_context():
     if not project_id or not cluster_name:
         print("Error: PROJECT_ID (or GCP_PROJECT_ID) and CLUSTER_NAME (or GKE_CLUSTER_NAME) must be set.")
         sys.exit(1)
+
+    # Establish per-run isolation BEFORE any provisioning so every gcloud /
+    # kubectl / tofu / agent subprocess inherits the run-scoped kubeconfig,
+    # gcloud config, and tofu data dir. A no-op unless BENCH_PARALLEL is set.
+    run_env = RunEnv.create(parallel=parallel_enabled())
+    run_env.apply()
+    cluster_name = run_env.cluster_name(cluster_name)
 
     bench_use_mcp = os.environ.get("BENCH_USE_MCP", "true")
     mcp_server_path = os.environ.get("MCP_SERVER_PATH", "third_party/gke-mcp/gke-mcp")
@@ -754,7 +762,14 @@ def main():
     detailed_results = []
 
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    run_dir = f"results/run_{timestamp}"
+    run_name = f"run_{timestamp}"
+    # The timestamp has 1-second resolution; append the (process-unique) run id
+    # so two evaluator processes started in the same second do not collide on a
+    # single results/run_<ts>/ directory.
+    run_id = os.environ.get("RUN_ID")
+    if run_id:
+        run_name = f"{run_name}_{re.sub(r'[^A-Za-z0-9_-]', '-', run_id)}"
+    run_dir = f"results/{run_name}"
     os.makedirs(run_dir, exist_ok=True)
 
     for item in eval_data:
@@ -806,7 +821,10 @@ def main():
 
                     if spec_list:
                         spec = spec_list[0]
-                        scenario_manager = ScenarioManager(target_deployment, namespace)
+                        local_port = pick_free_port() if parallel_enabled() else None
+                        scenario_manager = ScenarioManager(
+                            target_deployment, namespace, local_port=local_port
+                        )
                         t = threading.Thread(
                             target=scenario_manager.run_chaos_and_verification,
                             args=(spec, verification_spec_list),

--- a/pkg/manager/manager.py
+++ b/pkg/manager/manager.py
@@ -2,20 +2,36 @@ import json
 import threading
 import time
 import subprocess
+import socket
+import contextlib
 import datetime
 from pkg.agents.chaos.chaos import ChaosAgent
 from pkg.agents.verifier.verifier import VerifierAgent
+
+# Default local port; concurrent runs override it with a free port so two
+# port-forwards on one host do not contend for the same local port.
+_DEFAULT_LOCAL_PORT = 8080
+# The workload's in-cluster port (remote side of the port-forward) stays fixed.
+_REMOTE_PORT = 8080
 
 def log(msg):
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     print(f"[{timestamp}] {msg}", flush=True)
 
+def pick_free_port():
+    """Return an ephemeral TCP port currently free on the loopback interface."""
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
 class ScenarioManager:
     """Manages GKE port-forwarding, schedules chaos agent load spikes, and aggregates telemetry."""
-    
-    def __init__(self, target_deployment, namespace):
+
+    def __init__(self, target_deployment, namespace, local_port=None):
         self.target_deployment = target_deployment
         self.namespace = namespace
+        self.local_port = local_port or _DEFAULT_LOCAL_PORT
+        self.local_service_url = f"http://localhost:{self.local_port}"
         self.chaos_active_event = threading.Event()
         self.chaos_agent = ChaosAgent()
         self.chaos_agent.chaos_active_event = self.chaos_active_event
@@ -90,30 +106,30 @@ class ScenarioManager:
             log(f"[ScenarioManager] Waiting for trigger delay of {delay}s...")
             time.sleep(delay)
         
-        # 1. Establish kubectl port-forward to local port 8080
-        log(f"[ScenarioManager] Establishing port-forward to deployment/{self.target_deployment} on port 8080...")
+        # 1. Establish kubectl port-forward to the (possibly per-run) local port
+        log(f"[ScenarioManager] Establishing port-forward to deployment/{self.target_deployment} on local port {self.local_port}...")
         pf_cmd = [
-            "kubectl", "port-forward", 
-            f"deployment/{self.target_deployment}", 
-            "8080:8080", 
+            "kubectl", "port-forward",
+            f"deployment/{self.target_deployment}",
+            f"{self.local_port}:{_REMOTE_PORT}",
             "-n", self.namespace
         ]
-        
+
         self.pf_process = subprocess.Popen(
-            pf_cmd, 
-            stdout=subprocess.PIPE, 
+            pf_cmd,
+            stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
-        
+
         # Give it 3 seconds to establish the tunnel
         time.sleep(3)
-        
+
         # 2. Redirect Chaos Agent load generation to localhost
         local_action = action.copy()
         local_action["target"] = local_action.get("target", {}).copy()
-        local_action["target"]["service_url"] = "http://localhost:8080"
-        
-        log(f"[ScenarioManager] Triggering chaos action: generate_load on http://localhost:8080")
+        local_action["target"]["service_url"] = self.local_service_url
+
+        log(f"[ScenarioManager] Triggering chaos action: generate_load on {self.local_service_url}")
         try:
             self.chaos_agent.inject_fault(local_action)
         except Exception as e:

--- a/pkg/manager/test_manager.py
+++ b/pkg/manager/test_manager.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 from unittest.mock import MagicMock, patch
-from pkg.manager.manager import ScenarioManager
+from pkg.manager.manager import ScenarioManager, pick_free_port
 from pkg.agents.verifier.base import VerificationResult
 
 class TestScenarioManager(unittest.TestCase):
@@ -10,6 +10,21 @@ class TestScenarioManager(unittest.TestCase):
         # Avoid side-effects during init
         with patch("pkg.manager.manager.ChaosAgent"), patch("pkg.manager.manager.VerifierAgent"):
             self.manager = ScenarioManager("my-deployment", "my-namespace")
+
+    def test_default_local_port(self):
+        self.assertEqual(self.manager.local_port, 8080)
+        self.assertEqual(self.manager.local_service_url, "http://localhost:8080")
+
+    def test_custom_local_port(self):
+        with patch("pkg.manager.manager.ChaosAgent"), patch("pkg.manager.manager.VerifierAgent"):
+            manager = ScenarioManager("d", "ns", local_port=34567)
+        self.assertEqual(manager.local_port, 34567)
+        self.assertEqual(manager.local_service_url, "http://localhost:34567")
+
+    def test_pick_free_port_in_range(self):
+        port = pick_free_port()
+        self.assertIsInstance(port, int)
+        self.assertTrue(1 <= port <= 65535)
 
     @patch("pkg.manager.manager.ScenarioManager._inject_chaos_with_delay")
     def test_run_chaos_and_verification_success(self, mock_inject):

--- a/pkg/runenv.py
+++ b/pkg/runenv.py
@@ -1,0 +1,151 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-run isolation for the legacy evaluator so runs can execute concurrently.
+
+Standalone counterpart to ``devops_bench.core.run_env`` for the legacy ``pkg/``
+arm (the two arms share no code). When isolation is enabled (``--parallel`` /
+``BENCH_PARALLEL``), each evaluator process gets its own ``KUBECONFIG``,
+``CLOUDSDK_CONFIG``, and ``TF_DATA_DIR`` plus a run-unique, prefix-safe cluster
+name, so multiple processes on one host (bastion or local) do not collide.
+Isolation is opt-in to keep single-run and ``--no-infra`` workflows unchanged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+
+__all__ = ["RunEnv", "parallel_enabled"]
+
+# GKE cluster names cap at 40 chars and must match ``[a-z]([-a-z0-9]*[a-z0-9])?``.
+_MAX_CLUSTER_NAME = 40
+# Run discriminator placed at the FRONT of derived cluster names so it survives
+# the service-account ``account_id`` truncation (substr 0,10) in the tf/ stacks.
+_CLUSTER_TOKEN_LEN = 8
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "y", "on"})
+
+
+def parallel_enabled() -> bool:
+    """Return whether per-run isolation is requested via ``BENCH_PARALLEL``."""
+    return os.environ.get("BENCH_PARALLEL", "").strip().lower() in _TRUE_VALUES
+
+
+def _default_run_id() -> str:
+    """Build a run id unique among concurrent processes on one host."""
+    return f"{time.strftime('%Y%m%d-%H%M%S')}-{os.getpid()}"
+
+
+@dataclass(frozen=True)
+class RunEnv:
+    """Isolation context for one legacy evaluator process.
+
+    Attributes:
+        run_id: Stable identifier reused for artifact naming.
+        isolated: Whether per-run isolation is active (inert pass-through when
+            False).
+        run_dir: Per-run scratch directory (created on :meth:`apply`).
+        kubeconfig_path: Per-run ``KUBECONFIG`` target, or None.
+        gcloud_config_path: Per-run ``CLOUDSDK_CONFIG`` target, or None.
+        tf_data_dir: Per-run ``TF_DATA_DIR`` target, or None.
+    """
+
+    run_id: str
+    isolated: bool
+    run_dir: str
+    kubeconfig_path: str | None
+    gcloud_config_path: str | None
+    tf_data_dir: str | None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        parallel: bool,
+        run_id: str | None = None,
+        state_root: str | None = None,
+    ) -> RunEnv:
+        """Build a run environment, resolving the run id and scratch paths.
+
+        Args:
+            parallel: When True, derive per-run isolated paths; else an inert
+                pass-through.
+            run_id: Explicit run id; defaults to ``RUN_ID`` env, then a
+                PID/timestamp id.
+            state_root: Root for the scratch dir; defaults to
+                ``BENCH_RUN_STATE_ROOT`` env, then ``<tmp>/devops-bench-runs``.
+
+        Returns:
+            The constructed :class:`RunEnv` (no side effects until :meth:`apply`).
+        """
+        resolved_id = run_id or os.environ.get("RUN_ID") or _default_run_id()
+        if not parallel:
+            return cls(resolved_id, False, os.getcwd(), None, None, None)
+
+        root = state_root or os.environ.get("BENCH_RUN_STATE_ROOT") or os.path.join(
+            tempfile.gettempdir(), "devops-bench-runs"
+        )
+        run_dir = os.path.join(root, resolved_id)
+        return cls(
+            run_id=resolved_id,
+            isolated=True,
+            run_dir=run_dir,
+            kubeconfig_path=os.path.join(run_dir, "kubeconfig"),
+            gcloud_config_path=os.path.join(run_dir, "gcloud"),
+            tf_data_dir=os.path.join(run_dir, "tf-data"),
+        )
+
+    def apply(self) -> None:
+        """Create the scratch dir and point process env at the per-run paths.
+
+        A no-op when not isolated. Mutates ``os.environ`` so every subprocess
+        (``gcloud`` / ``kubectl`` / ``tofu`` / agents) inherits the isolated
+        kubeconfig, gcloud config, and tofu data dir.
+        """
+        if not self.isolated:
+            return
+        os.makedirs(self.gcloud_config_path, exist_ok=True)  # type: ignore[arg-type]
+        os.makedirs(self.tf_data_dir, exist_ok=True)  # type: ignore[arg-type]
+        os.environ["KUBECONFIG"] = self.kubeconfig_path  # type: ignore[assignment]
+        os.environ["CLOUDSDK_CONFIG"] = self.gcloud_config_path  # type: ignore[assignment]
+        os.environ["TF_DATA_DIR"] = self.tf_data_dir  # type: ignore[assignment]
+        os.environ["RUN_ID"] = self.run_id
+        os.environ["BENCH_RUN_DIR"] = self.run_dir
+
+    @property
+    def cluster_token(self) -> str:
+        """Short, prefix-safe, DNS-label-safe discriminator from the run id."""
+        digest = hashlib.blake2s(self.run_id.encode(), digest_size=8).hexdigest()
+        return ("c" + digest)[:_CLUSTER_TOKEN_LEN]
+
+    def cluster_name(self, base: str) -> str:
+        """Derive a collision-free cluster name from ``base`` for this run.
+
+        Returns ``base`` unchanged when not isolated; otherwise prepends the run
+        token (so it survives SA-name truncation), clamped to the GKE 40-char
+        limit with no trailing dash.
+
+        Args:
+            base: The configured (shared) cluster name.
+
+        Returns:
+            The per-run cluster name.
+        """
+        if not self.isolated:
+            return base
+        return f"{self.cluster_token}-{base}"[:_MAX_CLUSTER_NAME].rstrip("-")

--- a/scripts/bastion/_matrix_lib.sh
+++ b/scripts/bastion/_matrix_lib.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+#
+# Shared library for the bastion eval-matrix orchestrators:
+#   run_matrix.sh         (refactored arm: Task x Model x AgentConfig)
+#   run_matrix_legacy.sh  (legacy arm:     Task x Model)
+#
+# Not run directly. A wrapper sources this, sets the MATRIX_* / run config, then
+# builds the global COMBOS array (each entry "run_id|task|kvs|arm", where kvs is
+# a ';'-joined KEY=VALUE list of per-combo env, e.g.
+# "AGENT_MODEL=gemini-3.1-pro;BENCH_AGENT_TYPE=openclaw;...") and calls
+# `matrix_dispatch "<label>"`. Each combo runs as an isolated --parallel run on
+# the bastion (its own cluster); results are copied back to RESULTS_DIR.
+#
+# Connection env (same as sync-to-bastion.sh): BASTION_VM/ZONE/PROJECT, and
+# either default IAP or BASTION_USE_GCPNODE=1 / BASTION_SSH_HOST / BASTION_SSH_USER.
+# Run config: GCP_PROJECT_ID (req unless DRY_RUN), GKE_CLUSTER_NAME, GCP_LOCATION,
+# AGENT_PROVIDER, JUDGE_PROVIDER, JUDGE_MODEL, MAX_PARALLEL, RESULTS_DIR,
+# GKE_MCP_BIN, SKILLS_PATHS, SKIP_SYNC, DRY_RUN, MATRIX_TASKS, MATRIX_MODELS.
+# RESUME_STAMP=<stamp>: skip launching; re-poll + pull an existing remote run
+#   (use the stamp printed by the original invocation) — survives a dead local
+#   process. SSH keepalive + a retrying pull keep brief drops from aborting.
+# BENCH_VERTEX=1: run agents + judges against Vertex AI via the bastion VM SA's
+#   ADC instead of the API-key endpoints. The runner unsets every API key from
+#   secrets.env and exports GOOGLE_GENAI_USE_VERTEXAI/GOOGLE_CLOUD_*/
+#   GCP_VERTEX_LOCATION (default location 'global'; override GOOGLE_CLOUD_LOCATION
+#   / GCP_VERTEX_LOCATION). For the legacy oc arm also set AGENT_PROVIDER=
+#   google-vertex so the model id becomes 'google-vertex/<model>'. Prereq: the oc
+#   google-vertex provider must be auth'd once (see docs/bastion.md).
+# BENCH_REMOTE=1: run the matrix ON the bastion over ssh (sync + remote nohup +
+#   pull). Default (unset) runs every combo LOCALLY on this host (no ssh/sync;
+#   outputs in ~/matrix-runs/<stamp>, no pull). BASTION_* matter only when set.
+
+BASTION_VM="${BASTION_VM:-bench-bastion}"
+BASTION_ZONE="${BASTION_ZONE:-us-central1-a}"
+BASTION_PROJECT="${BASTION_PROJECT:-$(gcloud config get-value project 2>/dev/null || true)}"
+REMOTE_DIR="${REMOTE_DIR:-devops-bench}"
+
+MATRIX_TASKS="${MATRIX_TASKS:-complextasks/secret-rotation/task.yaml}"
+MATRIX_MODELS="${MATRIX_MODELS:-gemini-3.1-pro}"
+
+GKE_CLUSTER_NAME="${GKE_CLUSTER_NAME:-eval}"
+GCP_LOCATION="${GCP_LOCATION:-us-central1-a}"
+AGENT_PROVIDER="${AGENT_PROVIDER:-google}"
+JUDGE_PROVIDER="${JUDGE_PROVIDER:-google}"
+JUDGE_MODEL="${JUDGE_MODEL:-gemini-3.1-pro}"
+MAX_PARALLEL="${MAX_PARALLEL:-3}"
+GKE_MCP_BIN="${GKE_MCP_BIN:-\$HOME/gke-mcp}"     # expanded on the bastion
+SKILLS_PATHS="${SKILLS_PATHS:-\$HOME/oc-skills}" # expanded on the bastion
+DRY_RUN="${DRY_RUN:-}"
+BENCH_REMOTE="${BENCH_REMOTE:-}"  # empty = run locally on this host; set = ssh to the bastion
+
+STAMP="$(date +%Y%m%d_%H%M%S)"
+# Pulled results land in ${RESULTS_DIR}/${STAMP} (the pull re-creates the
+# stamped dir), so the default deliberately omits the stamp.
+RESULTS_DIR="${RESULTS_DIR:-results/matrix}"
+REMOTE_OUT="matrix-runs/${STAMP}"  # relative to the bastion user's $HOME
+
+_MATRIX_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${_MATRIX_LIB_DIR}/../.." && pwd)"
+
+# --- SSH transport (mirrors sync-to-bastion.sh) ----------------------------- #
+# Keepalive so sessions ride out brief network blips instead of dropping.
+_SSH_KA=(-o ServerAliveInterval=30 -o ServerAliveCountMax=4 -o ConnectTimeout=30)
+if [ -n "${BASTION_SSH_HOST:-}" ] || [ "${BASTION_USE_GCPNODE:-}" = "1" ]; then
+  SSH_HOST="${BASTION_SSH_HOST:-nic0.${BASTION_VM}.${BASTION_ZONE}.c.${BASTION_PROJECT}.internal.gcpnode.com}"
+  SSH_USER="${BASTION_SSH_USER:-$(id -un)_google_com}"
+  SSH_TARGET="${SSH_USER}@${SSH_HOST}"
+  remote_exec() { ssh -o BatchMode=yes "${_SSH_KA[@]}" "${SSH_TARGET}" "$1"; }
+  push_file()   { scp -o BatchMode=yes "${_SSH_KA[@]}" "$1" "${SSH_TARGET}:$2"; }
+  pull_dir()    { scp -o BatchMode=yes "${_SSH_KA[@]}" -r "${SSH_TARGET}:$1" "$2"; }
+else
+  _GKA=(--ssh-flag="-o ServerAliveInterval=30" --ssh-flag="-o ServerAliveCountMax=4")
+  _GKA_SCP=(--scp-flag="-o ServerAliveInterval=30" --scp-flag="-o ServerAliveCountMax=4")
+  remote_exec() { gcloud compute ssh "${BASTION_VM}" --tunnel-through-iap --zone "${BASTION_ZONE}" --project "${BASTION_PROJECT}" "${_GKA[@]}" --command "$1"; }
+  push_file()   { gcloud compute scp --tunnel-through-iap --zone "${BASTION_ZONE}" --project "${BASTION_PROJECT}" "${_GKA_SCP[@]}" "$1" "${BASTION_VM}:$2"; }
+  pull_dir()    { gcloud compute scp --tunnel-through-iap --recurse --zone "${BASTION_ZONE}" --project "${BASTION_PROJECT}" "${_GKA_SCP[@]}" "${BASTION_VM}:$1" "$2"; }
+fi
+
+# Run a check/command on the runner host: locally by default, on the bastion when
+# BENCH_REMOTE is set. (The detached matrix runner itself is launched separately.)
+host_exec() { if [ -n "${BENCH_REMOTE}" ]; then remote_exec "$1"; else bash -c "$1"; fi; }
+
+# Pull with a few retries — a drop during the final copy is otherwise fatal.
+pull_dir_retry() {
+  local src="$1" dst="$2" i
+  for i in 1 2 3 4 5; do
+    if pull_dir "${src}" "${dst}"; then return 0; fi
+    echo "    pull attempt ${i} failed; retrying in 15s..." >&2
+    sleep 15
+  done
+  echo "ERROR: could not pull ${src} after retries; results remain on the bastion at ~/${src}" >&2
+  return 1
+}
+
+sanitize() { echo "$1" | tr '/.+ ' '----' | tr -cd 'A-Za-z0-9_-'; }
+
+# ALL -> enumerate every task.yaml under complextasks/ + tasks/; else the list.
+resolve_tasks() {
+  if [ "${MATRIX_TASKS}" = "ALL" ]; then
+    ( cd "${REPO_ROOT}" && find complextasks tasks -name task.yaml 2>/dev/null | sort )
+  else
+    printf '%s\n' ${MATRIX_TASKS}
+  fi
+}
+
+# Poll until the remote .done marker appears. Resilient: a failed SSH check is
+# read as "not finished yet" and retried next tick, so brief drops don't abort
+# (the run itself is detached via nohup and unaffected). Arg: expected combo count.
+_poll_until_done() {
+  local expected="$1" done_n
+  echo "==> waiting for ${expected} run(s) (poll 60s; runs continue if this exits)"
+  while true; do
+    if host_exec "test -f \$HOME/${REMOTE_OUT}/.done" 2>/dev/null; then break; fi
+    done_n="$(host_exec "ls \$HOME/${REMOTE_OUT}/*/status 2>/dev/null | wc -l" 2>/dev/null | tr -d '[:space:]' || echo 0)"
+    echo "    ${done_n}/${expected} finished... ($(date +%H:%M:%S))"
+    sleep 60
+  done
+}
+
+# Pull results (with retry) and summarize from the pulled dirs. Reads the local
+# <rid> subdirs rather than COMBOS, so it also serves RESUME_STAMP attach.
+_pull_and_summarize() {
+  mkdir -p "${RESULTS_DIR}"
+  local LOCAL_OUT
+  if [ -n "${BENCH_REMOTE}" ]; then
+    echo "==> pulling results -> ${RESULTS_DIR}/${STAMP}"
+    pull_dir_retry "${REMOTE_OUT}" "${RESULTS_DIR}" || return 1
+    LOCAL_OUT="${RESULTS_DIR}/${STAMP}"
+  else
+    LOCAL_OUT="$HOME/${REMOTE_OUT}"
+    echo "==> local results at ${LOCAL_OUT}"
+  fi
+
+  echo "==> summary"
+  printf '%-56s %-8s %s\n' "COMBO" "EXIT" "results.json"
+  local d rid st rj
+  for d in "${LOCAL_OUT}"/*/; do
+    [ -d "$d" ] || continue
+    rid="$(basename "$d")"
+    st="$(cat "${d%/}/status" 2>/dev/null || echo '?')"
+    rj="$(find "${d}" -name results.json 2>/dev/null | head -1)"
+    printf '%-56s %-8s %s\n' "${rid}" "${st}" "${rj:-<none>}"
+  done
+  echo "==> done. results under ${LOCAL_OUT} (each combo provisioned + tore down its own cluster)"
+}
+
+# Run the COMBOS matrix. Arg: a human label for logging.
+#
+# Resume/attach: set RESUME_STAMP=<stamp> (from an earlier run's output) to skip
+# launching and just re-poll + pull an existing remote run — for when the local
+# process died after the bastion runner was already launched.
+matrix_dispatch() {
+  local label="$1"
+
+  if [ -n "${RESUME_STAMP:-}" ]; then
+    STAMP="${RESUME_STAMP}"
+    REMOTE_OUT="matrix-runs/${STAMP}"
+    local where; where="localhost"; [ -n "${BENCH_REMOTE}" ] && where="${BASTION_VM}"
+    echo "==> RESUME: attaching to existing run ~/${REMOTE_OUT} on ${where}"
+    host_exec "test -d \$HOME/${REMOTE_OUT}" 2>/dev/null \
+      || { echo "ERROR: no run at ~/${REMOTE_OUT} on ${where}" >&2; exit 2; }
+    local exp
+    exp="$(host_exec "ls -d \$HOME/${REMOTE_OUT}/*/ 2>/dev/null | wc -l" 2>/dev/null | tr -d '[:space:]' || echo '?')"
+    _poll_until_done "${exp}"
+    _pull_and_summarize
+    return $?
+  fi
+
+  echo "==> ${label} matrix: ${#COMBOS[@]} combo(s), MAX_PARALLEL=${MAX_PARALLEL}"
+  printf '    %s\n' "${COMBOS[@]%%|*}"
+
+  if [ -n "${DRY_RUN}" ]; then
+    echo "==> DRY_RUN: per-combo env (not executing):"
+    local c rid task kvs arm
+    for c in "${COMBOS[@]}"; do
+      IFS='|' read -r rid task kvs arm <<<"$c"
+      echo "  [${rid}] arm=${arm} task=${task}"
+      echo "      ${kvs}"
+    done
+    echo "==> DRY_RUN: results would land in ${RESULTS_DIR}/${STAMP}"
+    return 0
+  fi
+
+  [ "${#COMBOS[@]}" -gt 0 ] || { echo "ERROR: empty matrix" >&2; exit 2; }
+  [ -n "${GCP_PROJECT_ID:-}" ] || { echo "ERROR: set GCP_PROJECT_ID" >&2; exit 2; }
+
+  if [ -n "${BENCH_REMOTE}" ] && [ -z "${SKIP_SYNC:-}" ]; then
+    echo "==> syncing working tree to ${BASTION_VM}"
+    "${REPO_ROOT}/scripts/bastion/sync-to-bastion.sh"
+  fi
+
+  local runner; runner="$(mktemp -t matrix-runner-XXXXXX.sh)"
+  trap 'rm -f "${runner}"' RETURN
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'set -uo pipefail'
+    if [ -n "${BENCH_REMOTE}" ]; then echo "cd ~/${REMOTE_DIR}"; else echo "cd '${REPO_ROOT}'"; fi
+    echo '[ -f .venv/bin/activate ] && source .venv/bin/activate || true'
+    echo 'set -a; [ -f ~/secrets.env ] && . ~/secrets.env; set +a'
+    if [ -n "${BENCH_VERTEX:-}" ]; then
+      # Vertex mode: drop every API key secrets.env exported so agents AND judges
+      # fall back to ADC (the bastion VM SA via the metadata server), then point
+      # everything at Vertex. Location is global — the gemini-3.x *-preview models
+      # 404 on regional endpoints (us-central1). The legacy judge defaults to
+      # us-central1, so GCP_VERTEX_LOCATION must override it too.
+      echo 'unset AGENT_API_KEY GEMINI_API_KEY GOOGLE_API_KEY JUDGE_API_KEY GOOGLE_GENAI_API_KEY'
+      # The literal marker tells oc's google-vertex provider "use ADC". Passing it
+      # via env (not `oc models auth paste-api-key`) is what makes it PORTABLE
+      # across oc's isolated per-run OPENCLAW_STATE_DIRs — a pasted profile lives
+      # only in the global agent sqlite store, which parallel runs don't share, so
+      # they'd fail with `No API key found for provider "google-vertex"`. The
+      # gemini CLI and the google-genai judge ignore it (they pick ADC from
+      # GOOGLE_GENAI_USE_VERTEXAI + project/location).
+      echo 'export GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials'
+      echo "export GOOGLE_GENAI_USE_VERTEXAI=true GOOGLE_CLOUD_PROJECT='${GCP_PROJECT_ID}' GOOGLE_CLOUD_LOCATION='${GOOGLE_CLOUD_LOCATION:-global}' GCP_VERTEX_LOCATION='${GCP_VERTEX_LOCATION:-global}'"
+    fi
+    echo "OUT=\"\$HOME/${REMOTE_OUT}\"; mkdir -p \"\$OUT\""
+    echo "export GCP_PROJECT_ID='${GCP_PROJECT_ID}' GKE_CLUSTER_NAME='${GKE_CLUSTER_NAME}' GCP_LOCATION='${GCP_LOCATION}'"
+    echo "export AGENT_PROVIDER='${AGENT_PROVIDER}' JUDGE_PROVIDER='${JUDGE_PROVIDER}' JUDGE_MODEL='${JUDGE_MODEL}'"
+    echo "export BENCH_PARALLEL=true"
+    echo 'run_one() {'
+    echo '  local rid="$1" task="$2" kvs="$3" arm="$4" kv rc rdir'
+    echo '  local d="$OUT/$rid"; mkdir -p "$d"'
+    echo '  ('
+    echo '    export RUN_ID="$rid"'
+    echo '    # eval so values like AGENT_MCP_SERVER=$HOME/gke-mcp expand on the bastion'
+    echo '    IFS=";"; for kv in $kvs; do eval "export ${kv}"; done'
+    echo '    if [ "$arm" = "legacy" ]; then'
+    echo '      python3 pkg/evaluator/evaluate.py "$task"; rc=$?'
+    echo '      # legacy writes results/run_<ts>_<rid>; copy it into the combo dir'
+    echo '      rdir="$(ls -dt results/run_*_"$rid" 2>/dev/null | head -1)"'
+    echo '      [ -n "$rdir" ] && cp -a "$rdir/." "$d/" 2>/dev/null || true'
+    echo '    else'
+    echo '      python3 -m devops_bench --parallel --run-id "$rid" \'
+    echo '        --project "$GCP_PROJECT_ID" --cluster "$GKE_CLUSTER_NAME" \'
+    echo '        --results-root "$d" "$task"; rc=$?'
+    echo '    fi'
+    echo '    echo "exit=$rc" >"$d/status"'
+    echo '  ) >"$d/run.log" 2>&1'
+    echo '}'
+    echo "SEM=${MAX_PARALLEL}"
+    local c rid task kvs arm
+    for c in "${COMBOS[@]}"; do
+      IFS='|' read -r rid task kvs arm <<<"$c"
+      printf 'run_one %q %q %q %q &\n' "$rid" "$task" "$kvs" "$arm"
+      echo 'while [ "$(jobs -r | wc -l)" -ge "$SEM" ]; do wait -n; done'
+    done
+    echo 'wait'
+    echo "echo ALL_DONE >\"\$HOME/${REMOTE_OUT}/.done\""
+  } >"${runner}"
+
+  # Per-stamp runner path so two matrices (e.g. refactored + legacy) can be
+  # launched in parallel without clobbering each other's runner script.
+  local staged_runner="/tmp/matrix-runner-${STAMP}.sh"
+  # Create the output dir (and its parent) BEFORE the nohup redirect — the
+  # ``>...${REMOTE_OUT}.out`` target dir must exist or the job never starts.
+  if [ -n "${BENCH_REMOTE}" ]; then
+    echo "==> uploading + launching remote runner (detached)"
+    push_file "${runner}" "${staged_runner}"
+    remote_exec "mkdir -p \$HOME/${REMOTE_OUT}; chmod +x ${staged_runner}; nohup ${staged_runner} >\$HOME/${REMOTE_OUT}.out 2>&1 & echo launched pid=\$!"
+  else
+    echo "==> launching local runner (detached)"
+    cp "${runner}" "${staged_runner}"; chmod +x "${staged_runner}"
+    mkdir -p "$HOME/${REMOTE_OUT}"
+    nohup "${staged_runner}" >"$HOME/${REMOTE_OUT}.out" 2>&1 & echo "launched pid=$!"
+  fi
+  echo "    (to re-attach if this exits: RESUME_STAMP=${STAMP} re-run the same command)"
+
+  _poll_until_done "${#COMBOS[@]}"
+  _pull_and_summarize
+}

--- a/scripts/bastion/configure-oc.sh
+++ b/scripts/bastion/configure-oc.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Configure the GLOBAL ~/.openclaw config for a run mode, on the bastion.
+#
+# Why this is separate from vm-setup.sh: only the LEGACY arm reads the global oc
+# config — the refactored arm wires MCP/skills per-run via env
+# (AGENT_MCP_SERVER / AGENT_SKILLS_PATHS / BENCH_USE_MCP). Keeping this out of
+# the one-time setup means MCP/skills are a per-run-mode choice: run this with
+# --mcp/--skills before a legacy "with capabilities" run, or with --no-mcp /
+# --no-skills (or just don't run it) for a clean "no capabilities" run.
+#
+# Idempotent. Also stores the agent model API key in oc (from ~/secrets.env), so
+# both arms authenticate without baking the key into oc during provisioning.
+#
+# Usage:
+#   scripts/bastion/configure-oc.sh [--mcp|--no-mcp] [--skills|--no-skills] [--vertex]
+#
+# --vertex registers oc's built-in ``google-vertex`` provider in the global
+# config so the legacy arm can target ``google-vertex/<model>`` via the bastion
+# VM SA's ADC (no API keys). It writes the provider's ``api``/``baseUrl``/model
+# entries (without ``api: google-vertex`` oc would route the provider through the
+# OpenAI transport), allowlists the models for the agent, and pastes the ADC
+# marker. At run time the matrix still exports
+# GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials (see _matrix_lib.sh BENCH_VERTEX),
+# which is what makes auth portable across parallel runs' isolated state dirs.
+#
+# Env overrides:
+#   GKE_MCP_BIN    path to the gke-mcp binary    (default: ~/gke-mcp)
+#   SECRETS_ENV    file exporting GEMINI_API_KEY  (default: ~/secrets.env)
+#   SKILLS_SRC     dir of skill markdowns         (default: ~/devops-bench/skills)
+#   OC_SKILLS_DIR  staging dir for <name>/SKILL.md (default: ~/oc-skills)
+#   VERTEX_MODELS  space-separated model ids to register under google-vertex
+#                  (default: "gemini-3.1-pro-preview gemini-3-flash-preview")
+#   OPENCLAW_AGENT oc agent profile for the auth marker (default: main)
+set -euo pipefail
+
+WANT_MCP=1
+WANT_SKILLS=1
+WANT_VERTEX=0
+GKE_MCP_BIN="${GKE_MCP_BIN:-${HOME}/gke-mcp}"
+SECRETS_ENV="${SECRETS_ENV:-${HOME}/secrets.env}"
+SKILLS_SRC="${SKILLS_SRC:-${HOME}/devops-bench/skills}"
+OC_SKILLS_DIR="${OC_SKILLS_DIR:-${HOME}/oc-skills}"
+VERTEX_MODELS="${VERTEX_MODELS:-gemini-3.1-pro-preview gemini-3-flash-preview}"
+OPENCLAW_AGENT="${OPENCLAW_AGENT:-main}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mcp) WANT_MCP=1 ;;
+    --no-mcp) WANT_MCP=0 ;;
+    --skills) WANT_SKILLS=1 ;;
+    --no-skills) WANT_SKILLS=0 ;;
+    --vertex) WANT_VERTEX=1 ;;
+    --no-vertex) WANT_VERTEX=0 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+command -v oc >/dev/null 2>&1 || { echo "ERROR: oc not on PATH" >&2; exit 1; }
+
+# --- 1. Agent model API key -> oc auth (idempotent) ------------------------- #
+if [ -f "${SECRETS_ENV}" ]; then
+  # shellcheck disable=SC1090
+  . "${SECRETS_ENV}"
+  KEY="${GEMINI_API_KEY:-${GOOGLE_API_KEY:-}}"
+  if [ -n "${KEY}" ]; then
+    printf '%s\n' "${KEY}" | oc models auth paste-api-key --provider google >/dev/null \
+      && echo "==> oc model auth set (google)"
+  else
+    echo "==> WARN: no GEMINI_API_KEY/GOOGLE_API_KEY in ${SECRETS_ENV}; skipping oc auth"
+  fi
+else
+  echo "==> WARN: ${SECRETS_ENV} not found; skipping oc auth"
+fi
+
+# --- 2. GKE MCP server ------------------------------------------------------ #
+oc mcp unset gke-mcp >/dev/null 2>&1 || true   # idempotent: clear any prior entry
+if [ "${WANT_MCP}" = "1" ]; then
+  [ -x "${GKE_MCP_BIN}" ] || { echo "ERROR: gke-mcp not executable at ${GKE_MCP_BIN}" >&2; exit 1; }
+  oc mcp add gke-mcp --command "${GKE_MCP_BIN}" --no-probe >/dev/null
+  echo "==> gke-mcp registered (global oc config)"
+else
+  echo "==> gke-mcp NOT registered (--no-mcp)"
+fi
+
+# --- 3. Skills (reshape *.md -> <name>/SKILL.md, install --global) ---------- #
+managed_skills_dir="${HOME}/.openclaw/skills"
+if [ "${WANT_SKILLS}" = "1" ]; then
+  [ -d "${SKILLS_SRC}" ] || { echo "ERROR: skills source ${SKILLS_SRC} not found" >&2; exit 1; }
+  mkdir -p "${OC_SKILLS_DIR}"
+  for f in "${SKILLS_SRC}"/*.md; do
+    [ -f "$f" ] || continue
+    name="$(awk -F': ' '/^name:/{print $2; exit}' "$f" | tr -d '\r')"
+    [ -n "${name}" ] || name="$(basename "$f" .md)"
+    mkdir -p "${OC_SKILLS_DIR}/${name}"
+    cp "$f" "${OC_SKILLS_DIR}/${name}/SKILL.md"
+    oc skills install "${OC_SKILLS_DIR}/${name}" --global --force >/dev/null
+    echo "==> skill installed: ${name}"
+  done
+else
+  # Remove any skills this script previously installed, leaving oc's bundled ones.
+  if [ -d "${OC_SKILLS_DIR}" ]; then
+    for d in "${OC_SKILLS_DIR}"/*/; do
+      [ -d "$d" ] || continue
+      rm -rf "${managed_skills_dir}/$(basename "$d")"
+    done
+  fi
+  echo "==> skills NOT installed (--no-skills)"
+fi
+
+# --- 4. Vertex provider (optional) ------------------------------------------ #
+if [ "${WANT_VERTEX}" = "1" ]; then
+  # Paste the ADC marker so `oc agent` works even outside the matrix (the matrix
+  # itself relies on the GOOGLE_CLOUD_API_KEY env marker for parallel-safe auth).
+  printf 'gcp-vertex-credentials\n' \
+    | oc models auth --agent "${OPENCLAW_AGENT}" paste-api-key --provider google-vertex >/dev/null \
+    && echo "==> oc google-vertex auth marker set (agent ${OPENCLAW_AGENT})"
+  # Ensure the provider routes through the google-vertex transport (api field) and
+  # the models are registered + allowlisted for the agent. Idempotent.
+  OC_CONFIG="${HOME}/.openclaw/openclaw.json" VERTEX_MODELS="${VERTEX_MODELS}" \
+  OPENCLAW_AGENT="${OPENCLAW_AGENT}" python3 - <<'PY'
+import json, os
+path = os.environ["OC_CONFIG"]
+models = os.environ["VERTEX_MODELS"].split()
+agent = os.environ["OPENCLAW_AGENT"]
+with open(path) as f:
+    cfg = json.load(f)
+prov = cfg.setdefault("models", {}).setdefault("providers", {}).setdefault("google-vertex", {})
+prov["api"] = "google-vertex"
+prov["baseUrl"] = "https://{location}-aiplatform.googleapis.com"
+existing = {m.get("id") for m in prov.get("models", []) if isinstance(m, dict)}
+prov.setdefault("models", [])
+for m in models:
+    if m not in existing:
+        prov["models"].append({"id": m, "name": m})
+# Allowlist google-vertex/<model> for the agent's per-run --model override.
+allow = cfg.setdefault("agents", {}).setdefault("defaults", {}).setdefault("models", {})
+for m in models:
+    allow.setdefault(f"google-vertex/{m}", {})
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+print(f"==> google-vertex provider registered + allowlisted: {', '.join(models)}")
+PY
+else
+  echo "==> google-vertex provider NOT registered (use --vertex for Vertex/ADC runs)"
+fi
+
+echo "==> oc configured (mcp=${WANT_MCP} skills=${WANT_SKILLS} vertex=${WANT_VERTEX}). 'oc mcp list' / 'oc skills list' to verify."

--- a/scripts/bastion/run_matrix.sh
+++ b/scripts/bastion/run_matrix.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Parallel eval matrix — REFACTORED arm (python -m devops_bench). Runs locally by
+# default; set BENCH_REMOTE=1 to sync + run on the bastion over ssh.
+# Dimensions: Task x Model x AgentConfig. Run from your workstation; results are
+# copied back locally. (Legacy arm: scripts/bastion/run_matrix_legacy.sh.)
+#
+# Agent-config presets: "<oc|gcli>[+mcp][+skills]" (oc=openclaw, gcli=gemini).
+# The refactored arm wires MCP/skills per-run via env, so every combo is fully
+# independent. CUJs:
+#
+#   1) one task, many models, one config
+#      MATRIX_TASKS="complextasks/secret-rotation/task.yaml" \
+#      MATRIX_MODELS="gemini-3.1-pro gemini-3.5-flash" \
+#      MATRIX_AGENT_CONFIGS="gcli+mcp+skills" GCP_PROJECT_ID=<proj> run_matrix.sh
+#
+#   2) one task, one model, many configs
+#      MATRIX_AGENT_CONFIGS="oc oc+mcp+skills gcli gcli+mcp+skills" ... run_matrix.sh
+#
+#   3) all tasks, one model, one config
+#      MATRIX_TASKS=ALL MATRIX_MODELS="gemini-3.1-pro" MATRIX_AGENT_CONFIGS="oc+mcp+skills" ... run_matrix.sh
+#
+# DRY_RUN=1 prints the expanded matrix + per-combo env without provisioning.
+# See _matrix_lib.sh for the full connection/run-config env and docs/bastion.md.
+set -euo pipefail
+
+# shellcheck source=scripts/bastion/_matrix_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_matrix_lib.sh"
+
+MATRIX_AGENT_CONFIGS="${MATRIX_AGENT_CONFIGS:-oc+mcp+skills}"
+
+# Translate an agent-config preset into the refactored arm's env (';'-joined).
+# <type> is oc|gcli; +mcp / +skills toggle capabilities.
+agent_config_env() {
+  local preset="$1" type feat want_mcp=0 want_skills=0 out=()
+  type="${preset%%+*}"
+  case "$type" in
+    oc)   out+=("BENCH_AGENT_TYPE=openclaw" "AGENT_TARGET=oc" "OPENCLAW_BIN=oc" "OPENCLAW_AGENT=main") ;;
+    gcli) out+=("BENCH_AGENT_TYPE=cli" "AGENT_TARGET=gemini") ;;
+    *) echo "ERROR: unknown agent type '${type}' in preset '${preset}'" >&2; return 1 ;;
+  esac
+  for feat in $(echo "${preset}" | tr '+' ' '); do
+    case "$feat" in mcp) want_mcp=1 ;; skills) want_skills=1 ;; esac
+  done
+  if [ "${want_mcp}" = 1 ]; then out+=("BENCH_USE_MCP=true" "AGENT_MCP_SERVER=${GKE_MCP_BIN}"); else out+=("BENCH_USE_MCP=false"); fi
+  [ "${want_skills}" = 1 ] && out+=("AGENT_SKILLS_PATHS=${SKILLS_PATHS}")
+  ( IFS=';'; echo "${out[*]}" )
+}
+
+COMBOS=()
+while IFS= read -r task; do
+  [ -n "${task}" ] || continue
+  tname="$(basename "$(dirname "${task}")")"
+  for model in ${MATRIX_MODELS}; do
+    for preset in ${MATRIX_AGENT_CONFIGS}; do
+      cfg="$(agent_config_env "${preset}")" || exit 1
+      kvs="AGENT_MODEL=${model};AGENT_PROVIDER=${AGENT_PROVIDER};${cfg}"
+      rid="$(sanitize "${tname}")__$(sanitize "${model}")__$(sanitize "${preset}")"
+      COMBOS+=("${rid}|${task}|${kvs}|refactored")
+    done
+  done
+done < <(resolve_tasks)
+
+matrix_dispatch "refactored (Task x Model x AgentConfig)"

--- a/scripts/bastion/run_matrix_legacy.sh
+++ b/scripts/bastion/run_matrix_legacy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Parallel eval matrix — LEGACY arm (pkg/evaluator/evaluate.py). Runs locally by
+# default; set BENCH_REMOTE=1 to sync + run on the bastion over ssh.
+# Dimensions: Task x Model ONLY (no AgentConfig — the legacy arm reads MCP/skills
+# from the GLOBAL ~/.openclaw config, so capabilities are fixed for the whole
+# matrix; set them once with scripts/bastion/configure-oc.sh).
+#
+# This is a thin, throwaway companion to run_matrix.sh (the refactored matrix);
+# delete it when the legacy arm is retired — the shared _matrix_lib.sh stays.
+#
+# OpenClaw-only BY DESIGN, not just by default: the legacy Gemini runner reads
+# its trajectory from the shared ~/.gemini/tmp/.../chats dir keyed by a short
+# session id, which is NOT safe under concurrent runs. For parallel Gemini use
+# the refactored matrix (run_matrix.sh, MATRIX_AGENT_CONFIGS="gcli..."). See
+# docs/bastion.md "Parallel agent support".
+#
+# CUJs supported: one task x many models, and all tasks x one model. E.g.:
+#   MATRIX_TASKS="complextasks/secret-rotation/task.yaml" \
+#   MATRIX_MODELS="gemini-3.1-pro gemini-3.5-flash" \
+#   GCP_PROJECT_ID=<proj> run_matrix_legacy.sh
+#
+#   MATRIX_TASKS=ALL MATRIX_MODELS="gemini-3.1-pro" GCP_PROJECT_ID=<proj> run_matrix_legacy.sh
+#
+# Prereq: run `scripts/bastion/configure-oc.sh --mcp --skills` (or --no-*) once
+# to set the global oc config the legacy arm uses. DRY_RUN=1 previews the matrix.
+set -euo pipefail
+
+# shellcheck source=scripts/bastion/_matrix_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_matrix_lib.sh"
+
+# Legacy openclaw (local) env — fixed; capabilities come from the global oc config.
+LEGACY_KVS="BENCH_AGENT_TYPE=cli;AGENT_TARGET=oc;OPENCLAW_BIN=oc;OPENCLAW_LOCAL=true;OPENCLAW_AGENT=main"
+
+COMBOS=()
+while IFS= read -r task; do
+  [ -n "${task}" ] || continue
+  tname="$(basename "$(dirname "${task}")")"
+  for model in ${MATRIX_MODELS}; do
+    kvs="AGENT_MODEL=${model};AGENT_PROVIDER=${AGENT_PROVIDER};${LEGACY_KVS}"
+    rid="$(sanitize "${tname}")__$(sanitize "${model}")__legacy"
+    COMBOS+=("${rid}|${task}|${kvs}|legacy")
+  done
+done < <(resolve_tasks)
+
+matrix_dispatch "legacy (Task x Model)"

--- a/scripts/bastion/sync-to-bastion.sh
+++ b/scripts/bastion/sync-to-bastion.sh
@@ -34,7 +34,12 @@ cd "${REPO_ROOT}"
 # The subset the harness needs on the VM. Missing paths are skipped silently.
 PATHS=(
   devops_bench
+  pkg               # legacy arm (pkg/evaluator/evaluate.py etc.) for comparison runs
+  deployers         # legacy top-level deployers used by the legacy arm
+  skills            # judge/agent skill markdowns (legacy metrics read skills/*.md)
   pyproject.toml
+  README.md         # required by `pip install .` (pyproject readme = README.md)
+  LICENSE
   complextasks
   tasks
   tf

--- a/scripts/bastion/vm-setup.sh
+++ b/scripts/bastion/vm-setup.sh
@@ -55,6 +55,43 @@ else
   echo "    NOTE: run 'openclaw onboard' to configure the agent model API key."
 fi
 
+# Gemini CLI (the 'gemini' agent target for gcli runs). oc is installed
+# system-wide by startup.sh; this finishes the other agent CLI. Node's global
+# prefix is root-owned, so install with sudo. Idempotent.
+echo "==> gemini CLI check"
+if command -v gemini >/dev/null 2>&1; then
+  echo "    gemini present: $(gemini --version 2>/dev/null | head -1)"
+else
+  echo "    installing @google/gemini-cli (sudo npm -g)..."
+  sudo npm install -g @google/gemini-cli \
+    && echo "    gemini installed: $(gemini --version 2>/dev/null | head -1)" \
+    || echo "    WARN: gemini CLI install failed; gcli agent runs will not work until it's installed."
+fi
+
+# Disable Gemini CLI folder-trust gating at the USER level. The gcli agent runs
+# in a fresh, untrusted per-run temp cwd; untrusted folders have their MCP
+# servers (e.g. gke-mcp) suppressed, and a workspace-level setting can't lift it
+# (untrusted folders ignore their own settings.json) — nor does the --skip-trust
+# flag. Setting it here lets gke-mcp connect for every run. Merge-preserving +
+# idempotent.
+echo "==> gemini folder-trust (~/.gemini/settings.json: security.folderTrust.enabled=false)"
+mkdir -p "${HOME}/.gemini"
+python3 - "${HOME}/.gemini/settings.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+    if not isinstance(cfg, dict):
+        cfg = {}
+except (FileNotFoundError, ValueError):
+    cfg = {}
+cfg.setdefault("security", {}).setdefault("folderTrust", {})["enabled"] = False
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+print(f"    wrote {path}")
+PY
+
 if [ ! -f "${ENV_FILE}" ]; then
   echo "==> writing ${ENV_FILE} template (fill in values, then 'source ~/bench.env')"
   cat > "${ENV_FILE}" <<'EOF'

--- a/tests/test_gcp_deployer.py
+++ b/tests/test_gcp_deployer.py
@@ -12,6 +12,13 @@ if str(project_root) not in sys.path:
 from deployers.gcp.gcp_deployer import GCPDeployer
 
 
+@pytest.fixture(autouse=True)
+def _clear_isolation_env(monkeypatch):
+    """Keep the marker path under /tmp for default tests by clearing the
+    per-run dir env that the parallel-isolation path would otherwise use."""
+    monkeypatch.delenv("BENCH_RUN_DIR", raising=False)
+
+
 @pytest.fixture
 def gcp_deployer_setup():
     project = "test-project"
@@ -114,6 +121,20 @@ def test_down(mock_run, gcp_deployer_setup):
             env = kwargs.get('env')
             assert env is not None
             assert deployer.bin_dir in env['PATH']
+
+
+def test_state_marker_defaults_to_tmp(gcp_deployer_setup):
+    deployer = gcp_deployer_setup["deployer"]
+    marker = deployer._state_marker_path()
+    assert marker == Path("/tmp/test-project-us-central1-a-test-cluster_created")
+
+
+def test_state_marker_honors_per_run_dir(gcp_deployer_setup, monkeypatch, tmp_path):
+    monkeypatch.setenv("BENCH_RUN_DIR", str(tmp_path))
+    deployer = gcp_deployer_setup["deployer"]
+    marker = deployer._state_marker_path()
+    assert marker.parent == tmp_path
+    assert marker.name == "test-project-us-central1-a-test-cluster_created"
 
 
 def test_get_cluster_info(gcp_deployer_setup):

--- a/tests/test_runenv.py
+++ b/tests/test_runenv.py
@@ -1,0 +1,71 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the legacy evaluator's per-run isolation helper."""
+
+import os
+
+from pkg.runenv import RunEnv, parallel_enabled
+
+
+def test_parallel_enabled(monkeypatch):
+    monkeypatch.delenv("BENCH_PARALLEL", raising=False)
+    assert parallel_enabled() is False
+    monkeypatch.setenv("BENCH_PARALLEL", "true")
+    assert parallel_enabled() is True
+    monkeypatch.setenv("BENCH_PARALLEL", "0")
+    assert parallel_enabled() is False
+
+
+def test_passthrough_when_not_parallel(monkeypatch):
+    monkeypatch.delenv("KUBECONFIG", raising=False)
+    monkeypatch.delenv("TF_DATA_DIR", raising=False)
+    run_env = RunEnv.create(parallel=False, run_id="fixed")
+    run_env.apply()
+    assert run_env.isolated is False
+    assert run_env.cluster_name("c") == "c"
+    assert "KUBECONFIG" not in os.environ
+    assert "TF_DATA_DIR" not in os.environ
+
+
+def test_apply_sets_isolated_env_and_creates_dirs(monkeypatch, tmp_path):
+    run_env = RunEnv.create(parallel=True, run_id="run-1", state_root=str(tmp_path))
+    run_env.apply()
+    expected = tmp_path / "run-1"
+    assert os.environ["KUBECONFIG"] == str(expected / "kubeconfig")
+    assert os.environ["CLOUDSDK_CONFIG"] == str(expected / "gcloud")
+    assert os.environ["TF_DATA_DIR"] == str(expected / "tf-data")
+    assert os.environ["RUN_ID"] == "run-1"
+    assert os.environ["BENCH_RUN_DIR"] == str(expected)
+    assert (expected / "gcloud").is_dir()
+    assert (expected / "tf-data").is_dir()
+
+
+def test_cluster_name_prefixed_deterministic_and_unique(tmp_path):
+    a = RunEnv.create(parallel=True, run_id="A", state_root=str(tmp_path))
+    a2 = RunEnv.create(parallel=True, run_id="A", state_root=str(tmp_path))
+    b = RunEnv.create(parallel=True, run_id="B", state_root=str(tmp_path))
+    assert a.cluster_name("hpa") == a2.cluster_name("hpa")
+    assert a.cluster_name("hpa") != b.cluster_name("hpa")
+    assert a.cluster_name("hpa").startswith(a.cluster_token)
+    # Token leads so it survives SA-name truncation at 10 chars.
+    assert a.cluster_name("hpa")[:10] != b.cluster_name("hpa")[:10]
+
+
+def test_cluster_name_respects_length_limit(tmp_path):
+    name = RunEnv.create(parallel=True, run_id="X", state_root=str(tmp_path)).cluster_name(
+        "a" * 60
+    )
+    assert len(name) <= 40
+    assert not name.endswith("-")

--- a/tests/test_tf_deployer.py
+++ b/tests/test_tf_deployer.py
@@ -14,6 +14,13 @@ if str(project_root) not in sys.path:
 from deployers.tf.tf_deployer import TFDeployer
 
 
+@pytest.fixture(autouse=True)
+def _clear_isolation_env(monkeypatch):
+    """Default tests assert state-flag-free argv; clear TF_DATA_DIR so the
+    parallel-isolation path does not leak in from the ambient environment."""
+    monkeypatch.delenv("TF_DATA_DIR", raising=False)
+
+
 @pytest.fixture
 def tf_deployer_setup():
     variables = {
@@ -83,6 +90,29 @@ def test_down(mock_run, tf_deployer_setup):
         "-var", "location=us-central1-a",
         "-var", "node_count=3"
     ]
+
+
+@patch('subprocess.run')
+def test_up_isolates_state_under_tf_data_dir(mock_run, tf_deployer_setup, monkeypatch, tmp_path):
+    monkeypatch.setenv("TF_DATA_DIR", str(tmp_path / "tf-data"))
+    tf_deployer_setup.up()
+
+    apply_argv = mock_run.call_args_list[1][0][0]
+    expected_state = str((tmp_path / "tf-data").resolve().parent / "terraform.tfstate")
+    assert "-state" in apply_argv
+    assert apply_argv[apply_argv.index("-state") + 1] == expected_state
+    # init does not carry -state.
+    assert "-state" not in mock_run.call_args_list[0][0][0]
+
+
+@patch('subprocess.run')
+def test_down_isolates_state_under_tf_data_dir(mock_run, tf_deployer_setup, monkeypatch, tmp_path):
+    monkeypatch.setenv("TF_DATA_DIR", str(tmp_path / "tf-data"))
+    tf_deployer_setup.down()
+
+    destroy_argv = mock_run.call_args_list[1][0][0]
+    expected_state = str((tmp_path / "tf-data").resolve().parent / "terraform.tfstate")
+    assert destroy_argv[destroy_argv.index("-state") + 1] == expected_state
 
 
 @patch('subprocess.run')

--- a/tf/prebuilt/secret-rotation/cluster/main.tf
+++ b/tf/prebuilt/secret-rotation/cluster/main.tf
@@ -4,25 +4,43 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
   }
+}
+
+# Per-run random suffix so concurrent runs of the same task never collide on the
+# project-global GCP resource names (service accounts, Secret Manager secrets).
+# Created once per run and stable on re-apply (it lives in this run's state). The
+# k8s namespace is intentionally NOT suffixed — it is cluster-scoped, so two
+# separate clusters can both use the same namespace.
+resource "random_id" "run" {
+  byte_length = 4
 }
 
 # 1. GKE Cluster Provisioning
 module "gke" {
-  source       = "../../../modules/gke"
-  project_id   = var.project_id
-  cluster_name = var.cluster_name
-  location     = var.location
+  source                   = "../../../modules/gke"
+  project_id               = var.project_id
+  cluster_name             = var.cluster_name
+  location                 = var.location
   node_count               = var.node_count
   machine_type             = var.machine_type
   enable_workload_identity = true
-  agent_service_account    = "openclaw-vm-sa@${var.project_id}.iam.gserviceaccount.com"
-  enable_iap_ssh           = true
+  # BYO-credentials model: the agent runs as the operator-provided broad runner
+  # identity (the bastion VM SA), which is assumed to already hold the infra
+  # perms it needs. So this stack does NOT grant it container.admin — the
+  # module's project-level grant is disabled here (empty string -> count 0) to
+  # avoid a shared binding that concurrent runs would fight over at teardown.
+  agent_service_account = ""
+  enable_iap_ssh        = true
 }
 
 # 3. GCP Secret Manager Setup
 resource "google_secret_manager_secret" "db_credentials" {
-  secret_id = "db-credentials-${var.namespace}"
+  secret_id = "db-credentials-${var.namespace}-${random_id.run.hex}"
   project   = var.project_id
   replication {
     auto {}
@@ -36,7 +54,7 @@ resource "google_secret_manager_secret_version" "db_credentials_v1" {
 
 # 4. GCP IAM & GSA Configuration
 resource "google_service_account" "secret_rotation_sa" {
-  account_id   = "sa-${var.namespace}"
+  account_id   = "sa-${var.namespace}-${random_id.run.hex}"
   display_name = "GSA for GKE ExternalSecrets Secret Manager access"
   project      = var.project_id
 }
@@ -53,10 +71,13 @@ resource "google_service_account_iam_member" "workload_identity" {
   member             = "serviceAccount:${var.project_id}.svc.id.goog[external-secrets/external-secrets]"
 }
 
-# 10. Grant permissions to OpenClaw VM Service Account
-
-resource "google_project_iam_member" "openclaw_vm_secret_admin" {
-  project = var.project_id
-  role    = "roles/secretmanager.admin"
-  member  = "serviceAccount:openclaw-vm-sa@${var.project_id}.iam.gserviceaccount.com"
-}
+# 10. Runner identity: BYO credentials.
+#
+# The agent runs as the operator-provided broad runner identity (the bastion VM
+# SA, assumed pre-provisioned with the infra permissions it needs). This stack
+# intentionally grants that identity NOTHING: adding per-run/project bindings to
+# a shared SA is what caused concurrent runs to fight at teardown (one run's
+# destroy revoked the binding the other still needed). A least-privilege,
+# per-run runner SA is a tracked follow-up. The per-run resources above (the
+# workload SA + secret) are name-suffixed via random_id so concurrent runs of
+# this task never collide.

--- a/tf/prebuilt/secret-rotation/cluster/outputs.tf
+++ b/tf/prebuilt/secret-rotation/cluster/outputs.tf
@@ -10,6 +10,11 @@ output "secret_rotation_sa_email" {
   value = google_service_account.secret_rotation_sa.email
 }
 
+output "secret_id" {
+  description = "The (run-suffixed) Secret Manager secret id the ExternalSecret must reference."
+  value       = google_secret_manager_secret.db_credentials.secret_id
+}
+
 output "endpoint" {
   value = module.gke.endpoint
 }

--- a/tf/prebuilt/secret-rotation/k8s_config/main.tf
+++ b/tf/prebuilt/secret-rotation/k8s_config/main.tf
@@ -54,5 +54,10 @@ resource "helm_release" "workloads" {
     value = var.namespace
   }
 
+  set {
+    name  = "secretName"
+    value = var.secret_id
+  }
+
   depends_on = [helm_release.external_secrets]
 }

--- a/tf/prebuilt/secret-rotation/k8s_config/variables.tf
+++ b/tf/prebuilt/secret-rotation/k8s_config/variables.tf
@@ -13,3 +13,8 @@ variable "secret_rotation_sa_email" {
   description = "GCP IAM Service Account Email for Workload Identity annotation"
 }
 
+variable "secret_id" {
+  type        = string
+  description = "Run-suffixed Secret Manager secret id the ExternalSecret references."
+}
+

--- a/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/templates/external-secret.yaml
+++ b/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/templates/external-secret.yaml
@@ -14,5 +14,5 @@ spec:
   data:
     - secretKey: password
       remoteRef:
-        key: "db-credentials-{{ .Values.namespace }}"
+        key: {{ .Values.secretName | quote }}
         version: "1"

--- a/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/values.yaml
+++ b/tf/prebuilt/secret-rotation/k8s_config/workloads-chart/values.yaml
@@ -1,2 +1,3 @@
 projectID: ""
 namespace: ""
+secretName: ""

--- a/tf/prebuilt/secret-rotation/main.tf
+++ b/tf/prebuilt/secret-rotation/main.tf
@@ -54,6 +54,7 @@ module "k8s_config" {
   project_id               = var.project_id
   namespace                = var.namespace
   secret_rotation_sa_email = module.cluster.secret_rotation_sa_email
+  secret_id                = module.cluster.secret_id
 
   depends_on = [module.cluster]
 }


### PR DESCRIPTION
Mirror the per-run isolation onto the legacy pkg/ evaluator pipeline so it can
also run in parallel for legacy-vs-refactored comparison:

- pkg/runenv.py per-run isolation primitive; unique cluster name per run.
- Legacy TF state isolated per run; per-run gcp create marker.
- Chaos port-forward binds a free local port (pkg manager/evaluator).
- OpenClaw runner state isolated per run; per-run --model; configurable agent.
- Run id appended to the result dir.
