### PR TITLE
skills: agent skills home (devops-bench-review + run-parallel-evals + run-eval)

### DIFF
--- a/.agents/skills/devops-bench-review/SKILL.md
+++ b/.agents/skills/devops-bench-review/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: devops-bench-review
+description: >
+  Use when the user asks for a comprehensive review of devops-bench changes —
+  e.g. "review this PR", "review the workspace", "review my changes", "is this
+  task parallel-safe", "review this new task/stack/doc", "will this break under
+  the parallel matrix". Reviews a PR (number/URL) or the current working tree
+  across four lenses — correctness, parallel-safety across the eval matrix axes,
+  task/stack conventions, and docs conventions — and returns ranked, actionable
+  findings. The parallel-safety lens is the emphasis: it hunts for shared state
+  that makes a task fail when many runs execute at once. This skill is
+  review-only: it analyzes statically and may run unit tests, linting, and
+  formatting checks, but it NEVER runs benchmark evals or provisions infra.
+---
+
+# devops-bench comprehensive review
+
+Review either a **GitHub PR** or the **current workspace** for devops-bench, then
+return ranked findings a maintainer would act on. The defining lens here — beyond
+ordinary correctness — is **parallel-safety**: this repo runs an eval matrix
+(Task × Model × AgentConfig) where many evaluations execute concurrently on one
+host, and the most common way a new task/stack/script is "correct alone but wrong
+in the matrix" is that it touches a resource shared across runs.
+
+**Read these first when the change touches tasks, TF stacks, or run isolation —
+they are the source of truth; don't reconstruct them from memory:**
+- `docs/parallel-evals.md` — per-run isolation model, the **parallel-safety
+  matrix**, the **failure-mode -> fix** table, and the **known-issues** appendix.
+- `docs/bastion.md` — bastion architecture, provisioning, per-run isolation.
+- The isolation primitive itself: `devops_bench/core/run_env.py` (`RunEnv`) and
+  its legacy mirror `pkg/runenv.py`. Confirm what it actually isolates before
+  asserting a collision is or isn't covered.
+- Governing **agent-instruction files** — whichever your harness uses (`CLAUDE.md`,
+  `AGENTS.md`, `GEMINI.md`), at user level and at the repo root, plus any in a
+  directory that is an ancestor of a changed file — quote the exact rule when you
+  flag a violation.
+
+Work the phases in order. Default to **precision**: every finding should name a
+concrete failure (inputs/state -> wrong outcome), not a style preference.
+
+---
+
+## Scope & guardrails — review only, never run evals
+
+This skill **analyzes and reports**. It does **not** execute the benchmark, and it
+finds parallel-run hazards by **reading and reasoning** about the task/stack/
+scripts — never by launching runs to observe a collision.
+
+**May run** (only to validate the code under review):
+- Unit / integration tests for the changed code (`pytest` / the repo's runner).
+- Linting (`ruff`) and formatting **checks** (e.g. `ruff format --check`) — report
+  violations; do not reformat or modify files as part of a review.
+
+**Must NOT run — out of scope, stop and report instead:**
+- Benchmark evaluations or the eval matrix: `pkg/evaluator/evaluate.py`,
+  `python -m devops_bench`, `scripts/bastion/run_matrix*.sh`, or any agent/judge
+  invocation.
+- Infrastructure provisioning or teardown: `tofu`/`terraform apply|destroy|plan|
+  init`, `gcloud ... create/delete`, `kind create/delete cluster`, `kubectl
+  apply/delete`.
+- Anything that spends cloud resources or calls a model/agent API.
+
+If reviewing a change would seem to *require* running it (e.g. "does this task
+actually pass?"), do not run it — report what static analysis shows and state that
+an actual eval run is out of scope for this skill.
+
+---
+
+## Phase 0 — Scope the target and gather the diff
+
+Determine the target from the user's request:
+
+- **A PR** (number or URL): use `gh`, not local git.
+  - `gh pr view <target> --json title,body,author,baseRefName,headRefName,state,additions,deletions,changedFiles,labels`
+  - `gh pr diff <target>`
+  - When an angle needs surrounding code, Read the file in this checkout if it
+    matches the PR branch, else fetch with `git show <ref>:<path>` / `gh`.
+- **The current workspace** ("review my changes / the workspace"):
+  - `git diff @{upstream}...HEAD` (or `git diff main...HEAD` / `git diff HEAD~1`),
+    and also `git diff HEAD` when there are uncommitted changes — review is often
+    run pre-commit. Treat the union as scope.
+
+The diff is the review scope. For each touched function, also Read the enclosing
+function — bugs on unchanged lines of a touched function are in scope (the change
+re-exposes or fails to fix them).
+
+If the change references another PR's mechanism (e.g. "works with the parallel
+isolation from PR #N"), fetch that PR's relevant files too, so you review the
+**interaction**, not the change in isolation.
+
+---
+
+## Phase 1 — Classify what changed, then route to lenses
+
+Bucket each changed file so you apply the right lens (a PR often spans several):
+
+- **Task spec** — `complextasks/*/task.yaml`, `tasks/**/task.yaml` -> Lens C + B.
+- **TF stack / module** — `tf/prebuilt/**`, `tf/modules/**`, `*.tf`, seed/setup
+  `scripts/*.sh` -> Lens B (heavily) + C + A.
+- **Harness / deployer / agent code** — `devops_bench/**`, `pkg/**`,
+  `deployers/**` -> Lens A + B + E + F.
+- **Docs** — `*.md`, `README`, `docs/**` -> Lens D.
+
+Always run Lens A (correctness) and Lens B (parallel-safety) on anything
+executable; run B on any task/stack because that is where matrix collisions live.
+
+---
+
+## Phase 2 — Review lenses
+
+Run the relevant lenses below. Collect candidate findings with `file`, `line`, a
+one-line `summary`, and a concrete `failure_scenario`. Pass through every
+candidate with a nameable failure — verification (Phase 3) is where uncertain
+ones get cut, not here.
+
+### Lens A — correctness
+
+- **Line-by-line:** inverted/wrong conditions, off-by-one, null/undefined deref,
+  missing `await`, falsy-zero checks, wrong-variable copy-paste, swallowed errors,
+  unescaped regex/shell metachars, `set -euo pipefail` gaps in bash.
+- **Removed behavior:** for each deleted/replaced line, name the invariant it
+  enforced and find where it is re-established; a dropped guard/validation/error
+  path or deleted test covering a real case is a finding.
+- **Cross-file:** for each changed function, Grep its callers and callees — does a
+  new precondition, changed return shape, new exception, or timing/ordering
+  dependency break a call site?
+
+If the changed code has unit/integration tests, you **may** run them (and `ruff`)
+to corroborate a finding — see Scope & guardrails. Do not run anything that
+provisions infra or starts an eval.
+
+### Lens B — parallel-safety across the matrix axes (the emphasis)
+
+The eval matrix runs **Task × Model × AgentConfig** concurrently, often N on one
+host. `RunEnv` gives each run its own isolation; a change is unsafe when it
+introduces state shared *outside* that isolation. Establish this **by static
+analysis** — read the stack/scripts/prompt and reason about shared state; do not
+run concurrent evals to find out. First ground yourself in what isolation actually
+covers (verify against `run_env.py` / `docs/parallel-evals.md`, don't assume):
+
+**Per-run isolation covers:** `KUBECONFIG`, `CLOUDSDK_CONFIG`, `TF_DATA_DIR` (+ TF
+state beside it), a run-token-prefixed **cluster name** (short token, prefixed and
+clamped to GKE's 40-char limit), per-run **results dir** (run id appended), and
+`OPENCLAW_STATE_DIR` (sessions/auth/memory) while sharing `OPENCLAW_CONFIG_PATH`.
+
+**Isolation does NOT cover:** `$HOME` and paths under it, the shared
+`tf/prebuilt/<stack>` working dir (`.terraform.lock.hcl`), project-global GCP
+resource names that a stack hardcodes, IAM bindings on shared service accounts,
+`task_id`, host capacity (disk/inotify/ports), and anything an **agent** creates
+at runtime.
+
+**Reason per axis — the same collision can be safe on one axis and fatal on
+another.** For each shared-state suspect, ask which axis triggers it:
+
+- **Task axis** (different tasks, same model/config, concurrently): collides only
+  if the shared name is **fixed across tasks** or **project-global**. A resource
+  whose name is *distinct per task* (e.g. `~/taskA-repo.git` vs `~/taskB-repo.git`)
+  is safe here.
+- **Model / AgentConfig axis** (same task, different model/config): the **same
+  task runs more than once**, so any task-fixed `$HOME`/global name collides — even
+  one that was safe on the task axis. `rm -rf` of a shared path becomes a race.
+- **Repeated same combo / N-on-one-host:** cluster names derived from run id are
+  safe *only because the prior run tore down first* — do not run two of the same
+  combo at once; and host resources (kind clusters, disk, inotify, ports) **sum**
+  across all concurrent runs.
+
+**Shared-state checklist — flag any of these in changed code:**
+
+1. **`$HOME` / process-global paths.** Bare repos (`~/*-repo.git`), fixed temp
+   files, `~/.kube/config`, fixed dirs. `HOME` is **not** isolated. Check: is the
+   path task-distinct AND per-run? Is it hardcoded in the **prompt** with no
+   template token (prompt only templates `{{CLUSTER_NAME}}`, `{{NAMESPACE}}`,
+   `{{PROJECT_ID}}`, etc. — there is no `{{REPO_PATH}}`)? Does a seed/setup script
+   `rm -rf` it (a wipe race under the model/config axis)?
+2. **Cluster / resource names not flowing through the run token.** Names must
+   derive from the harness-supplied (already-prefixed) `cluster_name`. Watch
+   **length** (token + base + any stack suffix vs the 40-char GKE limit) and
+   **truncations that drop the discriminator** — e.g. a stack that appends
+   `-east`/`-west` to a name the gke module then truncates with
+   `substr(cluster_name, 0, 15)` collapses both to one node-SA `account_id`.
+3. **Project-global GCP names not random-suffixed.** Compare against the
+   secret-rotation pattern (appends a `random_id` suffix to `sa-*` /
+   `db-credentials-*` so concurrent runs coexist). Known offender: the gke module
+   node SA `gke-nodes-<cluster>` is deterministic, not suffixed -> `409 already
+   exists` on re-run after a failed teardown (see the known-issues appendix).
+4. **IAM bindings on a shared service account.** A stack that grants a project
+   role (e.g. `roles/container.admin`) to the shared `openclaw-vm-sa` via
+   `google_project_iam_member` in its own TF state: concurrent GKE tasks each
+   "own" that binding, and the first `tofu destroy` strips it from the SA while the
+   others are still running -> mid-run auth loss.
+5. **`task_id` uniqueness.** A new task must not reuse an existing `task_id`
+   (`grep -rn '^task_id' complextasks/ tasks/`). Duplicates make per-task scoring
+   ambiguous when both run in one matrix.
+6. **Agent-created resources & host capacity.** If the task design relies on the
+   agent creating clusters/resources at runtime, their names are agent-chosen
+   (un-prefixed -> cross-run collision risk) and they multiply host load. Sum the
+   per-task disk/inotify/cluster counts across a realistic concurrent batch and
+   flag if the single-run README sizing is exceeded.
+7. **Provisioner env inheritance.** A `local-exec` seed/setup script is only
+   isolated if it inherits the run-scoped `KUBECONFIG`/`CLOUDSDK_CONFIG` — verify
+   it doesn't re-point them at `~/.kube/config` or a global gcloud config.
+8. **Agent/runner parallel-safety.** Legacy arm + gemini CLI is **not**
+   parallel-safe (shared `~/.gemini` trajectory dir); parallel gemini must use the
+   refactored arm. Flag changes that reintroduce shared-session assumptions.
+
+For each parallel finding, **state which axis triggers it** and whether it's
+already covered by `RunEnv` — that is the distinction maintainers act on.
+
+### Lens C — task & stack conventions
+
+- `task.yaml`: unique `task_id`; `name`; `infrastructure` (`deployer`, `stack`,
+  `teardown`); a prompt that uses template tokens rather than hardcoded
+  project/cluster/namespace values; `expected_output` as discoverable critical
+  requirements (nothing in-cluster should *name* the fix — the agent must discover
+  it).
+- **Solvability:** there is a real path to success (a manual-solve in the README
+  or an equivalent), and the fault is injected from outside the cluster. Assess
+  this by reading the stack/scripts — do not provision to check.
+- **Substrate parity:** kind stacks declare `kubeconfig_path`/`cluster_name`/
+  `location` and emit `cluster_location = "local"`; GKE stacks return
+  `cluster_name`/`cluster_location` the deployer expects. New stack variables the
+  harness must set (beyond what the kind/gcp variable resolvers inject) are a
+  red flag — the resolver won't populate them.
+- **Idempotency / teardown:** `teardown: true` actually destroys everything the
+  stack and its scripts create; re-apply after a failed run isn't blocked by
+  orphans.
+
+### Lens D — docs conventions
+
+Apply the repo's documentation conventions:
+- Organize as **scope + user-guide**; GitHub-flavored markdown.
+- **Not journal-like** — no migration history, no "why this lives here", no diary
+  of what changed.
+- No **contradictions or duplication** with existing docs; put caveats in a
+  **known-issues appendix** rather than scattering them.
+- **No model scores / result tallies** in docs (those are tracked separately);
+  results-interpretation and formatting guidance is fine.
+- Convert relative dates to absolute; keep examples runnable.
+
+### Lens E — reuse / simplification / efficiency / altitude
+
+- **Reuse:** new code re-implementing an existing helper (Grep shared/utility
+  modules and adjacent files; name the helper to call).
+- **Simplification:** redundant/derivable state, copy-paste variants, dead code.
+- **Efficiency:** redundant I/O, sequential work that could be independent,
+  blocking work added to a hot path; closures capturing large scopes.
+- **Altitude:** special cases bolted onto shared infrastructure where generalizing
+  the underlying mechanism is the deeper fix (e.g. fixing repo-path isolation once
+  in `RunEnv` + a prompt token, instead of per-task patches).
+
+### Lens F — code conventions (agent-instruction files)
+
+For Python, enforce the docstring rules from the governing agent-instruction file
+(e.g. the user's Google-style rules: purpose; `Args`/
+`Returns`/`Attributes`; `Raises`; concise, no implementation narration). Flag a
+convention violation only when you can quote the exact rule and the exact line.
+
+---
+
+## Phase 3 — Verify candidates
+
+Dedup candidates that point at the same line/mechanism. For each survivor, decide
+one of three states (run an independent verifier pass for non-obvious ones — a
+sub-task/subagent if your harness supports one, otherwise re-check it yourself;
+for parallel-safety, the verifier should try to *refute* by finding the isolation
+that already covers it — by reading code, not by running evals):
+
+- **CONFIRMED** — name the inputs/state and the wrong output/crash; quote the line.
+- **PLAUSIBLE** — mechanism is real, trigger depends on env/config/composition
+  (common for parallel findings: "fires only if the batch also contains task X").
+  State what would confirm it.
+- **REFUTED** — guarded elsewhere or factually wrong; quote the proof (e.g. the
+  resolver that injects the per-run value, or the `count = ... != "" ? 1 : 0`).
+
+Keep CONFIRMED and PLAUSIBLE. Correctness bugs outrank cleanup/altitude/docs when
+trimming.
+
+---
+
+## Phase 4 — Present the review
+
+Do **not** dump raw JSON. Write a readable review:
+
+1. **Overview** — 2–3 sentences on what the change does and how it interacts with
+   the parallel-isolation model.
+2. **Findings**, most-severe first, each as
+   `file:line — summary (failure scenario)`. For parallel findings, state the
+   **triggering axis** and whether `RunEnv` already covers it.
+3. **Cleared** — a short list of things you checked and found safe (so the author
+   knows the coverage), e.g. "cluster name + KUBECONFIG isolation inherited from
+   RunEnv ok".
+4. **Systemic note** (when applicable) — if several findings share a root cause,
+   recommend the seam-level fix once rather than per-site patches.
+
+Scale effort to the ask: a quick "is this parallel-safe?" wants the B-lens
+checklist and a verdict; "comprehensive review" wants all lenses and a fuller
+findings list. If nothing survives verification, say so plainly. Remember the
+scope guardrail: present findings; never run the benchmark to produce them.

--- a/.agents/skills/run-eval/SKILL.md
+++ b/.agents/skills/run-eval/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: run-eval
+description: >
+  Use when the user wants to run a single evaluation — one Task on one Model with
+  one AgentConfig — on the GKE eval bastion or this host, e.g. "run secret-rotation
+  on gemini-3.1-pro-preview", "run one eval", "evaluate <task> with <model>", "kick
+  off a single eval run", "run this task once and watch it". Drives the whole
+  lifecycle for that one run: gather the spec + credentials, ensure a clean runner,
+  launch it detached, monitor with recovery, then summarize and diagnose. For more
+  than one Task/Model/AgentConfig combo, use `run-parallel-evals` instead. Inherits
+  the same recovery (RESUME_STAMP re-attach) and opt-in hands-off / self-healing
+  modes, which it reuses from the parallel skill's reference files.
+---
+
+# Run a single eval
+
+Orchestrate **one** eval run (one Task × one Model × one AgentConfig) end to end:
+set up env + credentials, ensure a clean runner, launch the run detached, babysit it
+with recovery, then deliver a result summary with failure analysis.
+
+## Relationship to `run-parallel-evals`
+
+A single run **is a 1×1×1 matrix** — it uses the exact same wrappers
+(`scripts/bastion/run_matrix.sh`, `run_matrix_legacy.sh`, `_matrix_lib.sh`) with one
+task, one model, one config. So this skill does **not** add scripts or new recovery
+machinery; it reuses the parallel skill's. The only difference is a leaner front-end:
+no concurrency (`MAX_PARALLEL`), no combo-count math, and no cross-combo
+parallel-safety pre-flight.
+
+**Reused as-is from `run-parallel-evals` (read there, don't duplicate):**
+- `.agents/skills/run-parallel-evals/SKILL.md` — *Harness portability*, *Execution
+  mode*, **Phase 2** (credentials), **Phase 3** (clean environment), the **Phase 5**
+  infra-flake-vs-real-failure classification, and the **Phase 6** scoring mechanics.
+- `docs/bastion.md` — bastion architecture, provisioning, per-run isolation. If
+  `docs/parallel-evals.md` is present, it is the fuller operational runbook +
+  failure-mode table; otherwise the classification inline in the parallel skill's
+  Phases 5–6 is the source of truth.
+
+This file states only what is **specific to a single run**. When a phase below says
+"same as the parallel skill," go read that phase there.
+
+**If the user actually wants more than one combo** (multiple tasks/models/configs, a
+comparison, a matrix), stop and use `run-parallel-evals` instead — it adds the
+concurrency, combo math, and cross-combo parallel-safety this skill deliberately omits.
+
+---
+
+## Modes & progressive disclosure
+
+Keep context lean: **this file is the standard single run** (Phases 1–6, you drive
+directly). The recovery/hands-off and self-healing capabilities live in the **parallel
+skill's** `references/` — read them only when the request calls for them:
+
+| If the user wants… | Read (when you reach it) | Default |
+|---|---|---|
+| A normal single run | nothing extra — Phases 1–6 below | — |
+| A long / hands-off run that "must not stop", "watch it", "stay alive" | `.agents/skills/run-parallel-evals/references/resilient-monitoring.md` — tiered-subagent monitoring + API-error recovery + keepalive. For one combo it degenerates to **one** analyzer + the keepalive loop. Read **before Phase 4** of any real (non-`DRY_RUN`) launch. | **on** for real runs |
+| "unlimited", "keep going until it passes", "auto-fix and restart", self-healing | `.agents/skills/run-parallel-evals/references/unlimited-mode.md` — diagnose → fix in a worktree → re-sync → restart the run → repeat (capped). | **off** — explicit opt-in only |
+
+Resolve the mode in Phase 1. If neither special mode applies, ignore the reference files.
+
+---
+
+## Harness portability & execution mode
+
+This skill is **agent/harness-agnostic** and **local by default; remote is opt-in** —
+identical to the parallel skill. Rather than duplicate them, see the *Harness
+portability* and *Execution mode* sections in
+`.agents/skills/run-parallel-evals/SKILL.md`. The essentials:
+
+- It needs only a **shell on the runner host** — *this host* by default (local
+  `nohup`, no ssh/sync, outputs in `~/matrix-runs/<stamp>`), or set **`BENCH_REMOTE=1`**
+  (+ the `BASTION_*` env) to sync to the bastion and run there over ssh.
+- Tool names like `Agent` / `ScheduleWakeup` are **examples** — substitute your
+  harness's equivalent (sub-task, scheduler, durable state, ask-the-user).
+- The snippets below show the **remote** form `ssh <bastion> '<cmd>'`; in **local
+  mode drop the `ssh <bastion>` wrapper** — the paths are the same on this host.
+- Durable run state lives on the runner host (`RESUME_STAMP`), so even a bare harness
+  (one shell, no sub-tasks) can drive and re-attach to a run.
+
+---
+
+## Phase 1 — Gather the single-run spec
+
+**First, always ask: local or remote?** (local runs on this host, the default; remote
+sets `BENCH_REMOTE=1` + the `BASTION_*` connection env.) Then pin down exactly the one
+run. Ask the user (your harness's clarify path) for anything not given; don't guess on
+the dimensions that cost a cluster + time. You need:
+
+1. **Task** — one `*/task.yaml` path (`MATRIX_TASKS="complextasks/secret-rotation/task.yaml"`).
+2. **Model** — one model (`MATRIX_MODELS="gemini-3.1-pro-preview"`).
+3. **Agent config** — refactored arm only: one `MATRIX_AGENT_CONFIGS`, e.g.
+   `gcli+mcp+skills` or `oc+mcp+skills` (`oc|gcli` `[+mcp][+skills]`).
+4. **Arm** — refactored (`run_matrix.sh`) **or** legacy (`run_matrix_legacy.sh`,
+   oc-only). One run = one arm.
+5. **Auth mode** — API-key vs **Vertex/ADC** (`BENCH_VERTEX=1`). If unsure, recommend
+   Vertex (no key handling, VM-SA ADC).
+
+State the **rough wall-clock** (≈25–40 min for an infra-bearing task like
+secret-rotation; less for a lightweight task) so the user can confirm before you spend
+a cluster. Then run with `DRY_RUN=1` to show the expanded (single) combo before the
+real launch.
+
+**Single-run safety (much lighter than the matrix pre-flight):**
+- **Never launch a second run of the same task+model+config concurrently** —
+  run-id-derived cluster names are reused (safe only because the prior run tore down
+  first). Different task/model/config is fine to run alongside.
+- If the task is **infra-bearing**, skim its stack/scripts (or run the
+  `devops-bench-review` skill on it) for self-collisions that bite even one run — e.g.
+  it seeds a fixed `$HOME` repo (`~/<task>-repo.git`) and `rm -rf`s it, or grants the
+  shared VM SA a project role it then revokes on teardown. The cross-*combo* hazards
+  the parallel skill lists (node-SA prefix collapse, duplicate `task_id`s, host
+  capacity across `MAX_PARALLEL`) don't apply to a single run.
+
+Note: **legacy + gemini CLI is not parallel-safe**, but a single run is not parallel,
+so either arm is fine here.
+
+---
+
+## Phase 2 — Credentials & environment
+
+**Same as the parallel skill's Phase 2** — see
+`.agents/skills/run-parallel-evals/SKILL.md`. In brief:
+
+- **Remote mode only:** export the connection env (`BASTION_USE_GCPNODE=1`,
+  `BASTION_VM`, `BASTION_ZONE`, `BASTION_PROJECT`, `GCP_PROJECT_ID`). Skip for local.
+- **API-key mode:** the runner sources `~/secrets.env` (must export `AGENT_API_KEY`,
+  `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `JUDGE_API_KEY`). Check names only — **never
+  print key values**; ask the user for a missing key (or have them paste with `!`).
+- **Vertex mode (`BENCH_VERTEX=1`):** no keys. Verify VM-SA roles, gemini
+  folder-trust (`security.folderTrust.enabled=false`), and for the **legacy oc** arm
+  the `google-vertex` provider (`scripts/bastion/configure-oc.sh --vertex` once). The
+  default `JUDGE_MODEL=gemini-3.1-pro` **404s on Vertex** — set
+  `JUDGE_MODEL=gemini-3.1-pro-preview` and `AGENT_PROVIDER=google-vertex`.
+- For legacy capabilities run `configure-oc.sh --mcp --skills` (or
+  `--no-mcp --no-skills`) once before launching.
+
+---
+
+## Phase 3 — Connect and ensure a clean environment
+
+**Same as the parallel skill's Phase 3.** Even for one run this matters — a stale
+process or a leftover GCP resource from a prior aborted run will `409` your launch.
+
+1. **Connectivity:** `ssh <bastion> 'echo OK; oc --version; gemini --version'`
+   (transient `exit 255` is a gcpnode blip — retry).
+2. **No stale processes:**
+   `ssh <bastion> 'pgrep -af "matrix-runner|evaluate.py|devops_bench|oc agent" | grep -v pgrep'`.
+3. **No leftover GCP resources** for this run's shape (clusters, `gke-nodes-*` SAs,
+   `sa-secret-rotation-*`, `db-credentials`) — Phase-3 `gcloud` checks in the parallel
+   skill. Delete confirmed orphans, **especially `gke-nodes-*` SAs**.
+4. **Prereqs present:** `~/gke-mcp`, `~/oc-skills/` (if skills), `~/devops-bench/.venv`;
+   else `scripts/bastion/vm-setup.sh`.
+
+---
+
+## Phase 4 — Launch the single run (detached)
+
+> **Hands-off run? (default for real runs)** Read
+> `.agents/skills/run-parallel-evals/references/resilient-monitoring.md` first and run
+> the keepalive + recovery loop (for one combo: one monitor tick, one analyzer on
+> finish). The inline path below is the direct foreground form.
+
+Drive the wrapper with the **single** task/model/config — a 1×1×1 matrix. By default
+it runs locally (detached `nohup`); with `BENCH_REMOTE=1` it syncs to the bastion and
+launches detached over ssh, then polls. Run it as a **background job** so you keep
+control. Example (Vertex, refactored arm):
+
+```bash
+# local by default; prefix BENCH_REMOTE=1 (+ BASTION_* env) to run on the bastion
+BENCH_VERTEX=1 AGENT_PROVIDER=google-vertex \
+JUDGE_PROVIDER=google JUDGE_MODEL=gemini-3.1-pro-preview \
+MATRIX_TASKS="complextasks/secret-rotation/task.yaml" \
+MATRIX_MODELS="gemini-3.1-pro-preview" \
+MATRIX_AGENT_CONFIGS="gcli+mcp+skills" \
+RESULTS_DIR="results/<label>" \
+  scripts/bastion/run_matrix.sh
+```
+
+(Legacy arm: `run_matrix_legacy.sh`, oc-only, no `MATRIX_AGENT_CONFIGS`. `MAX_PARALLEL`
+is irrelevant for one combo — leave it default.)
+
+**Capture the `STAMP`** the wrapper prints (`RESUME_STAMP=<stamp>`) — it's your handle
+for monitoring, retry, and re-attach. Record it in durable state (task list or notes
+file) so you survive a context reset. Outputs live on the runner host at
+`~/matrix-runs/<stamp>/<rid>/` (`run.log`, `status`); `~/matrix-runs/<stamp>/.done`
+appears when it finishes. **If your poller dies, the run continues** (detached) —
+re-attach with `RESUME_STAMP=<stamp>` and the same command.
+
+---
+
+## Phase 5 — Monitor + recover
+
+Check on an interval (every ~3–5 min for an infra-bearing task); **don't busy-poll**.
+
+```bash
+ssh <bastion> 'd=~/matrix-runs/<stamp>/*/; \
+  echo "status=$(cat $d/status 2>/dev/null || echo running) \
+        last=$(tail -1 $d/run.log 2>/dev/null | cut -c1-80)"; \
+  test -f ~/matrix-runs/<stamp>/.done && echo ALL_DONE'
+```
+
+Classify the run:
+- **Running** — no `status` file, runner process alive. Leave it.
+- **Finished** — `status` is `exit=<rc>`. `rc=0` ran to completion (score in Phase 6);
+  `rc!=0` the harness errored (diagnose in Phase 6).
+- **Aborted / flaked** — no `status` **and** no live process, or an **infra** error in
+  `run.log`. Retry case.
+
+**Infra flake vs real failure** — use the parallel skill's Phase-5 classification
+(`.agents/skills/run-parallel-evals/SKILL.md`):
+- **Infra flake → clean + retry:** tofu/provision failure, `409 already exists`
+  (orphaned `gke-nodes-*` SA), GKE quota/transient API error, SSH/relay drop, node-pool
+  timeout.
+- **Real failure → do NOT retry, analyze:** auth/config errors (`No API key`, `401`,
+  Vertex `404`, missing `--approval-mode`), or the agent ran but scored low (model
+  capability), or task-logic failure.
+
+**Retry procedure** (cap 2; log every retry):
+1. Kill any lingering process for the run on the VM.
+2. `rm -rf ~/matrix-runs/<stamp>/<rid>`.
+3. Clean its leaked GCP resources: cluster (`c<hash>-eval`), `gke-nodes-<hash>` SA, any
+   `sa-secret-rotation-*` / `db-credentials-*` (Phase-3 commands).
+4. Re-launch the **same single run** (new `STAMP`, `SKIP_SYNC=1` after a real sync).
+   Track the new stamp.
+
+If the detached runner itself died (no `.done`, no live process), re-attach with
+`RESUME_STAMP`; if truly dead, relaunch.
+
+> **Unlimited / self-healing mode?** Only if the user opted in: a *real* (non-flake)
+> failure from a task/code bug is not the end — read
+> `.agents/skills/run-parallel-evals/references/unlimited-mode.md` and follow
+> diagnose → fix → re-sync → restart instead of just reporting it.
+
+**Keepalive (hands-off run):** under a harness that may classify the session done,
+never emit a completion / `result:` / "done" line until the run is terminal **and**
+summarized; each tick emit a one-line `still working: running / done / flaked` status
+and schedule the next wake (see `resilient-monitoring.md`).
+
+---
+
+## Phase 6 — Summarize the result + diagnose
+
+When the run has a terminal `status` (or `.done`), pull results (the wrapper does this
+on normal exit; else `RESUME_STAMP=<stamp>` re-run to pull) and report:
+
+**task · model · agent-config · arm · auth-mode · exit · score · #MCP-tool-calls ·
+pass/fail checks.** Scoring mechanics are the **same as the parallel skill's Phase 6**:
+
+```bash
+grep -c 'Pass Rate: 100.0%' <run>/run.log   # passed checks
+grep -c 'Pass Rate: 0.0%'   <run>/run.log   # failed checks
+grep -oiE 'mcp_[a-z0-9_-]+|run_shell_command|activate_skill' <run>/run.log | sort | uniq -c
+```
+`results.json` is a **list** of per-criterion objects (`{name, score, success,
+reason}`); refactored nests under `run_<ts>_<rid>/results.json`, legacy copies
+`results/run_<ts>_<rid>` into the run dir. Beware grep false positives (bare
+`401`/`quota` match terraform output) — anchor on `invalid_api_key`,
+`ProviderAuthError`, `No API key`, `^OK$`.
+
+**If the run did not pass / errored**, give an analysis: what happened (quote the
+decisive log line, redacting secrets), the **root cause** (map to the failure table /
+parallel-skill Phase 6 — e.g. `exit -1` = **timeout** not crash; Vertex `404` = wrong
+location/model), **model vs harness** (clean trajectory + low score = model; early
+abort / auth error = harness/config), and the **concrete fix / next step**.
+
+Then **verify teardown is clean** (Phase-3 GCP checks — zero leftover cluster /
+`gke-nodes-*` / `sa-secret-rotation-*` / `db-credentials-*`) and report any residue.
+
+**Record any new failure mode** (same as the parallel skill) — a symptom → root cause →
+fix row in the failure-mode table for an operational flake, or a known-issues bullet for
+a structural gap, in `docs/bastion.md` (or `docs/parallel-evals.md` if present).
+Terse, no duplication, follow the docs conventions (scope + user-guide, GFM, no model
+scores).
+
+End with: the run's exit, score, pass/fail checks, and — if it didn't pass — the root
+cause + fix.
+
+---
+
+## Guardrails
+
+- One run still costs a real GKE cluster + ~25–40 min. Confirm scale and use
+  `DRY_RUN=1` first.
+- Never print or commit API keys; redact secrets in summaries.
+- Never launch a second run of the **same** task+model+config concurrently (cluster
+  name reuse).
+- Always confirm clean teardown — orphaned `gke-nodes-*` SAs silently `409` the next run.
+- Cap retries (≤2) and surface a persistent failure rather than looping.
+- Capture every **new** failure mode in the docs appendix (Phase 6) so learnings accrue.
+- Prefer leaving the run detached + re-attaching via `RESUME_STAMP` over a fragile
+  foreground SSH session.
+- **Hands-off run:** don't let an idle/completion classifier stop the job mid-run —
+  emit periodic progress, signal completion only when the run is terminal and summarized.
+- **Progressive disclosure:** read a `references/*.md` file only when its mode applies.
+- **Wrong tool?** If the request grows to multiple combos, switch to `run-parallel-evals`.

--- a/.agents/skills/run-parallel-evals/SKILL.md
+++ b/.agents/skills/run-parallel-evals/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: run-parallel-evals
+description: >
+  Use when the user wants to run a parallel evaluation matrix (Task × Model ×
+  AgentConfig) on the GKE eval bastion — e.g. "run a parallel eval matrix",
+  "run these evals on the bastion", "run the matrix for <tasks/models>",
+  "kick off a Vertex eval run", "compare legacy vs refactored on the bastion".
+  Drives the whole lifecycle: gather the matrix spec + credentials, set up the
+  bastion cleanly, launch the detached run, monitor and retry infra flakes, then
+  summarize results and diagnose failures. Supports delegated tiered-subagent monitoring and an opt-in unlimited/self-healing mode, loaded from reference files only when requested.
+---
+
+# Run parallel evals on the bastion
+
+Orchestrate a parallel eval-matrix run on the GCE bastion end to end. You set up
+env + credentials, ensure a clean VM, launch the matrix detached, babysit it
+(retrying infra flakes), then deliver a results summary with failure analysis.
+
+**Read these first — they are the source of truth; do not duplicate their content
+from memory:**
+- `docs/parallel-evals.md` — the runbook: env vars, Vertex/ADC setup, MCP setup,
+  isolation, the **operational runbook**, and the **failure-mode → fix table**.
+- `docs/bastion.md` — bastion architecture, provisioning, per-run isolation.
+
+The scripts you drive: `scripts/bastion/run_matrix.sh` (refactored arm),
+`scripts/bastion/run_matrix_legacy.sh` (legacy/oc arm), and the shared
+`scripts/bastion/_matrix_lib.sh`. `DRY_RUN=1` previews any matrix without
+provisioning — use it to validate the expansion before a real run.
+
+Work through the phases in order. Don't skip the clean-environment or
+credentials phases — they are the most common cause of wasted multi-hour runs.
+
+
+---
+
+## Modes & progressive disclosure
+
+Keep context lean: **this file is the standard run** (Phases 1–6, you drive
+directly). Two heavier capabilities live in `references/` — read them **only** when
+the request calls for them, and don't pull both in for a plain run.
+
+| If the user wants… | Read (when you reach it) | Default |
+|---|---|---|
+| A normal matrix run | nothing extra — Phases 1–6 below | — |
+| A long / hands-off run that "must not stop", "monitor with subagents", "stay alive" | `references/resilient-monitoring.md` — tiered-subagent monitoring + API-error recovery + background-classifier keepalive. Read **before Phase 5** of any real (non-`DRY_RUN`) launch. | **on** for real runs |
+| "unlimited", "keep going until it finishes", "auto-fix and restart", self-healing | `references/unlimited-mode.md` — diagnose → fix in a worktree → re-sync → restart failed combos → repeat. | **off** — explicit opt-in only |
+
+Resolve the mode in Phase 1 (ask if it's ambiguous for a long/expensive matrix). If
+neither special mode applies, ignore the reference files entirely.
+
+
+---
+
+## Harness portability
+
+This skill is **agent/harness-agnostic** — it runs under any coding agent (Claude
+Code, Antigravity/Gemini, Codex, …). It needs only a **shell on the runner host** — local by default, or `ssh` to the
+bastion in remote mode (Antigravity: the `run_command` tool); everything else is an optimization. Map each capability used below to
+whatever your harness provides, and degrade gracefully if it lacks one:
+
+| Capability | Claude Code | Antigravity | Other / fallback |
+|---|---|---|---|
+| Sub-task | `Agent` | `invoke_subagent` | subagent/`task`; else inline |
+| Model tiers | Haiku / Sonnet / Opus | `/models` (Flash / Pro) | mini / standard |
+| Background run | `run_in_background` | `manage_task` | async; else poll |
+| Timer / wake | `ScheduleWakeup` | `schedule` | scheduler; else `sleep` |
+| Durable state | task list | Artifacts / `write_to_file` | notes file |
+| Isolated worktree | `EnterWorktree` | `run_command` | `git worktree add` |
+| Ask the user | `AskUserQuestion` | `ask_question` | ask in chat |
+| Keepalive | progress, no early "done" | same | same |
+
+Each cell names **one primitive** — assume your harness chains the supporting
+calls (args, follow-ups, file reads) from it; the full Antigravity set is in the
+footnote below.
+
+Throughout this skill and its `references/`, tool names like `Agent` or
+`ScheduleWakeup` are **examples**, not requirements — substitute your harness's
+equivalent. Durable run state lives on the **bastion** (`RESUME_STAMP`), so even a
+bare harness (one shell, no sub-tasks, no scheduler) can drive a run by polling.
+
+**Antigravity tools** (the actual agent tool set, confirmed from a live Antigravity instance — the public [hooks docs](https://antigravity.google/docs/hooks) render client-side): files `view_file` · `list_dir` · `grep_search` · `write_to_file` · `replace_file_content` · `multi_replace_file_content`; exec `run_command` · `ask_permission` · `list_permissions`; web `search_web` · `read_url_content`; subagents/background `invoke_subagent` · `define_subagent` · `manage_subagents` · `send_message` · `manage_task` · `schedule`; interaction `ask_question` · `generate_image`. Hooks match these by tool name on `PreToolUse` / `PostToolUse` (config in `.agents/hooks.json`).
+
+---
+
+## Execution mode
+
+**Local by default; remote is opt-in.** The matrix runs on the **runner host** —
+the machine where you invoke the wrapper. By default that's *this host* (local
+`nohup`, no ssh/sync, outputs in `~/matrix-runs/<stamp>`). Set **`BENCH_REMOTE=1`**
+(plus the `BASTION_*` connection env) to sync the tree to the bastion and run
+there over ssh, pulling results back.
+
+**Command convention:** the snippets below show the **remote** form,
+`ssh <bastion> '<cmd>'`. In **local mode, drop the `ssh <bastion>` wrapper** and
+run `<cmd>` directly — the paths (`~/secrets.env`, `~/.kube`,
+`~/matrix-runs/<stamp>`) are the same, just on this host. `RESUME_STAMP` and
+`DRY_RUN` behave identically in both modes.
+
+---
+
+## Phase 1 — Gather the matrix spec
+
+**First, always ask: local or remote?** (see *Execution mode*) — local runs on
+this host (default); remote sets `BENCH_REMOTE=1` + the `BASTION_*` connection
+env. Then determine exactly what to run. Ask the user (your harness's clarify path — see *Harness portability*) for
+anything not given;
+do not guess on dimensions that cost clusters/time. You need:
+
+1. **Tasks** — `MATRIX_TASKS` (space-separated `*/task.yaml` paths, or `ALL`).
+2. **Models** — `MATRIX_MODELS` (e.g. `gemini-3.1-pro-preview gemini-3.5-flash`).
+3. **Agent configs** — refactored arm only: `MATRIX_AGENT_CONFIGS`, each
+   `oc|gcli` `[+mcp][+skills]` (e.g. `gcli+mcp+skills oc+mcp+skills`).
+4. **Arm(s)** — refactored (`run_matrix.sh`), legacy (`run_matrix_legacy.sh`,
+   oc-only), or both in parallel.
+5. **Auth mode** — API-key vs **Vertex/ADC** (`BENCH_VERTEX=1`). If unsure,
+   recommend Vertex (no key handling, VM-SA ADC).
+6. **Concurrency** — `MAX_PARALLEL` (default 3). Each combo provisions its own
+   cluster; mind project quota. Count combos = tasks × models × configs.
+
+Compute and **state the combo count and rough wall-clock** (≈25–40 min/combo for
+infra-bearing tasks like secret-rotation) before launching, so the user can
+confirm scale. Then run with `DRY_RUN=1` and show the expanded matrix.
+
+Note the parallel-safety rule (see `docs/parallel-evals.md`): **legacy + gemini
+CLI is not parallel-safe** — for parallel gemini, use the refactored arm.
+
+**Pre-flight the matrix tasks for parallel hazards** before a real run — a doomed
+combo wastes a cluster + ~30 min. Skim each selected task's stack/scripts (or run
+the `devops-bench-review` skill on it) against the per-run isolation gaps in
+`docs/parallel-evals.md` (known-issues appendix). The ones that bite a matrix:
+- a task that seeds a fixed `$HOME` repo (`~/<task>-repo.git`) and `rm -rf`s it —
+  unsafe once the matrix repeats that task across models/configs;
+- a multi-cluster stack whose node-SA name collapses under the run-token prefix;
+- a per-task stack that grants a project role to the shared VM SA (teardown
+  clobber across concurrent GKE combos);
+- duplicate `task_id`s among the selected tasks (ambiguous reporting);
+- host capacity: sum kind clusters / disk / inotify across `MAX_PARALLEL`.
+
+Never run two of the **same** combo at once — run-id-derived cluster names are
+reused (safe only because the prior run tore down first).
+
+---
+
+## Phase 2 — Credentials & environment
+
+Set the **connection env** (**remote mode only** — same as `sync-to-bastion.sh`;
+skip it entirely for a local run):
+
+```bash
+export BASTION_USE_GCPNODE=1 BASTION_VM=bench-bastion \
+       BASTION_ZONE=us-central1-a BASTION_PROJECT=<proj> GCP_PROJECT_ID=<proj>
+```
+
+**API-key mode:** the remote runner sources `~/secrets.env` on the VM, which must
+export `AGENT_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `JUDGE_API_KEY`.
+Check it exists and has the needed keys (names only — **never print key values**):
+
+```bash
+ssh <bastion> 'grep -oE "^[A-Z_]+=" ~/secrets.env | sort -u'
+```
+
+If a required key is missing, **ask the user for it** (your harness's clarify path) (or have
+them paste it with the `!` prefix so it isn't echoed), then append it to
+`~/secrets.env` on the VM. Treat keys as secrets: don't log them, don't commit
+them, redact in any summary.
+
+**Vertex mode (`BENCH_VERTEX=1`):** no API keys needed. Verify prereqs instead:
+- VM SA has `roles/aiplatform.user` (+ `container.admin`, `secretmanager.admin`).
+- gemini folder-trust: `~/.gemini/settings.json` has
+  `security.folderTrust.enabled=false` (else MCP won't load). `vm-setup.sh` sets
+  it; if absent, run `vm-setup.sh` or write it.
+- For the **legacy oc** arm on Vertex: the `google-vertex` provider must be
+  registered — run `scripts/bastion/configure-oc.sh --vertex` once.
+- `_matrix_lib.sh` defaults `JUDGE_MODEL=gemini-3.1-pro`, which **404s on
+  Vertex** — always set `JUDGE_MODEL=gemini-3.1-pro-preview` and
+  `AGENT_PROVIDER=google-vertex`. Location is `global` (handled by `BENCH_VERTEX`).
+
+If the legacy arm needs capabilities, run `configure-oc.sh --mcp --skills`
+(or `--no-mcp --no-skills` for a clean no-capability run) once before launching.
+
+---
+
+## Phase 3 — Connect and ensure a clean environment
+
+1. **Connectivity:** `ssh <bastion> 'echo OK; oc --version; gemini --version'`.
+   Transient `exit 255` is a gcpnode/cert blip — retry a couple times.
+2. **No stale processes:** check for and kill leftover runners/agents from prior
+   aborted runs:
+   ```bash
+   ssh <bastion> 'pgrep -af "matrix-runner|evaluate.py|devops_bench|oc agent" | grep -v pgrep'
+   ```
+3. **No leftover GCP resources** (a prior failed teardown can `409` your run):
+   ```bash
+   gcloud container clusters list --project <proj>
+   gcloud iam service-accounts list --project <proj> | grep -E 'gke-nodes-|sa-secret-rotation-'
+   gcloud secrets list --project <proj> | grep db-credentials
+   ```
+   If anything is left over, confirm it isn't from another active run, then delete
+   it — **especially the easy-to-miss `gke-nodes-*` SAs** (their orphaning is a
+   known bug; see `docs/parallel-evals.md`).
+4. **Prereqs present:** `~/gke-mcp` (executable), `~/oc-skills/` (if using skills),
+   `~/devops-bench/.venv`. If missing, run `scripts/bastion/vm-setup.sh`.
+
+---
+
+## Phase 4 — Launch the matrix (detached)
+
+By default the wrappers run the matrix **locally** (detached `nohup` on this
+host). With `BENCH_REMOTE=1` they sync the working tree to the bastion, upload a
+runner, and launch it detached over ssh, then poll. To run **both arms in parallel**: sync
+once, then start each wrapper with `SKIP_SYNC=1`, staggered ~5s so their
+second-resolution `STAMP`s differ.
+
+Run each wrapper as a **background job** so you keep control to monitor. Build the
+env from Phase 1–2, e.g. Vertex refactored:
+
+```bash
+# local by default; prefix BENCH_REMOTE=1 (+ BASTION_* env) to run on the bastion
+BENCH_VERTEX=1 AGENT_PROVIDER=google-vertex \
+JUDGE_PROVIDER=google JUDGE_MODEL=gemini-3.1-pro-preview \
+MAX_PARALLEL=<n> MATRIX_TASKS="..." MATRIX_MODELS="..." \
+MATRIX_AGENT_CONFIGS="..." RESULTS_DIR="results/<label>" \
+  scripts/bastion/run_matrix.sh
+```
+
+**Capture the `STAMP`** each wrapper prints (`RESUME_STAMP=<stamp>`). It is your
+handle for monitoring, retry, and re-attach. Record it (and the combo list) in durable state (a
+task list or a notes file) so you survive a context reset. Outputs live on the runner host at
+`~/matrix-runs/<stamp>/<rid>/` (`run.log`, `status`); a `~/matrix-runs/<stamp>/.done`
+marker appears when all combos finish.
+
+If your poller dies, the run continues (detached on the runner host) — re-attach
+with `RESUME_STAMP=<stamp>` and the same command.
+
+---
+
+## Phase 5 — Monitor periodically + retry infra flakes
+
+> **Long or hands-off run? (default for real runs)** Read
+> `references/resilient-monitoring.md` and delegate polling/analysis to tiered
+> subagents — a cheap model (Haiku / Flash-low) polls, a mid model (Sonnet /
+> Flash-medium) analyzes finished combos, you supervise and re-spawn on API errors.
+> It also covers keeping the background job from being classified as finished
+> mid-run. The inline steps below are the direct (small-matrix / foreground) path.
+
+Check progress on an interval (every ~3–5 min for infra-bearing tasks). **Don't
+busy-poll**; sleep between checks. Per tick, inspect each combo:
+
+```bash
+ssh <bastion> 'for d in ~/matrix-runs/<stamp>/*/; do
+  echo "$(basename $d): status=$(cat $d/status 2>/dev/null || echo running) \
+        last=$(tail -1 $d/run.log 2>/dev/null | cut -c1-80)"; done
+ssh <bastion> 'test -f ~/matrix-runs/<stamp>/.done && echo ALL_DONE'
+```
+
+Classify each combo:
+- **Running** — no `status` file, runner process alive. Leave it.
+- **Finished** — `status` is `exit=<rc>`. `rc=0` = ran to completion (score
+  separately); `rc!=0` = the harness errored (diagnose in Phase 6).
+- **Aborted / flaked** — no `status` **and** no live process, or `run.log` shows
+  an **infra** error. This is the retry case.
+
+**Distinguish infra flake from real failure** (consult the failure-mode table in
+`docs/parallel-evals.md`):
+- **Infra flake → clean + retry:** tofu apply/provision failure, `409 already
+  exists` (orphaned `gke-nodes-*` SA), GKE quota/transient API error, SSH/relay
+  drop that killed the runner, node pool creation timeout.
+- **Real failure → do NOT retry, analyze:** auth/config errors (`No API key`,
+  `401`, Vertex `404`, missing `--approval-mode`), agent ran but scored low
+  (model capability), task-logic failures. Retrying won't help; fix config or
+  report.
+
+**Retry procedure** for a flaked combo (cap at 2 retries; log every retry —
+never silently drop a combo):
+1. Kill any lingering process for that combo on the VM.
+2. Delete its remote run dir: `rm -rf ~/matrix-runs/<stamp>/<rid>`.
+3. Clean leaked GCP resources for it: its cluster (`c<hash>-eval`), the matching
+   `gke-nodes-<hash>` SA, and any `sa-secret-rotation-*` / `db-credentials-*`
+   left behind (Phase 3 commands).
+4. Re-launch **just that combo** as a fresh single-combo matrix (same task/model/
+   config, new `STAMP`, `SKIP_SYNC=1`). Track the new stamp.
+
+If the **whole** detached runner died (no `.done`, no live process, partial
+combos), re-attach with `RESUME_STAMP`; if that shows it's truly dead, relaunch
+the unfinished combos.
+
+> **Unlimited / self-healing mode?** If (and only if) the user opted in, a *real*
+> (non-flake) failure caused by a task/code bug is not the end — read
+> `references/unlimited-mode.md` and follow diagnose → fix → re-sync → restart
+> instead of just reporting it.
+
+---
+
+## Phase 6 — Summarize results + diagnose failures
+
+When every combo has a terminal `status` (or `.done` is present), pull results
+(the wrapper does this on its normal exit; otherwise `RESUME_STAMP=<stamp>` re-run
+to pull) and produce a **comprehensive summary**.
+
+For each combo report: **task · model · agent-config · arm · auth-mode · exit ·
+score · #MCP-tool-calls · pass/fail checks**. Read scores from the pulled
+results:
+
+```bash
+# per-check pass/fail
+grep -c 'Pass Rate: 100.0%' <combo>/run.log   # passed
+grep -c 'Pass Rate: 0.0%'   <combo>/run.log   # failed
+# tool usage (MCP shows as mcp_<server>_<tool>)
+grep -oiE 'mcp_[a-z0-9_-]+|run_shell_command|activate_skill' <combo>/run.log | sort | uniq -c
+```
+`results.json` is a **list** of per-criterion objects (`{name, score, success,
+reason}`). Refactored results nest under `run_<ts>_<rid>/results.json`; legacy
+writes `results/run_<ts>_<rid>` copied into the combo dir.
+
+Beware grep false positives: bare `401`/`quota` match terraform output
+(`92401222`, `cpu_cfs_quota`). Anchor on `invalid_api_key`, `ProviderAuthError`,
+`No API key`, `^OK$`.
+
+**For every non-passing / errored combo, give an analysis:**
+- What happened (quote the decisive log line, redacting secrets).
+- **Root cause** — map it to an entry in the `docs/parallel-evals.md` failure
+  table where possible (e.g. `exit -1` = a **timeout**, not a crash;
+  `No API key` under isolation = the sqlite-store vs `GOOGLE_CLOUD_API_KEY`
+  marker issue; Vertex `404` = wrong location/model).
+- **Whether it's the model or the harness** — a clean trajectory with a low score
+  is the model; an early abort/auth error is the harness/config.
+- **Concrete fix or next step**, and whether a retry would help.
+
+Then **verify teardown is clean** (Phase 3 GCP checks — zero leftover clusters /
+`gke-nodes-*` / `sa-secret-rotation-*` / `db-credentials-*`) and report any
+residue you couldn't remove.
+
+**Record any new failure mode** — this capture step is part of the run, not
+optional. If a combo failed in a way **not** already in the
+`docs/parallel-evals.md` failure-mode table or known-issues appendix (or the
+`docs/bastion.md` appendix for bastion-host / VM-SA issues), append it so the next
+run benefits:
+- a **symptom → root cause → fix** row in the failure-mode table for an
+  operational flake;
+- a known-issues bullet/row for a **structural** gap (isolation, naming, capacity).
+
+Keep it terse, don't duplicate an existing entry, and follow the docs conventions
+(scope + user-guide, GFM, not journal-like, no model scores).
+
+End with: total combos, passed/failed counts, best performer, the headline score
+table, and the list of failures with their root cause + fix.
+
+---
+
+## Guardrails
+
+- Each combo costs a real GKE cluster + ~25–40 min. Confirm the combo count with
+  the user before launching a large matrix; use `DRY_RUN=1` first.
+- Never print or commit API keys; redact secrets in summaries.
+- Always confirm clean teardown — orphaned `gke-nodes-*` SAs silently break the
+  next run with `409`.
+- Cap retries (≤2/combo) and surface anything still failing rather than looping.
+- Capture every **new** failure mode in the `docs/parallel-evals.md` /
+  `docs/bastion.md` appendices (see Phase 6) so learnings accrue across runs.
+- Prefer leaving the run detached + re-attaching via `RESUME_STAMP` over holding a
+  fragile foreground SSH session.
+- **Don't let an idle timeout / completion classifier stop the job mid-run** (if
+  your harness has one). A long detached
+  matrix has quiet stretches; never emit a completion / `result:` / "done" /
+  "failed" line until *every* combo is terminal and summarized. Each check-in, emit
+  a one-line "still working: N running / M done / K flaked" status and schedule the
+  next wake (see `references/resilient-monitoring.md`) rather than going silent.
+- **Progressive disclosure:** read a `references/*.md` file only when its mode
+  applies; don't load both for a plain run.

--- a/.agents/skills/run-parallel-evals/references/resilient-monitoring.md
+++ b/.agents/skills/run-parallel-evals/references/resilient-monitoring.md
@@ -1,0 +1,81 @@
+# Resilient monitoring — tiered sub-tasks + recovery
+
+Load this for a **real, long, or hands-off** matrix run (the default once you
+actually launch one). Goal: the run survives quiet stretches, sub-task failures, and
+local drops, and — on harnesses that have one — the session is never marked
+"finished" while combos are still going.
+
+This is **harness-agnostic** (see *Harness portability* in `SKILL.md`): the roles
+below are capabilities, with Claude Code tools named only as examples. The **runner host**
+(this machine in local mode, the bastion when `BENCH_REMOTE`) **is the source of
+truth** — every combo's state lives in `~/matrix-runs/<stamp>/<rid>/`
+(`status`, `run.log`) plus the pulled results. Helper sub-tasks are disposable readers
+of that state: losing one loses nothing, because a fresh one re-reads the same
+`RESUME_STAMP`. If your harness has **no** sub-tasks at all, do the monitor/analyzer
+steps inline yourself — the loop still works, just on one model.
+
+## Roles & model tiers
+
+| Role | Model tier | Cadence | Job |
+|---|---|---|---|
+| **Supervisor** | your **main/session** model | every ~5 min while combos run; longer when idle | dispatch + re-spawn helpers, decide retries, keep the session alive, never go silent |
+| **Monitor** | a **low** tier (Claude Haiku · Gemini Flash · Codex mini · …) | each tick | shell to the runner host (local, or `ssh <bastion>` when `BENCH_REMOTE`), read each combo's `status` + `run.log` tail, return a one-line-per-combo digest + an overall `running / done / flaked / .done` summary. No analysis, no log dumps. |
+| **Analyzer** | a **mid** tier (Claude Sonnet · Gemini Flash/Pro · Codex standard · …) | once per finished combo (or a small batch) | pull + read that combo's `results.json` + `run.log`; return scores + pass/fail checks + a root-cause digest if it failed |
+
+Run the monitor/analyzer as **sub-tasks that can shell out on the runner host**
+(local shell, or `ssh` / `gcloud` to the bastion in remote mode) — Claude Code: the `Agent` tool with `model:` + `subagent_type: general-purpose`;
+other harnesses: their subagent/delegation mechanism. Give each the connection env
+(`BASTION_*`, project) and the `RESUME_STAMP`, and tell it to **return a compact
+digest, not raw logs** — that keeps the supervisor's context clean (progressive
+disclosure applies to tool output too).
+
+## Supervision loop
+
+1. Launch the matrix detached (Phase 4) and capture `RESUME_STAMP`; record the stamp +
+   combo list in **durable state** (a task list or a notes file) so a context reset
+   can resume.
+2. Start the **monitor** — as a **background** sub-task if your harness supports one,
+   else a short foreground check each tick.
+3. Each supervisor tick:
+   - Read the monitor's latest digest; emit a one-line status to the user (keepalive).
+   - Newly `exit=0` combos → dispatch an **analyzer** (in parallel across them).
+   - **Flaked** combos → Phase-5 retry procedure (cap 2); or, in unlimited mode, the
+     `references/unlimited-mode.md` loop.
+   - `.done` present **and** every combo has an analyzer result → go to Phase 6.
+   - Otherwise **schedule the next wake** (a timer/cron, ~5 min while active; 20–30
+     min if genuinely idle) and end the turn — do **not** busy-loop. No scheduler?
+     `sleep` between checks in a loop.
+
+## Recovery — sub-task stuck / API error
+
+- A sub-task that dies on a terminal API error comes back as an error / empty result.
+  Either way **re-spawn a fresh one** pointed at the same `RESUME_STAMP` — no state is
+  lost.
+- Cap re-spawns (≤3 per role per tick). If a role keeps dying, **fall back to doing
+  that check yourself** (one shell digest) so the run still advances, and note the
+  degradation.
+- Whole detached runner died on the VM (no `.done`, no live process) → re-attach with
+  `RESUME_STAMP`; if truly dead, relaunch the unfinished combos.
+- Local/SSH `exit 255` is a transient relay blip — retry; the detached run is fine.
+
+## Keep the session alive (if your harness can stop it)
+
+Some harnesses watch the session and may mark it done — or time it out — during quiet
+stretches (Claude Code's background job list classifies from your message text). When
+running under one:
+- **Never** signal completion (Claude Code: a `result:` / "done" / "failed" line)
+  until *every* combo is terminal and summarized.
+- Each tick, emit a short `still working: N running / M done / K flaked` line so the
+  session stays classified as active.
+- Re-engage via a timer rather than blocking, so you don't go silent. Ask the user to
+  unblock only for a genuine blocker (e.g. a missing API key you can't supply) — and
+  in unlimited mode, avoid even that by deciding sanely.
+
+Harnesses without such a classifier can ignore this section — but emitting periodic
+progress is still good practice.
+
+## Cost discipline
+
+Poll with the cheap monitor (frequent), analyze with the mid tier (per-finish only),
+spend the main model rarely (supervise/decide). Never analyze a combo twice; prefer
+one batched analyzer when several combos finish together.

--- a/.agents/skills/run-parallel-evals/references/unlimited-mode.md
+++ b/.agents/skills/run-parallel-evals/references/unlimited-mode.md
@@ -1,0 +1,66 @@
+# Unlimited / self-healing mode
+
+Load this **only** when the user explicitly opted in ("unlimited", "keep going until
+it finishes", "auto-fix and restart", "self-healing"). It turns a *real* (non-flake)
+failure caused by a **task or code bug** into: diagnose → fix → re-sync → restart the
+failed combos → continue, until the whole matrix reaches a terminal-acceptable state.
+It builds on `references/resilient-monitoring.md` (reuse that loop + recovery +
+keepalive); this file only adds the fix-and-restart behavior. It is **harness-
+agnostic** — see *Harness portability* in `SKILL.md` for the capability mapping
+(isolated worktree, durable state, sub-tasks); tool names here are examples.
+
+## Classify before you "fix" — fixing the wrong thing corrupts the eval
+
+- **Infra flake** → retry, no code change (Phase-5 retry procedure).
+- **Model capability** (clean trajectory, low score — the agent ran but did the task
+  badly) → **do NOT fix.** That's a real result; record it and move on.
+- **Task / stack / harness bug** (the combo cannot succeed regardless of model:
+  broken stack, bad prompt template, wrong `expected_output`, missing var, or a
+  parallel-safety collision from the known-issues appendix) → **the fixable class.**
+
+When unsure, prefer recording over fixing; only fix when you can name the bug **and**
+the change that resolves it.
+
+## The loop
+
+1. **Isolate.** Make changes in an isolated git worktree / branch (Claude Code:
+   `EnterWorktree`; else `git worktree add` + a branch), never the shared checkout.
+   Branch off the arm under test.
+2. **Diagnose** the failing combo with the review checks (the `devops-bench-review`
+   skill if your harness loaded it, plus the `docs/parallel-evals.md` failure table).
+   Name the bug and the minimal fix.
+3. **Fix**, scoped to that bug — don't refactor unrelated code. Run the unit tests /
+   `ruff` locally if they cover it (never run an eval to "test" a fix).
+4. **Log** the fix in a running changelog (durable state — a notes file or task list):
+   combo, symptom, root cause, the change, commit sha.
+5. **Re-sync (remote only).** In `BENCH_REMOTE` mode, push the working tree to the
+   bastion (`scripts/bastion/sync-to-bastion.sh`; `SKIP_SYNC=1` only after a real
+   sync). In local mode the edits are already in place — skip this.
+6. **Restart only the failed combo(s)** as fresh single-combo matrices (new stamp),
+   after cleaning their leaked GCP resources (cluster, `gke-nodes-*` SA, secrets).
+7. **Continue** the resilient-monitoring loop over the remaining + restarted combos.
+
+## Guardrails (so "unlimited" still terminates safely)
+
+- **Cap fix attempts per combo** (default 3). After that, stop fixing it, mark it
+  blocked, and keep going on the rest — never loop one combo forever.
+- **Scope every change**; commit each fix separately with a clear message; keep the
+  changelog for human review at the end.
+- **Local commits only.** Do **not** push to or merge shared branches (main, the arm
+  branches) unless the user said so — surface the branch/diff for review instead.
+- **Self-check risky fixes** with the review checks before restarting — especially
+  parallel-safety fixes, since you're about to run them concurrently.
+- **Budget awareness.** Each restart costs a cluster + ~25–40 min. Track combos
+  fixed/remaining; if a token or wall-clock budget was given, respect it and report
+  where you stopped.
+- **Checkpoint** stamp + per-combo state + fix log in durable state every tick so a
+  context reset resumes mid-flight.
+- **Keepalive** as in resilient-monitoring: don't signal completion until the whole
+  matrix is done.
+
+## Done condition + final report
+
+Finish when every combo is terminal-acceptable: **passed**, recorded as a genuine
+**model-capability** result, or **blocked** after the fix-attempt cap. Then deliver
+the Phase-6 summary **plus** the fix changelog (each bug → change → commit) and the
+list of still-blocked combos with why.

--- a/.claude/skills/devops-bench-review
+++ b/.claude/skills/devops-bench-review
@@ -1,0 +1,1 @@
+../../.agents/skills/devops-bench-review

--- a/.claude/skills/run-eval
+++ b/.claude/skills/run-eval
@@ -1,0 +1,1 @@
+../../.agents/skills/run-eval

--- a/.claude/skills/run-parallel-evals
+++ b/.claude/skills/run-parallel-evals
@@ -1,0 +1,1 @@
+../../.agents/skills/run-parallel-evals


### PR DESCRIPTION
## Summary

A dedicated home for **agent skills / guidelines** so they can evolve independently of feature PRs.
**Stacked on #131** (`feat/bastion-matrix`).

Three skills:

- **`devops-bench-review`** (new) — **review-only** review of a PR or the current workspace across
  four lenses: correctness; **parallel-safety across the eval matrix axes** (Task × Model ×
  AgentConfig) — the emphasis, with a shared-state checklist and per-axis reasoning; task & stack
  conventions; and docs conventions. It analyzes statically and may run unit tests / `ruff`
  lint+format checks, but **never** runs benchmark evals or provisions infra.
- **`run-parallel-evals`** — drives the full parallel matrix; harness-agnostic with an Antigravity
  portability map and local/remote execution modes. (Relocated here so all skills sit together.)
- **`run-eval`** (new) — drive a **single** Task × Model × AgentConfig run end to end (a 1×1×1
  matrix); reuses `run-parallel-evals`' wrappers and recovery/reference files.

Each skill is a source dir under `.agents/skills/<name>/` plus a `.claude/skills/` discovery symlink
(both force-added, since `.agents`/`.claude` are in `.git/info/exclude`).

## Stacking / dependencies

- Base: **#131** (`feat/bastion-matrix`) — provides `docs/bastion.md` and `scripts/bastion/*` that
  `run-parallel-evals` / `run-eval` reference.
- `run-parallel-evals` also references `docs/parallel-evals.md`, which lands in **#126**
  (`feat/parallel-eval-runs`); the skill is fully wired once #126 is in the merge path.
