### PR TITLE
openclaw: add gemini-3.5-flash catalog support + pin transport

### DIFF
--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -89,20 +89,18 @@ _OPENCLAW_STATE_DIRNAME = "state"
 _OPENCLAW_SKILLS_DIRNAME = "skills"
 _OPENCLAW_CONFIG_FILE = "openclaw.json"
 
-# Bare model ids (the part after the ``provider/`` prefix) that openclaw's
-# built-in catalog doesn't ship. ``oc agent --model provider/id`` aborts on an
-# unknown id unless the provider's catalog is patched; for these the harness
-# registers a catalog entry in the per-run isolated ``openclaw.json`` instead of
-# relying on a global ``oc models``/``configure-oc.sh`` step (which races across
-# parallel runs and pollutes the operator's config).
+# Bare model ids (the part after ``provider/``) absent from openclaw's built-in
+# catalog; the harness registers these per-run (see :func:`_build_model_override`).
 _CATALOG_OVERRIDES: frozenset[str] = frozenset({"gemini-3.5-flash"})
 
-# Providers that need an explicit transport so oc routes them correctly. The
-# built-in ``google`` (google-genai) provider already carries its transport, so
-# only the Vertex provider is listed: without ``api: google-vertex`` oc falls
-# back to the OpenAI transport and 401s. ``{location}`` is expanded by oc from
-# its transport location (``GOOGLE_CLOUD_LOCATION``), so it stays a literal here.
+# Transport each per-run provider entry must pin: such an entry *replaces* oc's
+# built-in provider rather than merging, so without ``api`` oc falls back to the
+# OpenAI transport and 401s. ``google`` needs no ``baseUrl``; for ``google-vertex``
+# ``{location}`` is expanded by oc, so it stays literal here.
 _PROVIDER_TRANSPORT: dict[str, dict[str, str]] = {
+    "google": {
+        "api": "google-generative-ai",
+    },
     "google-vertex": {
         "api": "google-vertex",
         "baseUrl": "https://{location}-aiplatform.googleapis.com",
@@ -152,8 +150,9 @@ def _build_model_override(config: AgentConfig) -> dict:
     The entry is provider-agnostic across Google's two backends: the provider is
     read from the resolved oc model id, so the *same* model id works on
     ``google`` (google-genai, API key) or ``google-vertex`` (Vertex AI, ADC) by
-    flipping ``config.provider`` alone. Vertex needs its transport pinned (see
-    :data:`_PROVIDER_TRANSPORT`); the built-in google provider does not.
+    flipping ``config.provider`` alone. Both pin their transport (see
+    :data:`_PROVIDER_TRANSPORT`) because a per-run provider entry replaces oc's
+    built-in one rather than merging into it.
 
     No auth is written here — it flows from the env: an API key
     (``GEMINI_API_KEY``/``GOOGLE_API_KEY``) for google-genai, or, when no key is

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -25,8 +25,15 @@ a per-run temp dir:
   ``<OPENCLAW_STATE_DIR>/skills/<name>/SKILL.md``.
 * **Rules** — ``config.capabilities.rules.text`` is prepended to the prompt
   (the ``oc`` build has no dedicated system-prompt flag).
+* **Model catalog** — models openclaw doesn't ship in its built-in catalog
+  (e.g. ``gemini-3.5-flash``) are registered in the same per-run
+  ``<run>/openclaw.json`` so a run never depends on a global
+  ``oc models``/``configure-oc.sh`` step. The entry is written for whichever
+  Google backend ``config.provider`` selects — ``google`` (google-genai) or
+  ``google-vertex`` (Vertex AI).
 * **Model auth** — ``config.api_key`` is threaded into the provider env var
-  (``GEMINI_API_KEY``/``ANTHROPIC_API_KEY``/...) that ``oc agent --local`` reads.
+  (``GEMINI_API_KEY``/``GOOGLE_CLOUD_API_KEY``/``ANTHROPIC_API_KEY``/...) that
+  ``oc agent --local`` reads.
 
 Trajectory extraction uses the official session commands documented in
 ``docs/openclaw/sessions.md``: run ``oc agent --local``, locate the single
@@ -82,6 +89,26 @@ _OPENCLAW_STATE_DIRNAME = "state"
 _OPENCLAW_SKILLS_DIRNAME = "skills"
 _OPENCLAW_CONFIG_FILE = "openclaw.json"
 
+# Bare model ids (the part after the ``provider/`` prefix) that openclaw's
+# built-in catalog doesn't ship. ``oc agent --model provider/id`` aborts on an
+# unknown id unless the provider's catalog is patched; for these the harness
+# registers a catalog entry in the per-run isolated ``openclaw.json`` instead of
+# relying on a global ``oc models``/``configure-oc.sh`` step (which races across
+# parallel runs and pollutes the operator's config).
+_CATALOG_OVERRIDES: frozenset[str] = frozenset({"gemini-3.5-flash"})
+
+# Providers that need an explicit transport so oc routes them correctly. The
+# built-in ``google`` (google-genai) provider already carries its transport, so
+# only the Vertex provider is listed: without ``api: google-vertex`` oc falls
+# back to the OpenAI transport and 401s. ``{location}`` is expanded by oc from
+# its transport location (``GOOGLE_CLOUD_LOCATION``), so it stays a literal here.
+_PROVIDER_TRANSPORT: dict[str, dict[str, str]] = {
+    "google-vertex": {
+        "api": "google-vertex",
+        "baseUrl": "https://{location}-aiplatform.googleapis.com",
+    },
+}
+
 
 def _oc_model_id(config: AgentConfig) -> str:
     """Resolve the canonical ``provider/model`` id ``oc agent --model`` expects.
@@ -111,30 +138,79 @@ def _oc_model_id(config: AgentConfig) -> str:
     return f"{provider}/{model}"
 
 
-def _build_openclaw_config(mcp_servers: tuple[McpBinding, ...]) -> dict:
+def _build_model_override(config: AgentConfig) -> dict:
+    """Register a catalog entry for a model openclaw doesn't ship by default.
+
+    openclaw resolves ``--model provider/id`` against its built-in catalog;
+    ids absent from it (e.g. ``gemini-3.5-flash``) abort the run unless the
+    provider's catalog is patched. Rather than depend on a global
+    ``oc models``/``configure-oc.sh`` step — which races across parallel runs
+    and mutates the operator's shared config — the harness writes the catalog
+    entry into the per-run isolated ``openclaw.json`` selected via
+    ``OPENCLAW_CONFIG_PATH``.
+
+    The entry is provider-agnostic across Google's two backends: the provider is
+    read from the resolved oc model id, so the *same* model id works on
+    ``google`` (google-genai, API key) or ``google-vertex`` (Vertex AI, ADC) by
+    flipping ``config.provider`` alone. Vertex needs its transport pinned (see
+    :data:`_PROVIDER_TRANSPORT`); the built-in google provider does not.
+
+    No auth is written here — it flows from the env: an API key
+    (``GEMINI_API_KEY``/``GOOGLE_API_KEY``) for google-genai, or, when no key is
+    set, the Vertex **ADC** path (the ``GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials``
+    marker → metadata-server credentials). So the override stands on its own for
+    a keyless ADC run.
+
+    Returns an empty dict when no model is configured or the model is already in
+    oc's catalog (caller then writes no ``models``/``agents`` sections).
+    """
+    model_id = _oc_model_id(config)
+    if not model_id:
+        return {}
+    provider, _, bare = model_id.partition("/")
+    if bare not in _CATALOG_OVERRIDES:
+        return {}
+    provider_entry: dict = dict(_PROVIDER_TRANSPORT.get(provider, {}))
+    provider_entry["models"] = [{"id": bare, "name": bare}]
+    return {
+        "models": {"providers": {provider: provider_entry}},
+        # Allowlist ``provider/id`` for the agent's per-run ``--model`` override.
+        "agents": {"defaults": {"models": {model_id: {}}}},
+    }
+
+
+def _build_openclaw_config(config: AgentConfig, mcp_servers: tuple[McpBinding, ...]) -> dict:
     """Assemble the isolated ``openclaw.json`` payload for a run.
 
+    Merges the two per-run config concerns the harness owns: command-bearing MCP
+    bindings (``mcp.servers``) and a catalog entry for a model openclaw doesn't
+    ship by default (``models``/``agents``; see :func:`_build_model_override`).
+    Their key spaces are disjoint, so either, both, or neither may be present.
+
     Args:
+        config: Resolved :class:`AgentConfig` (drives the model-catalog entry).
         mcp_servers: Bindings to render into ``mcp.servers`` (empty-command
             bindings are skipped by :func:`build_mcp_servers`).
 
     Returns:
-        A config mapping with an ``mcp.servers`` section, or an empty dict when
-        no binding carries a launch command (caller then skips the config write
-        and leaves ``OPENCLAW_CONFIG_PATH`` unset).
+        A config mapping, or an empty dict when there is neither a launchable MCP
+        binding nor a model needing a catalog entry (caller then skips the config
+        write and leaves ``OPENCLAW_CONFIG_PATH`` unset).
 
-    Each server entry inherits the run's ``KUBECONFIG`` (set by ``RunEnv``) as an
-    explicit ``env`` so the MCP server (e.g. gke-mcp) reads the run-scoped cluster
-    credentials directly instead of forcing the agent to re-fetch them.
+    Each MCP server entry inherits the run's ``KUBECONFIG`` (set by ``RunEnv``) as
+    an explicit ``env`` so the MCP server (e.g. gke-mcp) reads the run-scoped
+    cluster credentials directly instead of forcing the agent to re-fetch them.
     """
+    payload: dict = {}
     servers = build_mcp_servers(mcp_servers)
-    if not servers:
-        return {}
-    kubeconfig = os.environ.get("KUBECONFIG")
-    if kubeconfig:
-        for entry in servers.values():
-            entry.setdefault("env", {})["KUBECONFIG"] = kubeconfig
-    return {"mcp": {"servers": servers}}
+    if servers:
+        kubeconfig = os.environ.get("KUBECONFIG")
+        if kubeconfig:
+            for entry in servers.values():
+                entry.setdefault("env", {})["KUBECONFIG"] = kubeconfig
+        payload["mcp"] = {"servers": servers}
+    payload.update(_build_model_override(config))
+    return payload
 
 
 def _build_env(config: AgentConfig) -> dict[str, str]:
@@ -144,6 +220,15 @@ def _build_env(config: AgentConfig) -> dict[str, str]:
     benchmark's neutral ``config.api_key`` is mapped onto the provider-specific
     variable(s) openclaw expects; the model itself is never hardcoded (it flows
     from ``config.model`` via ``oc agent --model``).
+
+    When ``config.api_key`` is unset the overlay carries no key at all — this is
+    the **Vertex / ADC** path: ``google-vertex`` resolves credentials from the
+    metadata-server Application Default Credentials at request time (the matrix
+    exports the ``GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials`` ADC marker that
+    tells oc's vertex transport to use ADC), so no key is threaded here. A
+    provided ``google-vertex`` key lands on ``GOOGLE_CLOUD_API_KEY`` rather than
+    ``GEMINI_API_KEY`` so it reaches the vertex transport, not the google-genai
+    one.
 
     Args:
         config: Resolved :class:`AgentConfig` for this run.
@@ -158,6 +243,8 @@ def _build_env(config: AgentConfig) -> dict[str, str]:
         if provider in ("google", "gemini"):
             overlay["GEMINI_API_KEY"] = config.api_key
             overlay["GOOGLE_API_KEY"] = config.api_key
+        elif provider == "google-vertex":
+            overlay["GOOGLE_CLOUD_API_KEY"] = config.api_key
         elif provider == "anthropic":
             overlay["ANTHROPIC_API_KEY"] = config.api_key
         elif provider == "openai":
@@ -204,9 +291,7 @@ def _prepend_rules(rules_text: str, prompt: str) -> str:
     return f"{rules_text.rstrip()}\n\n{prompt}"
 
 
-def _build_local_command(
-    config: AgentConfig, prompt: str, agent_name: str, oc_bin: str
-) -> str:
+def _build_local_command(config: AgentConfig, prompt: str, agent_name: str, oc_bin: str) -> str:
     """Build the bash command that sets the model and runs ``oc agent --local``.
 
     Every interpolated value is ``shlex.quote``d so prompts/agent names
@@ -259,9 +344,7 @@ class OpenClawAgent(AgentHarness):
             per-run isolated one written for MCP).
     """
 
-    def __init__(
-        self, config: AgentConfig | None = None, *, agent_name: str = "main"
-    ) -> None:
+    def __init__(self, config: AgentConfig | None = None, *, agent_name: str = "main") -> None:
         AgentHarness.__init__(self, config)
         self.agent_name = agent_name
         caps = self.config.capabilities
@@ -304,7 +387,7 @@ class OpenClawAgent(AgentHarness):
             env_overlay = _build_env(self.config)
             env_overlay["OPENCLAW_STATE_DIR"] = str(state_dir)
 
-            config_payload = _build_openclaw_config(caps.mcp_servers)
+            config_payload = _build_openclaw_config(self.config, caps.mcp_servers)
             if config_payload:
                 config_path = workdir / _OPENCLAW_CONFIG_FILE
                 config_path.write_text(json.dumps(config_payload, indent=2))
@@ -340,9 +423,7 @@ class OpenClawAgent(AgentHarness):
 
             if completed.returncode != 0:
                 stderr = (completed.stderr or "").strip()
-                errors.append(
-                    f"oc agent exited {completed.returncode}: {stderr or '<no stderr>'}"
-                )
+                errors.append(f"oc agent exited {completed.returncode}: {stderr or '<no stderr>'}")
                 metadata["returncode"] = completed.returncode
 
             trajectory, tokens, bundle_output, export_errors = self._extract_trajectory(
@@ -393,9 +474,7 @@ class OpenClawAgent(AgentHarness):
 
         if sessions.returncode != 0:
             stderr = (sessions.stderr or "").strip()
-            errors.append(
-                f"oc sessions exited {sessions.returncode}: {stderr or '<no stderr>'}"
-            )
+            errors.append(f"oc sessions exited {sessions.returncode}: {stderr or '<no stderr>'}")
             return [], {}, "", errors
 
         key = _pick_session_key(sessions.stdout or "")
@@ -431,8 +510,7 @@ class OpenClawAgent(AgentHarness):
             if export.returncode != 0:
                 stderr = (export.stderr or "").strip()
                 errors.append(
-                    f"oc export-trajectory exited {export.returncode}: "
-                    f"{stderr or '<no stderr>'}"
+                    f"oc export-trajectory exited {export.returncode}: {stderr or '<no stderr>'}"
                 )
                 return [], {}, "", errors
 
@@ -441,8 +519,6 @@ class OpenClawAgent(AgentHarness):
             if not events_text:
                 return [], {}, "", errors
 
-            trajectory, tokens, output_text, parse_errors = parse_trajectory_export(
-                events_text
-            )
+            trajectory, tokens, output_text, parse_errors = parse_trajectory_export(events_text)
             errors.extend(parse_errors)
             return trajectory, tokens, output_text, errors

--- a/docs/parallel-evals.md
+++ b/docs/parallel-evals.md
@@ -174,6 +174,21 @@ and the `-preview` models.
   `scripts/bastion/configure-oc.sh --mcp --skills` (or `--no-mcp --no-skills` for
   a clean "no capabilities" run). The agent profile is `main`.
 
+#### Model catalog overrides (e.g. `gemini-3.5-flash`)
+
+Models openclaw doesn't ship in its built-in catalog must be registered before
+`oc agent --model provider/<id>` will accept them.
+
+- **Refactored arm**: the harness registers the entry *automatically* in its
+  per-run isolated `openclaw.json` for whichever Google backend `AGENT_PROVIDER`
+  selects — `google` (google-genai, API key) or `google-vertex` (Vertex AI,
+  ADC). No manual step, no shared-config mutation. Vertex runs work **keyless**
+  (auth is the metadata-server ADC marker). Currently auto-registered:
+  `gemini-3.5-flash`.
+- **Legacy arm**: `scripts/bastion/configure-oc.sh` registers the catalog entry
+  in the **global** config — under `google-vertex` with `--vertex` (`VERTEX_MODELS`)
+  and under `google` always (`GENAI_MODELS`, default `gemini-3.5-flash`).
+
 ### Gemini CLI (refactored `gcli` config) — headless MCP requirements
 
 Making the gemini CLI actually **load and execute** MCP tools (e.g. gke-mcp) in

--- a/scripts/bastion/configure-oc.sh
+++ b/scripts/bastion/configure-oc.sh
@@ -81,11 +81,9 @@ else
 fi
 
 # --- 1b. google-genai catalog overrides ------------------------------------- #
-# Register models oc's built-in catalog doesn't ship (e.g. gemini-3.5-flash)
-# under the google (google-genai) provider so the legacy arm can target
-# `google/<model>` over the API-key endpoint. The provider's transport is
-# built-in, so only the model + agent allowlist entries are added. Idempotent;
-# auth still flows from `oc models auth paste-api-key --provider google` above.
+# Register models oc doesn't ship (e.g. gemini-3.5-flash) under the google
+# (google-genai) provider so the legacy arm can target `google/<model>`.
+# Idempotent; auth flows from the `oc models auth` paste above.
 if [ -n "${GENAI_MODELS}" ]; then
   OC_CONFIG="${HOME}/.openclaw/openclaw.json" GENAI_MODELS="${GENAI_MODELS}" \
   python3 - <<'PY'
@@ -98,6 +96,7 @@ try:
 except FileNotFoundError:
     cfg = {}
 prov = cfg.setdefault("models", {}).setdefault("providers", {}).setdefault("google", {})
+prov["api"] = "google-generative-ai"  # replaces built-in entry; pin transport
 prov.setdefault("models", [])
 existing = {m.get("id") for m in prov["models"] if isinstance(m, dict)}
 for m in models:

--- a/scripts/bastion/configure-oc.sh
+++ b/scripts/bastion/configure-oc.sh
@@ -30,7 +30,11 @@
 #   SKILLS_SRC     dir of skill markdowns         (default: ~/devops-bench/skills)
 #   OC_SKILLS_DIR  staging dir for <name>/SKILL.md (default: ~/oc-skills)
 #   VERTEX_MODELS  space-separated model ids to register under google-vertex
-#                  (default: "gemini-3.1-pro-preview gemini-3-flash-preview")
+#                  (default: "gemini-3.1-pro-preview gemini-3-flash-preview
+#                            gemini-3.5-flash")
+#   GENAI_MODELS   space-separated model ids to register under the google
+#                  (google-genai) provider's catalog — only models oc doesn't
+#                  ship by default need listing (default: "gemini-3.5-flash")
 #   OPENCLAW_AGENT oc agent profile for the auth marker (default: main)
 set -euo pipefail
 
@@ -41,7 +45,8 @@ GKE_MCP_BIN="${GKE_MCP_BIN:-${HOME}/gke-mcp}"
 SECRETS_ENV="${SECRETS_ENV:-${HOME}/secrets.env}"
 SKILLS_SRC="${SKILLS_SRC:-${HOME}/devops-bench/skills}"
 OC_SKILLS_DIR="${OC_SKILLS_DIR:-${HOME}/oc-skills}"
-VERTEX_MODELS="${VERTEX_MODELS:-gemini-3.1-pro-preview gemini-3-flash-preview}"
+VERTEX_MODELS="${VERTEX_MODELS:-gemini-3.1-pro-preview gemini-3-flash-preview gemini-3.5-flash}"
+GENAI_MODELS="${GENAI_MODELS:-gemini-3.5-flash}"
 OPENCLAW_AGENT="${OPENCLAW_AGENT:-main}"
 
 while [ $# -gt 0 ]; do
@@ -73,6 +78,39 @@ if [ -f "${SECRETS_ENV}" ]; then
   fi
 else
   echo "==> WARN: ${SECRETS_ENV} not found; skipping oc auth"
+fi
+
+# --- 1b. google-genai catalog overrides ------------------------------------- #
+# Register models oc's built-in catalog doesn't ship (e.g. gemini-3.5-flash)
+# under the google (google-genai) provider so the legacy arm can target
+# `google/<model>` over the API-key endpoint. The provider's transport is
+# built-in, so only the model + agent allowlist entries are added. Idempotent;
+# auth still flows from `oc models auth paste-api-key --provider google` above.
+if [ -n "${GENAI_MODELS}" ]; then
+  OC_CONFIG="${HOME}/.openclaw/openclaw.json" GENAI_MODELS="${GENAI_MODELS}" \
+  python3 - <<'PY'
+import json, os
+path = os.environ["OC_CONFIG"]
+models = os.environ["GENAI_MODELS"].split()
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+except FileNotFoundError:
+    cfg = {}
+prov = cfg.setdefault("models", {}).setdefault("providers", {}).setdefault("google", {})
+prov.setdefault("models", [])
+existing = {m.get("id") for m in prov["models"] if isinstance(m, dict)}
+for m in models:
+    if m not in existing:
+        prov["models"].append({"id": m, "name": m})
+# Allowlist google/<model> for the agent's per-run --model override.
+allow = cfg.setdefault("agents", {}).setdefault("defaults", {}).setdefault("models", {})
+for m in models:
+    allow.setdefault(f"google/{m}", {})
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+print(f"==> google (genai) catalog overrides registered: {', '.join(models)}")
+PY
 fi
 
 # --- 2. GKE MCP server ------------------------------------------------------ #

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -577,13 +577,16 @@ def test_model_override_empty_when_no_model():
     assert _build_model_override(AgentConfig()) == {}
 
 
-def test_model_override_genai_registers_under_google_provider():
-    """google-genai: catalog entry + allowlist under the built-in google provider,
-    with no transport pinned (oc's google provider carries its own)."""
+def test_model_override_genai_pins_generative_ai_transport():
+    """google-genai: the entry pins ``api: google-generative-ai`` so oc routes it
+    through the google-genai transport (a per-run provider entry replaces oc's
+    built-in one, so the transport must be carried) and needs no ``baseUrl``.
+    Allowlists ``google/<model>``."""
     override = _build_model_override(AgentConfig(model="gemini-3.5-flash", provider="google"))
     google = override["models"]["providers"]["google"]
-    assert google == {"models": [{"id": "gemini-3.5-flash", "name": "gemini-3.5-flash"}]}
-    assert "api" not in google and "baseUrl" not in google
+    assert google["api"] == "google-generative-ai"
+    assert "baseUrl" not in google
+    assert google["models"] == [{"id": "gemini-3.5-flash", "name": "gemini-3.5-flash"}]
     assert override["agents"]["defaults"]["models"] == {"google/gemini-3.5-flash": {}}
 
 

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -37,6 +37,7 @@ from devops_bench.agents.cli.openclaw import agent as oc_mod
 from devops_bench.agents.cli.openclaw.agent import (
     _build_env,
     _build_local_command,
+    _build_model_override,
     _build_openclaw_config,
     _oc_model_id,
 )
@@ -49,10 +50,15 @@ def _events(*entries: dict) -> str:
 
 
 def _tool_call(call_id: str, name: str, arguments: dict) -> dict:
-    return {"type": "tool.call", "data": {"toolCallId": call_id, "name": name, "arguments": arguments}}
+    return {
+        "type": "tool.call",
+        "data": {"toolCallId": call_id, "name": name, "arguments": arguments},
+    }
 
 
-def _tool_result(call_id: str, text: str, *, is_error: bool = False, status: str = "completed") -> dict:
+def _tool_result(
+    call_id: str, text: str, *, is_error: bool = False, status: str = "completed"
+) -> dict:
     return {
         "type": "tool.result",
         "data": {
@@ -154,7 +160,9 @@ def test_parse_trajectory_export_output_falls_back_to_assistant_message():
     blob = _events(
         {
             "type": "assistant.message",
-            "data": {"message": {"role": "assistant", "content": [{"type": "text", "text": "done."}]}},
+            "data": {
+                "message": {"role": "assistant", "content": [{"type": "text", "text": "done."}]}
+            },
         },
         {"type": "model.completed", "data": {"usage": {"input": 1, "output": 2}}},
     )
@@ -262,7 +270,9 @@ def _bundle_writer(events_jsonl: str):
     writes ``events.jsonl`` (the real trajectory filename) into the bundle dir
     under the ``--workspace`` it was handed.
     """
-    sessions_payload = json.dumps([{"key": "agent:operator:test", "model": "google/gemini-2.5-pro"}])
+    sessions_payload = json.dumps(
+        [{"key": "agent:operator:test", "model": "google/gemini-2.5-pro"}]
+    )
 
     def fake_core_run(argv, **kwargs):
         if argv[1] == "sessions" and "export-trajectory" not in argv:
@@ -271,9 +281,7 @@ def _bundle_writer(events_jsonl: str):
             ws = Path(argv[argv.index("--workspace") + 1])
             export_root = ws / ".openclaw" / "trajectory-exports" / "openclaw-trajectory-x"
             export_root.mkdir(parents=True, exist_ok=True)
-            (export_root / "events.jsonl").write_text(
-                events_jsonl, encoding="utf-8"
-            )
+            (export_root / "events.jsonl").write_text(events_jsonl, encoding="utf-8")
             return _make_subprocess_result(stdout="exported", returncode=0)
         raise AssertionError(f"unexpected argv {argv}")
 
@@ -306,11 +314,7 @@ def test_execute_prefers_bundle_output_over_noisy_stdout(monkeypatch, tmp_path):
     """The agent's final answer (events.jsonl assistantTexts) must win over
     `oc --log-level debug` noise — otherwise the judge grades debug spew.
     """
-    noisy_stdout = (
-        "[DEBUG] starting oc...\n"
-        "[INFO] sessionFile=/tmp/.openclaw/...\n"
-        "[DEBUG] turn 1\n"
-    )
+    noisy_stdout = "[DEBUG] starting oc...\n[INFO] sessionFile=/tmp/.openclaw/...\n[DEBUG] turn 1\n"
 
     def fake_bash(cmd, **kwargs):
         return _make_subprocess_result(stdout=noisy_stdout, returncode=0)
@@ -319,7 +323,10 @@ def test_execute_prefers_bundle_output_over_noisy_stdout(monkeypatch, tmp_path):
     events = _events(
         _tool_call("1", "exec", {"command": "kubectl get pods"}),
         _tool_result("1", "pod-a Running"),
-        {"type": "model.completed", "data": {"usage": {"input": 1, "output": 1}, "assistantTexts": [clean_answer]}},
+        {
+            "type": "model.completed",
+            "data": {"usage": {"input": 1, "output": 1}, "assistantTexts": [clean_answer]},
+        },
     )
     monkeypatch.setattr(subprocess, "run", fake_bash)
     monkeypatch.setattr(oc_mod, "run", _bundle_writer(events))
@@ -403,6 +410,7 @@ def test_execute_passes_timeout_to_bash(monkeypatch, tmp_path):
 
 
 # Tests for the now-deleted legacy surface — fail-fast if SSH transport returns.
+
 
 def test_legacy_ssh_runner_is_gone():
     assert not hasattr(oc_mod, "run_openclaw_agent")
@@ -525,14 +533,88 @@ def test_execute_does_not_prepend_rules_when_empty(monkeypatch, tmp_path):
 
 def test_build_openclaw_config_wraps_servers_under_mcp():
     """A launchable binding renders under the ``mcp.servers`` config path."""
-    cfg = _build_openclaw_config((McpBinding(name="gke", command=("gke-mcp",)),))
+    cfg = _build_openclaw_config(AgentConfig(), (McpBinding(name="gke", command=("gke-mcp",)),))
     assert cfg == {"mcp": {"servers": {"gke": {"command": "gke-mcp"}}}}
 
 
-def test_build_openclaw_config_empty_without_launchable_server():
-    """No command-bearing binding → empty config (caller skips the write)."""
-    assert _build_openclaw_config(()) == {}
-    assert _build_openclaw_config((McpBinding(name="b", command=(), tools=("t",)),)) == {}
+def test_build_openclaw_config_empty_without_launchable_server_or_override():
+    """No MCP binding and a catalog-known model → empty config (caller skips)."""
+    assert _build_openclaw_config(AgentConfig(), ()) == {}
+    assert (
+        _build_openclaw_config(
+            AgentConfig(model="gemini-3.1-pro-preview"),
+            (McpBinding(name="b", command=(), tools=("t",)),),
+        )
+        == {}
+    )
+
+
+def test_build_openclaw_config_merges_mcp_and_model_override():
+    """MCP servers and a model-catalog entry coexist (disjoint key spaces)."""
+    cfg = _build_openclaw_config(
+        AgentConfig(model="gemini-3.5-flash", provider="google"),
+        (McpBinding(name="gke", command=("gke-mcp",)),),
+    )
+    assert cfg["mcp"] == {"servers": {"gke": {"command": "gke-mcp"}}}
+    assert cfg["models"]["providers"]["google"]["models"] == [
+        {"id": "gemini-3.5-flash", "name": "gemini-3.5-flash"}
+    ]
+    assert cfg["agents"]["defaults"]["models"] == {"google/gemini-3.5-flash": {}}
+
+
+# ---------------------------------------------------------------------------
+# Model catalog override: models oc doesn't ship by default get registered in
+# the per-run isolated config, for both google-genai and google-vertex.
+# ---------------------------------------------------------------------------
+
+
+def test_model_override_empty_for_catalog_known_model():
+    """A model already in oc's catalog needs no override."""
+    assert _build_model_override(AgentConfig(model="gemini-3.1-pro-preview")) == {}
+
+
+def test_model_override_empty_when_no_model():
+    assert _build_model_override(AgentConfig()) == {}
+
+
+def test_model_override_genai_registers_under_google_provider():
+    """google-genai: catalog entry + allowlist under the built-in google provider,
+    with no transport pinned (oc's google provider carries its own)."""
+    override = _build_model_override(AgentConfig(model="gemini-3.5-flash", provider="google"))
+    google = override["models"]["providers"]["google"]
+    assert google == {"models": [{"id": "gemini-3.5-flash", "name": "gemini-3.5-flash"}]}
+    assert "api" not in google and "baseUrl" not in google
+    assert override["agents"]["defaults"]["models"] == {"google/gemini-3.5-flash": {}}
+
+
+def test_model_override_gemini_alias_normalizes_to_google():
+    """``provider=gemini`` resolves to the ``google`` provider (id alias)."""
+    override = _build_model_override(AgentConfig(model="gemini-3.5-flash", provider="gemini"))
+    assert "google" in override["models"]["providers"]
+    assert override["agents"]["defaults"]["models"] == {"google/gemini-3.5-flash": {}}
+
+
+def test_model_override_vertex_pins_transport_and_allowlists():
+    """google-vertex: the entry pins ``api``/``baseUrl`` so oc uses the vertex
+    transport (not the OpenAI fallback), and allowlists ``google-vertex/<model>``."""
+    override = _build_model_override(
+        AgentConfig(model="gemini-3.5-flash", provider="google-vertex")
+    )
+    vertex = override["models"]["providers"]["google-vertex"]
+    assert vertex["api"] == "google-vertex"
+    assert vertex["baseUrl"] == "https://{location}-aiplatform.googleapis.com"
+    assert vertex["models"] == [{"id": "gemini-3.5-flash", "name": "gemini-3.5-flash"}]
+    assert override["agents"]["defaults"]["models"] == {"google-vertex/gemini-3.5-flash": {}}
+
+
+def test_model_override_vertex_needs_no_api_key():
+    """The override is independent of ``api_key`` — a keyless ADC vertex run still
+    gets its catalog entry (auth is the metadata-server ADC, set outside)."""
+    override = _build_model_override(
+        AgentConfig(model="gemini-3.5-flash", provider="google-vertex", api_key=None)
+    )
+    assert override["agents"]["defaults"]["models"] == {"google-vertex/gemini-3.5-flash": {}}
+    assert _build_env(AgentConfig(model="gemini-3.5-flash", provider="google-vertex")) == {}
 
 
 def test_build_env_threads_api_key_by_provider():
@@ -542,6 +624,13 @@ def test_build_env_threads_api_key_by_provider():
     anthropic = _build_env(AgentConfig(api_key="k", provider="anthropic"))
     assert anthropic == {"ANTHROPIC_API_KEY": "k"}
     assert _build_env(AgentConfig()) == {}
+
+
+def test_build_env_routes_vertex_key_to_cloud_api_key():
+    """A ``google-vertex`` key reaches ``GOOGLE_CLOUD_API_KEY`` (the vertex
+    transport's var), not ``GEMINI_API_KEY`` (the google-genai one)."""
+    vertex = _build_env(AgentConfig(api_key="marker", provider="google-vertex"))
+    assert vertex == {"GOOGLE_CLOUD_API_KEY": "marker"}
 
 
 def _empty_sessions_run(argv, **kwargs):
@@ -560,9 +649,7 @@ def test_execute_writes_mcp_servers_into_isolated_config(monkeypatch, tmp_path):
         cfg_path = env.get("OPENCLAW_CONFIG_PATH")
         captured["cfg_path"] = cfg_path
         captured["config"] = (
-            json.loads(Path(cfg_path).read_text())
-            if cfg_path and Path(cfg_path).exists()
-            else None
+            json.loads(Path(cfg_path).read_text()) if cfg_path and Path(cfg_path).exists() else None
         )
         return _make_subprocess_result(stdout="ok", returncode=0)
 
@@ -577,7 +664,8 @@ def test_execute_writes_mcp_servers_into_isolated_config(monkeypatch, tmp_path):
 
 
 def test_execute_writes_no_config_when_no_launchable_server(monkeypatch, tmp_path):
-    """No command-bearing MCP binding → no isolated config, env var unset."""
+    """No command-bearing MCP binding and a catalog-known model → no isolated
+    config, env var unset."""
     captured: dict = {}
 
     def fake_bash(cmd, **kwargs):
@@ -590,8 +678,50 @@ def test_execute_writes_no_config_when_no_launchable_server(monkeypatch, tmp_pat
     caps = AllCapabilities(
         mcp_servers=(McpBinding(name="builtin", command=(), tools=("alpha",)),),
     )
-    OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), capabilities=caps)).run("p")
+    OpenClawAgent(
+        AgentConfig(
+            target=str(tmp_path / "oc"),
+            model="gemini-3.1-pro-preview",
+            capabilities=caps,
+        )
+    ).run("p")
     assert captured["has_cfg"] is False
+
+
+def test_execute_writes_model_override_config_without_mcp(monkeypatch, tmp_path):
+    """A model absent from oc's catalog gets an isolated config + OPENCLAW_CONFIG_PATH
+    even with no MCP server — and works keyless (vertex/ADC)."""
+    captured: dict = {}
+
+    def fake_bash(cmd, **kwargs):
+        env = kwargs.get("env") or {}
+        cfg_path = env.get("OPENCLAW_CONFIG_PATH")
+        captured["cfg_path"] = cfg_path
+        captured["config"] = (
+            json.loads(Path(cfg_path).read_text()) if cfg_path and Path(cfg_path).exists() else None
+        )
+        # ADC path: no API key threaded into the subprocess env.
+        captured["has_key"] = any(
+            k in env for k in ("GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_CLOUD_API_KEY")
+        )
+        return _make_subprocess_result(stdout="ok", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_bash)
+    monkeypatch.setattr(oc_mod, "run", _empty_sessions_run)
+    OpenClawAgent(
+        AgentConfig(
+            target=str(tmp_path / "oc"),
+            model="gemini-3.5-flash",
+            provider="google-vertex",
+        )
+    ).run("p")
+    assert captured["cfg_path"], "OPENCLAW_CONFIG_PATH must be set for a catalog override"
+    vertex = captured["config"]["models"]["providers"]["google-vertex"]
+    assert vertex["api"] == "google-vertex"
+    assert captured["config"]["agents"]["defaults"]["models"] == {
+        "google-vertex/gemini-3.5-flash": {}
+    }
+    assert captured["has_key"] is False
 
 
 def test_execute_isolates_state_dir_and_drops_global_session_wipe(monkeypatch, tmp_path):
@@ -660,9 +790,7 @@ def test_execute_warns_and_skips_missing_skill_paths(monkeypatch, tmp_path):
     def fake_bash(cmd, **kwargs):
         cwd = kwargs.get("cwd")
         skills_root = os.path.join(cwd, "state", "skills")
-        captured["entries"] = (
-            sorted(os.listdir(skills_root)) if os.path.isdir(skills_root) else []
-        )
+        captured["entries"] = sorted(os.listdir(skills_root)) if os.path.isdir(skills_root) else []
         return _make_subprocess_result(stdout="ok", returncode=0)
 
     monkeypatch.setattr(subprocess, "run", fake_bash)


### PR DESCRIPTION
**Stack 2/4** · base: `split/1-tasks-regroup` (#148)

Add `gemini-3.5-flash` to the openclaw per-run catalog for both google-genai (API key) and google-vertex (keyless ADC), and pin each provider's transport so a per-run provider entry (which *replaces* oc's built-in one) routes correctly instead of falling back to the OpenAI transport and 401'ing.

Verified e2e on the bastion on both backends. Unit suite green (763).

---
Stack: #148 → **this** → docs/harness/bastion → eval-skills. Review/merge in order.