### PR TITLE
tasks: add spot-rebalancing — cost-efficiency rebalancing + spot optimization (kind)

### DIFF
--- a/tasks/common/spot-rebalancing/README.md
+++ b/tasks/common/spot-rebalancing/README.md
@@ -48,8 +48,11 @@ Runs on **kind** (local, on the runner VM) — no cloud dependency, no GKE quota
 
 Moving a workload to Spot requires **both** a toleration (for the Spot taint) and
 a node selector / affinity (for the Spot label) — a toleration alone would let the
-pod stay on the untainted on-demand node. The fault-tolerant workloads carry
-PodDisruptionBudgets so "without downtime" is a real constraint.
+pod stay on the untainted on-demand node. "Without downtime" is a real constraint:
+the migration is an image/scheduling change that rolls through the ReplicaSet
+(rolling update with surge), so the agent must avoid scaling to zero or deleting
+pods. (Note: PodDisruptionBudgets don't gate a rolling update — they only apply to
+Eviction-API disruptions like a node drain — so this task doesn't rely on them.)
 
 ### How it maps to the source-of-truth scenario (Complex Task #8)
 
@@ -57,8 +60,8 @@ PodDisruptionBudgets so "without downtime" is a real constraint.
 | --- | --- |
 | 1. Workload profiling & priority categorization | Classify the fleet by the `workload-tier` label + the rightsizing report into Spot-eligible vs must-stay-on-demand. |
 | 2. Bin-packing & Spot node-pool provisioning | The Spot pool is pre-provisioned (tainted/labeled); the agent targets it with tolerations + node affinity, and may spread replicas across the distinct Spot instance families. |
-| 3. Orchestrated workload migration | Add Spot tolerations + affinity and roll the fault-tolerant workloads onto Spot capacity in a batched, PDB-respecting way that keeps replicas available. |
-| 4. Real-time preemption handling | *Not scored* — a real Spot preemption within the 30s grace window can't be triggered deterministically on any substrate. The Spot-readiness (tolerations/affinity + replica spread + PDBs) captures the intent. |
+| 3. Orchestrated workload migration | Add Spot tolerations + affinity and roll the fault-tolerant workloads onto Spot capacity via a rolling update (surge) that keeps replicas available. |
+| 4. Real-time preemption handling | *Not scored* — a real Spot preemption within the 30s grace window can't be triggered deterministically on any substrate. The Spot-readiness (tolerations/affinity + replica spread) captures the intent. |
 | 5. Cost-savings reporting | Write `cost-optimization-report.md` with the classification, the rightsizing applied, and a projected ~30% cost reduction. |
 
 The parts of the SOT that the harness cannot score objectively (real Spot billing,
@@ -97,7 +100,7 @@ export JUDGE_PROVIDER="google"
 export JUDGE_MODEL="gemini-3.1-pro-preview"
 export JUDGE_API_KEY="<your-gemini-key>"
 
-python pkg/evaluator/evaluate.py tasks/common/spot-rebalancing/task.yaml
+python -m devops_bench tasks/common/spot-rebalancing/task.yaml
 ```
 
 ## Verify the environment manually (optional smoke test)

--- a/tasks/common/spot-rebalancing/README.md
+++ b/tasks/common/spot-rebalancing/README.md
@@ -1,0 +1,133 @@
+# Cost-Efficiency Rebalancing & Spot Optimization
+
+This task evaluates an agent's ability to **cut cluster compute cost without
+sacrificing reliability**: classify workloads by criticality, migrate the
+fault-tolerant ones onto cheaper Spot capacity, rightsize over-provisioned
+services, and keep everything available throughout — then report the savings.
+
+The cluster runs a mixed-criticality fleet entirely on on-demand capacity (the
+costly "before" state). Some workloads are fault-tolerant/batch (safe to move to
+Spot); others are critical/stateful (must stay on-demand). A rightsizing report
+flags the over-provisioned workloads. The agent must discover which is which from
+each workload's own metadata and rebalance the cluster safely.
+
+Runs on **kind** (local, on the runner VM) — no cloud dependency, no GKE quota.
+
+## How it works
+
+- **Infrastructure** (`tf/prebuilt/spot-rebalancing-kind`) provisions a **multi-node**
+  kind cluster (1 control-plane + 3 workers) and runs `scripts/setup.sh`, which:
+  - designates node pools: one worker stays **on-demand** (untainted); the other
+    two become a **Spot** pool — labeled `cloud.google.com/gke-spot=true` (the real
+    GKE Spot label) and tainted `cloud.google.com/gke-spot=true:NoSchedule`, with
+    distinct mock instance families so a careful plan can spread replicas across
+    them,
+  - deploys the workload fleet. Because the Spot nodes are tainted and nothing
+    tolerates them yet, **everything starts on the on-demand node** — the state the
+    agent must optimize,
+  - waits for the fleet to become Available so the agent starts healthy,
+  - delivers the rightsizing report to a per-run file
+    `~/rightsizing-report-<cluster_name>.json`.
+- The report host path derives from `cluster_name` (which the harness
+  run-token-prefixes), so concurrent runs on the shared bastion never collide. The
+  prompt references it via `{{CLUSTER_NAME}}`.
+- **Nothing tells the agent which workloads to move** — criticality is encoded in
+  each workload's `workload-tier` label / `fault-tolerant` annotation, which the
+  agent must read and act on.
+
+### The fleet (namespace `apps`)
+
+| Workload | Tier | Spot-eligible? | Over-provisioned? |
+| --- | --- | --- | --- |
+| `payments-api` | critical | No — keep on-demand | Yes (in report) |
+| `session-store` | critical | No — keep on-demand | No |
+| `image-resizer` | batch | **Yes — move to Spot** | Yes (in report) |
+| `report-builder` | batch | **Yes — move to Spot** | Yes (in report) |
+| `log-shipper` | batch | **Yes — move to Spot** | No |
+
+Moving a workload to Spot requires **both** a toleration (for the Spot taint) and
+a node selector / affinity (for the Spot label) — a toleration alone would let the
+pod stay on the untainted on-demand node. The fault-tolerant workloads carry
+PodDisruptionBudgets so "without downtime" is a real constraint.
+
+### How it maps to the source-of-truth scenario (Complex Task #8)
+
+| SOT step | Realization in this task |
+| --- | --- |
+| 1. Workload profiling & priority categorization | Classify the fleet by `workload-tier`/`fault-tolerant` metadata + the rightsizing report into Spot-eligible vs must-stay-on-demand. |
+| 2. Bin-packing & Spot node-pool provisioning | The Spot pool is pre-provisioned (tainted/labeled); the agent targets it with tolerations + node affinity, and may spread replicas across the distinct Spot instance families. |
+| 3. Orchestrated workload migration | Add Spot tolerations + affinity and roll the fault-tolerant workloads onto Spot capacity in a batched, PDB-respecting way that keeps replicas available. |
+| 4. Real-time preemption handling | *Not scored* — a real Spot preemption within the 30s grace window can't be triggered deterministically on any substrate. The Spot-readiness (tolerations/affinity + replica spread + PDBs) captures the intent. |
+| 5. Cost-savings reporting | Write `cost-optimization-report.md` with the classification, the rightsizing applied, and a projected ~30% cost reduction. |
+
+The parts of the SOT that the harness cannot score objectively (real Spot billing,
+live preemption handling) are distilled into the Spot-placement + rightsizing +
+availability constraints above, which are fully observable from cluster state and
+the agent's trajectory.
+
+## Setup (run on the GCE VM)
+
+As with the other kind-based complex tasks, run on the runner VM so kind and the
+agent are co-located. Prereqs (one-time):
+
+- Docker (running), `kind`, `kubectl`, `tofu`, and the agent binary.
+- Python ≥ 3.10 venv with the repo requirements installed.
+- `fs.inotify` bump (kind) + ≥ 20 GB free disk (a 4-node cluster is heavier than a
+  single-node one):
+  ```bash
+  echo -e "fs.inotify.max_user_watches=524288\nfs.inotify.max_user_instances=512" | sudo tee /etc/sysctl.d/99-kind.conf
+  sudo sysctl --system
+  ```
+
+## Run
+
+```bash
+export GKE_CLUSTER_NAME="spot-kind"    # used as the kind cluster name
+export NAMESPACE="default"             # unused by this task; just needs to be set
+export GCP_PROJECT_ID="local-kind"     # placeholder; only used for prompt/Vertex judge
+export OPENCLAW_LOCAL="true"
+
+export BENCH_AGENT_TYPE="cli"
+export AGENT_TARGET="oc"
+export AGENT_PROVIDER="google"
+export AGENT_MODEL="gemini-3.1-pro-preview"
+export AGENT_API_KEY="<your-gemini-key>"
+export JUDGE_PROVIDER="google"
+export JUDGE_MODEL="gemini-3.1-pro-preview"
+export JUDGE_API_KEY="<your-gemini-key>"
+
+python pkg/evaluator/evaluate.py tasks/common/spot-rebalancing/task.yaml
+```
+
+## Verify the environment manually (optional smoke test)
+
+```bash
+cd tf/prebuilt/spot-rebalancing-kind
+tofu init && tofu apply -auto-approve -var cluster_name=spot-kind
+export KUBECONFIG=~/.kube/config && kubectl config use-context kind-spot-kind
+
+kubectl get nodes -L cloud.google.com/gke-spot,cloud.google.com/gke-nodepool   # 1 on-demand + 2 spot
+kubectl -n apps get pods -o wide                          # all on the on-demand node initially
+cat ~/rightsizing-report-spot-kind.json                   # the delivered report
+
+tofu destroy -auto-approve -var cluster_name=spot-kind
+```
+You should see two Spot-tainted/labeled worker nodes and one on-demand worker, the
+five `apps` workloads all scheduled on the on-demand node, and the rightsizing
+report on disk. `tofu destroy` removes the cluster and the host-side report.
+
+## Results
+
+`results/run_<timestamp>/`:
+- `results.json` — per-check scores + the agent's full trajectory (classify +
+  migrate + rightsize).
+- `generated_files/cost-optimization-report.md` — the report the agent wrote.
+
+## Troubleshooting
+
+| Symptom | Cause / Fix |
+| --- | --- |
+| `failed to join node with kubeadm … exit status 1` | inotify limits — apply the sysctl bump above (a 4-node cluster needs more watches). |
+| `Error: … no space left on device` | Disk too small — grow to ≥ 20 GB. |
+| Fleet never becomes Available during setup | The on-demand node lacks capacity, or an image pull from Docker Hub was slow; re-run `tofu apply`. `setup.sh` waits on `rollout`/`wait` and fails loudly rather than handing the agent a broken fixture. |
+| Spot-eligible pods stay on the on-demand node after the agent's change | A toleration was added without a matching node selector/affinity for `cloud.google.com/gke-spot` — the pod tolerates Spot but isn't pulled to it. |

--- a/tasks/common/spot-rebalancing/README.md
+++ b/tasks/common/spot-rebalancing/README.md
@@ -31,9 +31,10 @@ Runs on **kind** (local, on the runner VM) — no cloud dependency, no GKE quota
 - The report host path derives from `cluster_name` (which the harness
   run-token-prefixes), so concurrent runs on the shared bastion never collide. The
   prompt references it via `{{CLUSTER_NAME}}`.
-- **Nothing tells the agent which workloads to move** — criticality is encoded in
-  each workload's `workload-tier` label / `fault-tolerant` annotation, which the
-  agent must read and act on.
+- **Nothing tells the agent which workloads to move** — each workload carries a
+  `workload-tier` label (`critical` vs `batch`) that the agent must read and map to
+  a Spot policy itself (batch/fault-tolerant tolerate preemption; critical/stateful
+  do not); the fix (tolerations, affinity, rightsizing) is never named.
 
 ### The fleet (namespace `apps`)
 
@@ -54,7 +55,7 @@ PodDisruptionBudgets so "without downtime" is a real constraint.
 
 | SOT step | Realization in this task |
 | --- | --- |
-| 1. Workload profiling & priority categorization | Classify the fleet by `workload-tier`/`fault-tolerant` metadata + the rightsizing report into Spot-eligible vs must-stay-on-demand. |
+| 1. Workload profiling & priority categorization | Classify the fleet by the `workload-tier` label + the rightsizing report into Spot-eligible vs must-stay-on-demand. |
 | 2. Bin-packing & Spot node-pool provisioning | The Spot pool is pre-provisioned (tainted/labeled); the agent targets it with tolerations + node affinity, and may spread replicas across the distinct Spot instance families. |
 | 3. Orchestrated workload migration | Add Spot tolerations + affinity and roll the fault-tolerant workloads onto Spot capacity in a batched, PDB-respecting way that keeps replicas available. |
 | 4. Real-time preemption handling | *Not scored* — a real Spot preemption within the 30s grace window can't be triggered deterministically on any substrate. The Spot-readiness (tolerations/affinity + replica spread + PDBs) captures the intent. |

--- a/tasks/common/spot-rebalancing/task.yaml
+++ b/tasks/common/spot-rebalancing/task.yaml
@@ -43,4 +43,4 @@ expected_output: |
   - Agent rightsizes the over-provisioned workloads named in the report ('payments-api', 'image-resizer', 'report-builder') so their CPU/memory requests are approximately the recommended values.
   - The rebalancing and rightsizing are performed without downtime: each change is rolled out so replicas stay available throughout (a rolling update keeps the workload serving while pods reschedule onto Spot), and no Spot-eligible workload is left unschedulable or crash-looping.
   - Agent writes 'cost-optimization-report.md' documenting which workloads it moved to Spot and which it kept on-demand (with the reasoning), the rightsizing it applied, and a projected cost reduction that meets the ~30% target with sound reasoning.
-validated: false
+validated: true

--- a/tasks/common/spot-rebalancing/task.yaml
+++ b/tasks/common/spot-rebalancing/task.yaml
@@ -37,10 +37,10 @@ expected_output: |
 
   GRADING NOTE: Grade on outcome and sound reasoning. Any correct mechanism for targeting Spot capacity (nodeSelector or nodeAffinity on 'cloud.google.com/gke-spot') plus the matching toleration is acceptable, as is any safe (batched/rolling, PDB-respecting) rollout method. The projected-savings figure need not be exact as long as the reasoning is sound and meets the ~30% target.
 
-  - Agent profiles the workloads in the 'apps' namespace and classifies them using their own metadata (the 'workload-tier' label / 'fault-tolerant' annotation): it identifies the fault-tolerant/batch workloads ('image-resizer', 'report-builder', 'log-shipper') as Spot-eligible and the critical/stateful workloads ('payments-api', 'session-store') as not Spot-eligible.
+  - Agent profiles the workloads in the 'apps' namespace and classifies them by their own metadata (the 'workload-tier' label) plus the nature of each service: it identifies the batch / fault-tolerant workloads ('image-resizer', 'report-builder', 'log-shipper') as Spot-eligible and the critical/stateful workloads ('payments-api', 'session-store') as not Spot-eligible.
   - Agent migrates each Spot-eligible workload onto the Spot nodes by adding both the toleration for the 'cloud.google.com/gke-spot=true:NoSchedule' taint and a node selector / node affinity for the 'cloud.google.com/gke-spot=true' label.
   - After rebalancing, the Spot-eligible workloads' pods are actually Running on Spot-labeled nodes, while the critical/stateful workloads remain on the on-demand node (never scheduled onto Spot and given no Spot toleration).
   - Agent rightsizes the over-provisioned workloads named in the report ('payments-api', 'image-resizer', 'report-builder') so their CPU/memory requests are approximately the recommended values.
   - The rebalancing and rightsizing are performed without downtime: replicas stay available throughout (batched/rolling updates, PodDisruptionBudgets respected) and no Spot-eligible workload is left unschedulable or crash-looping.
   - Agent writes 'cost-optimization-report.md' documenting which workloads it moved to Spot and which it kept on-demand (with the reasoning), the rightsizing it applied, and a projected cost reduction that meets the ~30% target with sound reasoning.
-validated: true
+validated: false

--- a/tasks/common/spot-rebalancing/task.yaml
+++ b/tasks/common/spot-rebalancing/task.yaml
@@ -43,4 +43,4 @@ expected_output: |
   - Agent rightsizes the over-provisioned workloads named in the report ('payments-api', 'image-resizer', 'report-builder') so their CPU/memory requests are approximately the recommended values.
   - The rebalancing and rightsizing are performed without downtime: replicas stay available throughout (batched/rolling updates, PodDisruptionBudgets respected) and no Spot-eligible workload is left unschedulable or crash-looping.
   - Agent writes 'cost-optimization-report.md' documenting which workloads it moved to Spot and which it kept on-demand (with the reasoning), the rightsizing it applied, and a projected cost reduction that meets the ~30% target with sound reasoning.
-validated: false
+validated: true

--- a/tasks/common/spot-rebalancing/task.yaml
+++ b/tasks/common/spot-rebalancing/task.yaml
@@ -35,12 +35,12 @@ prompt: |
 expected_output: |
   critical requirements:
 
-  GRADING NOTE: Grade on outcome and sound reasoning. Any correct mechanism for targeting Spot capacity (nodeSelector or nodeAffinity on 'cloud.google.com/gke-spot') plus the matching toleration is acceptable, as is any safe (batched/rolling, PDB-respecting) rollout method. The projected-savings figure need not be exact as long as the reasoning is sound and meets the ~30% target.
+  GRADING NOTE: Grade on outcome and sound reasoning. Any correct mechanism for targeting Spot capacity (nodeSelector or nodeAffinity on 'cloud.google.com/gke-spot') plus the matching toleration is acceptable, as is any safe (rolling-update / surge) rollout method that avoids dropping the workload. The projected-savings figure need not be exact as long as the reasoning is sound and meets the ~30% target.
 
   - Agent profiles the workloads in the 'apps' namespace and classifies them by their own metadata (the 'workload-tier' label) plus the nature of each service: it identifies the batch / fault-tolerant workloads ('image-resizer', 'report-builder', 'log-shipper') as Spot-eligible and the critical/stateful workloads ('payments-api', 'session-store') as not Spot-eligible.
   - Agent migrates each Spot-eligible workload onto the Spot nodes by adding both the toleration for the 'cloud.google.com/gke-spot=true:NoSchedule' taint and a node selector / node affinity for the 'cloud.google.com/gke-spot=true' label.
   - After rebalancing, the Spot-eligible workloads' pods are actually Running on Spot-labeled nodes, while the critical/stateful workloads remain on the on-demand node (never scheduled onto Spot and given no Spot toleration).
   - Agent rightsizes the over-provisioned workloads named in the report ('payments-api', 'image-resizer', 'report-builder') so their CPU/memory requests are approximately the recommended values.
-  - The rebalancing and rightsizing are performed without downtime: replicas stay available throughout (batched/rolling updates, PodDisruptionBudgets respected) and no Spot-eligible workload is left unschedulable or crash-looping.
+  - The rebalancing and rightsizing are performed without downtime: each change is rolled out so replicas stay available throughout (a rolling update keeps the workload serving while pods reschedule onto Spot), and no Spot-eligible workload is left unschedulable or crash-looping.
   - Agent writes 'cost-optimization-report.md' documenting which workloads it moved to Spot and which it kept on-demand (with the reasoning), the rightsizing it applied, and a projected cost reduction that meets the ~30% target with sound reasoning.
-validated: true
+validated: false

--- a/tasks/common/spot-rebalancing/task.yaml
+++ b/tasks/common/spot-rebalancing/task.yaml
@@ -1,0 +1,46 @@
+task_id: 22
+name: "spot-rebalancing"
+# Cost-efficiency rebalancing: migrate fault-tolerant workloads onto Spot
+# capacity and rightsize over-provisioned ones, without downtime. Each run
+# provisions its own multi-node kind cluster (1 control-plane + 1 on-demand
+# worker + 2 Spot workers) pre-seeded with a mixed-criticality fleet and a
+# delivered rightsizing report. Spot nodes carry the real GKE Spot label
+# ('cloud.google.com/gke-spot=true') + a NoSchedule taint, so the agent's
+# actions (tolerations + node affinity) are exactly what they'd be on GKE.
+# Parallel-SAFE: kind cluster name is the run-token-prefixed {{CLUSTER_NAME}}
+# (Docker nodes per-run unique), the kubeconfig is the per-run $KUBECONFIG, and
+# the report host path derives from cluster_name. No GKE quota.
+infrastructure:
+  deployer: "tofu"
+  stack: "prebuilt/spot-rebalancing-kind"
+  teardown: true
+prompt: |
+  You are the platform FinOps engineer for the Kubernetes cluster '{{CLUSTER_NAME}}'.
+  Monthly compute spend is too high and needs to come down by roughly 30%.
+
+  The cluster has a mix of node capacity: standard on-demand nodes and cheaper,
+  preemptible Spot nodes (labeled 'cloud.google.com/gke-spot=true' and tainted to
+  reserve them for workloads that opt in). Today every workload runs on on-demand
+  capacity. A rightsizing report has been delivered to
+  '~/rightsizing-report-{{CLUSTER_NAME}}.json'.
+
+  Bring the cost down without sacrificing reliability: move the workloads that can
+  safely tolerate disruption onto Spot capacity, keep the ones that cannot where
+  they are, and rightsize the over-provisioned workloads. Decide which workloads
+  are safe to move from their own metadata, and make every change in a way that
+  keeps the services available throughout.
+
+  When you are done, write a cost optimization report to 'cost-optimization-report.md'
+  for the FinOps team.
+expected_output: |
+  critical requirements:
+
+  GRADING NOTE: Grade on outcome and sound reasoning. Any correct mechanism for targeting Spot capacity (nodeSelector or nodeAffinity on 'cloud.google.com/gke-spot') plus the matching toleration is acceptable, as is any safe (batched/rolling, PDB-respecting) rollout method. The projected-savings figure need not be exact as long as the reasoning is sound and meets the ~30% target.
+
+  - Agent profiles the workloads in the 'apps' namespace and classifies them using their own metadata (the 'workload-tier' label / 'fault-tolerant' annotation): it identifies the fault-tolerant/batch workloads ('image-resizer', 'report-builder', 'log-shipper') as Spot-eligible and the critical/stateful workloads ('payments-api', 'session-store') as not Spot-eligible.
+  - Agent migrates each Spot-eligible workload onto the Spot nodes by adding both the toleration for the 'cloud.google.com/gke-spot=true:NoSchedule' taint and a node selector / node affinity for the 'cloud.google.com/gke-spot=true' label.
+  - After rebalancing, the Spot-eligible workloads' pods are actually Running on Spot-labeled nodes, while the critical/stateful workloads remain on the on-demand node (never scheduled onto Spot and given no Spot toleration).
+  - Agent rightsizes the over-provisioned workloads named in the report ('payments-api', 'image-resizer', 'report-builder') so their CPU/memory requests are approximately the recommended values.
+  - The rebalancing and rightsizing are performed without downtime: replicas stay available throughout (batched/rolling updates, PodDisruptionBudgets respected) and no Spot-eligible workload is left unschedulable or crash-looping.
+  - Agent writes 'cost-optimization-report.md' documenting which workloads it moved to Spot and which it kept on-demand (with the reasoning), the rightsizing it applied, and a projected cost reduction that meets the ~30% target with sound reasoning.
+validated: false

--- a/tf/prebuilt/spot-rebalancing-kind/main.tf
+++ b/tf/prebuilt/spot-rebalancing-kind/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    kind = {
+      source  = "tehcyx/kind"
+      version = ">= 0.5.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "kind" {}
+
+locals {
+  # Host-side artifact on the shared bastion. setup.sh overwrites it, so a fixed
+  # path would let one run clobber a concurrent run's report. cluster_name is
+  # run-token-prefixed, making it per-run unique. The task prompt references the
+  # same path via the {{CLUSTER_NAME}} placeholder. An explicit override wins.
+  report_path = var.report_path != "" ? var.report_path : "~/rightsizing-report-${var.cluster_name}.json"
+}
+
+# Multi-node kind cluster: 1 control-plane + 3 workers. setup.sh designates one
+# worker as the "on-demand" pool and taints/labels the other two as a reserved
+# "spot" pool (control-plane is tainted by kind, so workloads land on workers).
+resource "kind_cluster" "default" {
+  name            = var.cluster_name
+  node_image      = var.node_image
+  kubeconfig_path = pathexpand(var.kubeconfig_path)
+  wait_for_ready  = true
+
+  kind_config {
+    kind        = "Cluster"
+    api_version = "kind.x-k8s.io/v1alpha4"
+
+    node {
+      role = "control-plane"
+    }
+    node {
+      role = "worker"
+    }
+    node {
+      role = "worker"
+    }
+    node {
+      role = "worker"
+    }
+  }
+}
+
+# Outside-the-cluster setup: label/taint the pools, deploy the fleet, deliver the
+# rightsizing report. Runs during `tofu apply`, before the agent starts.
+resource "null_resource" "setup" {
+  triggers = {
+    cluster     = kind_cluster.default.name
+    report_path = pathexpand(local.report_path)
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = "${path.module}/scripts/setup.sh"
+    environment = {
+      KUBECONFIG    = pathexpand(var.kubeconfig_path)
+      REPORT_PATH   = pathexpand(local.report_path)
+      MANIFESTS_DIR = "${path.module}/manifests"
+    }
+  }
+
+  # Remove the host-side report on teardown. The kind cluster is destroyed by its
+  # own resource; the report lives outside the cluster, so clean it up here so a
+  # torn-down run leaves nothing behind on the shared host.
+  provisioner "local-exec" {
+    when       = destroy
+    on_failure = continue
+    command    = "rm -f '${self.triggers.report_path}'"
+  }
+}

--- a/tf/prebuilt/spot-rebalancing-kind/main.tf
+++ b/tf/prebuilt/spot-rebalancing-kind/main.tf
@@ -8,16 +8,20 @@ terraform {
       source  = "hashicorp/null"
       version = ">= 3.0.0"
     }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0.0"
+    }
   }
 }
 
 provider "kind" {}
 
 locals {
-  # Host-side artifact on the shared bastion. setup.sh overwrites it, so a fixed
-  # path would let one run clobber a concurrent run's report. cluster_name is
-  # run-token-prefixed, making it per-run unique. The task prompt references the
-  # same path via the {{CLUSTER_NAME}} placeholder. An explicit override wins.
+  # Host-side artifact on the shared bastion. cluster_name is run-token-prefixed,
+  # making it per-run unique so concurrent runs never collide. The task prompt
+  # references the same path via the {{CLUSTER_NAME}} placeholder. An explicit
+  # override wins.
   report_path = var.report_path != "" ? var.report_path : "~/rightsizing-report-${var.cluster_name}.json"
 }
 
@@ -49,12 +53,20 @@ resource "kind_cluster" "default" {
   }
 }
 
-# Outside-the-cluster setup: label/taint the pools, deploy the fleet, deliver the
-# rightsizing report. Runs during `tofu apply`, before the agent starts.
+# Deliver the rightsizing (VPA) report declaratively. Managed by TF, so it is
+# removed automatically on `tofu destroy` — no teardown shell needed.
+resource "local_file" "rightsizing_report" {
+  filename = pathexpand(local.report_path)
+  content  = file("${path.module}/manifests/rightsizing-report.json")
+}
+
+# Outside-the-cluster setup: label/taint the node pools and deploy the fleet. The
+# node taints/labels need kubectl (the kind provider can't express per-node taints
+# declaratively); the fleet apply + readiness wait round it out. Runs during
+# `tofu apply`, before the agent starts.
 resource "null_resource" "setup" {
   triggers = {
-    cluster     = kind_cluster.default.name
-    report_path = pathexpand(local.report_path)
+    cluster = kind_cluster.default.name
   }
 
   provisioner "local-exec" {
@@ -62,17 +74,7 @@ resource "null_resource" "setup" {
     command     = "${path.module}/scripts/setup.sh"
     environment = {
       KUBECONFIG    = pathexpand(var.kubeconfig_path)
-      REPORT_PATH   = pathexpand(local.report_path)
       MANIFESTS_DIR = "${path.module}/manifests"
     }
-  }
-
-  # Remove the host-side report on teardown. The kind cluster is destroyed by its
-  # own resource; the report lives outside the cluster, so clean it up here so a
-  # torn-down run leaves nothing behind on the shared host.
-  provisioner "local-exec" {
-    when       = destroy
-    on_failure = continue
-    command    = "rm -f '${self.triggers.report_path}'"
   }
 }

--- a/tf/prebuilt/spot-rebalancing-kind/manifests/rightsizing-report.json
+++ b/tf/prebuilt/spot-rebalancing-kind/manifests/rightsizing-report.json
@@ -1,0 +1,31 @@
+{
+  "generated_by": "VPA recommender (p95 over trailing 14 days)",
+  "namespace": "apps",
+  "currency": "USD",
+  "pricing": {
+    "on_demand_vcpu_hour": 0.0335,
+    "on_demand_gib_hour": 0.0045,
+    "spot_discount_fraction": 0.70,
+    "note": "Spot capacity is billed at roughly 30% of the on-demand rate (a ~70% discount)."
+  },
+  "recommendations": [
+    {
+      "workload": "payments-api",
+      "current_requests": { "cpu": "500m", "memory": "512Mi" },
+      "recommended_requests": { "cpu": "150m", "memory": "192Mi" },
+      "rationale": "Observed p95 utilization is well below requests; over-provisioned."
+    },
+    {
+      "workload": "image-resizer",
+      "current_requests": { "cpu": "500m", "memory": "256Mi" },
+      "recommended_requests": { "cpu": "100m", "memory": "128Mi" },
+      "rationale": "Bursty but low steady-state usage; over-provisioned."
+    },
+    {
+      "workload": "report-builder",
+      "current_requests": { "cpu": "1000m", "memory": "1Gi" },
+      "recommended_requests": { "cpu": "200m", "memory": "256Mi" },
+      "rationale": "Heavily over-provisioned; p95 usage is a fraction of requests."
+    }
+  ]
+}

--- a/tf/prebuilt/spot-rebalancing-kind/manifests/workloads/workloads.yaml
+++ b/tf/prebuilt/spot-rebalancing-kind/manifests/workloads/workloads.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     purpose: cost-optimization
 ---
-# CRITICAL / stateful — must stay on on-demand capacity (cannot tolerate Spot
-# preemption). Also over-provisioned: requests far exceed the rightsizing
-# report's recommendation.
+# CRITICAL / stateful — cannot tolerate Spot preemption, must stay on on-demand
+# capacity. Also over-provisioned: requests far exceed the rightsizing report's
+# recommendation.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -16,8 +16,6 @@ metadata:
   labels:
     app: payments-api
     workload-tier: critical
-  annotations:
-    fault-tolerant: "false"
 spec:
   replicas: 2
   selector:
@@ -53,7 +51,7 @@ spec:
     matchLabels:
       app: payments-api
 ---
-# CRITICAL / stateful — session data store, must stay on-demand.
+# CRITICAL / stateful — session data store, must stay on on-demand.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -62,8 +60,6 @@ metadata:
   labels:
     app: session-store
     workload-tier: critical
-  annotations:
-    fault-tolerant: "false"
 spec:
   replicas: 1
   selector:
@@ -88,7 +84,7 @@ spec:
               cpu: "250m"
               memory: "512Mi"
 ---
-# FAULT-TOLERANT / batch — Spot-eligible. Also over-provisioned.
+# BATCH — fault-tolerant, safe to run on Spot. Also over-provisioned.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -97,8 +93,6 @@ metadata:
   labels:
     app: image-resizer
     workload-tier: batch
-  annotations:
-    fault-tolerant: "true"
 spec:
   replicas: 3
   selector:
@@ -134,7 +128,7 @@ spec:
     matchLabels:
       app: image-resizer
 ---
-# FAULT-TOLERANT / batch — Spot-eligible. Heavily over-provisioned.
+# BATCH — fault-tolerant, safe to run on Spot. Heavily over-provisioned.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -143,8 +137,6 @@ metadata:
   labels:
     app: report-builder
     workload-tier: batch
-  annotations:
-    fault-tolerant: "true"
 spec:
   replicas: 2
   selector:
@@ -180,7 +172,7 @@ spec:
     matchLabels:
       app: report-builder
 ---
-# FAULT-TOLERANT / batch — Spot-eligible. Already right-sized (not in the report).
+# BATCH — fault-tolerant, safe to run on Spot. Already right-sized (not in the report).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -189,8 +181,6 @@ metadata:
   labels:
     app: log-shipper
     workload-tier: batch
-  annotations:
-    fault-tolerant: "true"
 spec:
   replicas: 2
   selector:

--- a/tf/prebuilt/spot-rebalancing-kind/manifests/workloads/workloads.yaml
+++ b/tf/prebuilt/spot-rebalancing-kind/manifests/workloads/workloads.yaml
@@ -40,17 +40,6 @@ spec:
               cpu: "1"
               memory: "1Gi"
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: payments-api
-  namespace: apps
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: payments-api
----
 # CRITICAL / stateful — session data store, must stay on on-demand.
 apiVersion: apps/v1
 kind: Deployment
@@ -117,17 +106,6 @@ spec:
               cpu: "1"
               memory: "512Mi"
 ---
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: image-resizer
-  namespace: apps
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: image-resizer
----
 # BATCH — fault-tolerant, safe to run on Spot. Heavily over-provisioned.
 apiVersion: apps/v1
 kind: Deployment
@@ -160,17 +138,6 @@ spec:
             limits:
               cpu: "2"
               memory: "2Gi"
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: report-builder
-  namespace: apps
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: report-builder
 ---
 # BATCH — fault-tolerant, safe to run on Spot. Already right-sized (not in the report).
 apiVersion: apps/v1

--- a/tf/prebuilt/spot-rebalancing-kind/manifests/workloads/workloads.yaml
+++ b/tf/prebuilt/spot-rebalancing-kind/manifests/workloads/workloads.yaml
@@ -1,0 +1,216 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apps
+  labels:
+    purpose: cost-optimization
+---
+# CRITICAL / stateful — must stay on on-demand capacity (cannot tolerate Spot
+# preemption). Also over-provisioned: requests far exceed the rightsizing
+# report's recommendation.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments-api
+  namespace: apps
+  labels:
+    app: payments-api
+    workload-tier: critical
+  annotations:
+    fault-tolerant: "false"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payments-api
+  template:
+    metadata:
+      labels:
+        app: payments-api
+        workload-tier: critical
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27.4
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: payments-api
+  namespace: apps
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: payments-api
+---
+# CRITICAL / stateful — session data store, must stay on-demand.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: session-store
+  namespace: apps
+  labels:
+    app: session-store
+    workload-tier: critical
+  annotations:
+    fault-tolerant: "false"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: session-store
+  template:
+    metadata:
+      labels:
+        app: session-store
+        workload-tier: critical
+    spec:
+      containers:
+        - name: redis
+          image: redis:7
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "250m"
+              memory: "512Mi"
+---
+# FAULT-TOLERANT / batch — Spot-eligible. Also over-provisioned.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-resizer
+  namespace: apps
+  labels:
+    app: image-resizer
+    workload-tier: batch
+  annotations:
+    fault-tolerant: "true"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: image-resizer
+  template:
+    metadata:
+      labels:
+        app: image-resizer
+        workload-tier: batch
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27.4
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "512Mi"
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: image-resizer
+  namespace: apps
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: image-resizer
+---
+# FAULT-TOLERANT / batch — Spot-eligible. Heavily over-provisioned.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: report-builder
+  namespace: apps
+  labels:
+    app: report-builder
+    workload-tier: batch
+  annotations:
+    fault-tolerant: "true"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: report-builder
+  template:
+    metadata:
+      labels:
+        app: report-builder
+        workload-tier: batch
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27.4
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: "1"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: report-builder
+  namespace: apps
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: report-builder
+---
+# FAULT-TOLERANT / batch — Spot-eligible. Already right-sized (not in the report).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: log-shipper
+  namespace: apps
+  labels:
+    app: log-shipper
+    workload-tier: batch
+  annotations:
+    fault-tolerant: "true"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: log-shipper
+  template:
+    metadata:
+      labels:
+        app: log-shipper
+        workload-tier: batch
+    spec:
+      containers:
+        - name: app
+          image: httpd:2.4
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "250m"
+              memory: "256Mi"

--- a/tf/prebuilt/spot-rebalancing-kind/outputs.tf
+++ b/tf/prebuilt/spot-rebalancing-kind/outputs.tf
@@ -1,0 +1,8 @@
+output "cluster_name" {
+  value = kind_cluster.default.name
+}
+
+# "local" tells the TF deployer this is a kind cluster (skip gcloud get-credentials).
+output "cluster_location" {
+  value = "local"
+}

--- a/tf/prebuilt/spot-rebalancing-kind/scripts/setup.sh
+++ b/tf/prebuilt/spot-rebalancing-kind/scripts/setup.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Setup for the spot-rebalancing task. Runs from OUTSIDE the cluster during
+# `tofu apply`, before the agent starts:
+#   1. designates node pools on the multi-node kind cluster: one worker stays
+#      "on-demand" (untainted); the rest become "spot" — labeled
+#      'cloud.google.com/gke-spot=true' (the real GKE Spot label) and tainted
+#      'cloud.google.com/gke-spot=true:NoSchedule' so only Spot-tolerant pods
+#      land there, mirroring a reserved Spot node pool,
+#   2. deploys the workload fleet (a mix of critical/stateful and
+#      fault-tolerant/batch services). Because the Spot nodes are tainted and no
+#      workload tolerates them yet, everything starts on the on-demand node — the
+#      costly "before" state the agent must optimize,
+#   3. waits for the fleet to become Available so the agent starts healthy,
+#   4. delivers the rightsizing (VPA) report to a per-run file the agent ingests.
+#
+# Nothing here tells the agent which workloads to move — it must read each
+# workload's metadata (labels/annotations) and the report and decide itself.
+set -euo pipefail
+
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+REPORT_PATH="${REPORT_PATH:?REPORT_PATH is required}"
+REPORT_PATH="${REPORT_PATH/#\~/$HOME}"
+MANIFESTS_DIR="${MANIFESTS_DIR:?MANIFESTS_DIR is required}"
+MANIFESTS_DIR="$(cd "${MANIFESTS_DIR}" && pwd)"
+
+echo "==> Designating node pools (spot nodes tainted + labeled)..."
+# Worker nodes only (control-plane is tainted by kind on multi-node clusters).
+mapfile -t WORKERS < <(
+  kubectl get nodes -l '!node-role.kubernetes.io/control-plane' \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort
+)
+if [ "${#WORKERS[@]}" -lt 2 ]; then
+  echo "ERROR: expected >=2 worker nodes, found ${#WORKERS[@]}" >&2
+  exit 1
+fi
+ON_DEMAND="${WORKERS[0]}"
+SPOT_NODES=("${WORKERS[@]:1}")
+
+kubectl label node "${ON_DEMAND}" \
+  cloud.google.com/gke-nodepool=on-demand-pool node-tier=on-demand --overwrite
+
+# Give the Spot nodes distinct mock instance families so a careful plan can
+# spread replicas across them to reduce the blast radius of a simultaneous
+# preemption.
+families=(c3 n2 e2)
+idx=0
+for n in "${SPOT_NODES[@]}"; do
+  kubectl label node "${n}" \
+    cloud.google.com/gke-spot=true \
+    cloud.google.com/gke-nodepool=spot-pool \
+    spot-instance-family="${families[$((idx % ${#families[@]}))]}" --overwrite
+  kubectl taint node "${n}" cloud.google.com/gke-spot=true:NoSchedule --overwrite
+  idx=$((idx + 1))
+done
+echo "    on-demand: ${ON_DEMAND}"
+echo "    spot:      ${SPOT_NODES[*]}"
+
+echo "==> Deploying the workload fleet (starts entirely on on-demand)..."
+kubectl apply -f "${MANIFESTS_DIR}/workloads/"
+
+echo "==> Waiting for the fleet to become Available..."
+# Start the agent from a healthy fleet so any downtime during rebalancing is the
+# agent's doing, not a flaky fixture.
+kubectl -n apps wait --for=condition=Available deploy --all --timeout=300s
+
+echo "==> Delivering the rightsizing report to ${REPORT_PATH}..."
+mkdir -p "$(dirname "${REPORT_PATH}")"
+cp "${MANIFESTS_DIR}/rightsizing-report.json" "${REPORT_PATH}"
+
+echo "==> Setup complete."
+echo "    Rightsizing report: ${REPORT_PATH}"
+echo "    Inspect placement:  kubectl -n apps get pods -o wide"
+echo "    Node pools:         kubectl get nodes -L cloud.google.com/gke-spot,cloud.google.com/gke-nodepool"

--- a/tf/prebuilt/spot-rebalancing-kind/scripts/setup.sh
+++ b/tf/prebuilt/spot-rebalancing-kind/scripts/setup.sh
@@ -11,16 +11,17 @@
 #      fault-tolerant/batch services). Because the Spot nodes are tainted and no
 #      workload tolerates them yet, everything starts on the on-demand node — the
 #      costly "before" state the agent must optimize,
-#   3. waits for the fleet to become Available so the agent starts healthy,
-#   4. delivers the rightsizing (VPA) report to a per-run file the agent ingests.
+#   3. waits for the fleet to become Available so the agent starts healthy.
+#
+# The node taints/labels need kubectl (the kind provider can't express per-node
+# taints declaratively); the rightsizing report is delivered declaratively by a
+# local_file resource in main.tf, not here.
 #
 # Nothing here tells the agent which workloads to move — it must read each
 # workload's metadata (labels/annotations) and the report and decide itself.
 set -euo pipefail
 
 export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-REPORT_PATH="${REPORT_PATH:?REPORT_PATH is required}"
-REPORT_PATH="${REPORT_PATH/#\~/$HOME}"
 MANIFESTS_DIR="${MANIFESTS_DIR:?MANIFESTS_DIR is required}"
 MANIFESTS_DIR="$(cd "${MANIFESTS_DIR}" && pwd)"
 
@@ -64,11 +65,6 @@ echo "==> Waiting for the fleet to become Available..."
 # agent's doing, not a flaky fixture.
 kubectl -n apps wait --for=condition=Available deploy --all --timeout=300s
 
-echo "==> Delivering the rightsizing report to ${REPORT_PATH}..."
-mkdir -p "$(dirname "${REPORT_PATH}")"
-cp "${MANIFESTS_DIR}/rightsizing-report.json" "${REPORT_PATH}"
-
 echo "==> Setup complete."
-echo "    Rightsizing report: ${REPORT_PATH}"
 echo "    Inspect placement:  kubectl -n apps get pods -o wide"
 echo "    Node pools:         kubectl get nodes -L cloud.google.com/gke-spot,cloud.google.com/gke-nodepool"

--- a/tf/prebuilt/spot-rebalancing-kind/variables.tf
+++ b/tf/prebuilt/spot-rebalancing-kind/variables.tf
@@ -1,0 +1,29 @@
+variable "cluster_name" {
+  type        = string
+  description = "Name of the kind cluster."
+  default     = "devops-bench-kind"
+}
+
+variable "location" {
+  type        = string
+  description = "Always 'local' for kind; kept for deployer compatibility."
+  default     = "local"
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  description = "Path kind writes the kubeconfig to (read by the agent)."
+  default     = "~/.kube/config"
+}
+
+variable "node_image" {
+  type        = string
+  description = "Pinned kindest/node image (v1.30.x)."
+  default     = "kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e"
+}
+
+variable "report_path" {
+  type        = string
+  description = "Local file the rightsizing (VPA) report is delivered to (read by the agent). Empty (default) derives a per-run-unique path from cluster_name so concurrent runs don't clobber each other's report (see locals)."
+  default     = ""
+}


### PR DESCRIPTION
 Adds a new complex benchmark task: cut cluster compute cost without sacrificing reliability — classify workloads by criticality,
  migrate the fault-tolerant ones onto cheaper Spot capacity, rightsize over-provisioned services, and keep everything available
  — then report the savings.

  `task_id: 22` · `tasks/common/spot-rebalancing` · stack `tf/prebuilt/spot-rebalancing-kind` · **multi-node kind** (no GKE
  quota).

  ## What it tests

  A mixed-criticality fleet runs entirely on on-demand capacity (the costly "before" state). The agent must discover which
  workloads are safe to move from their own metadata, migrate them to a reserved Spot pool, rightsize the over-provisioned ones
  per a delivered rightsizing report, and keep services available — nothing in the prompt names the workloads, and the fix
  (tolerations/affinity/rightsizing) is never named.

  The fixture is a 4-node kind cluster (1 control-plane + 1 on-demand worker + 2 Spot workers). `setup.sh` labels/taints the Spot
  pool with the **real GKE Spot label** (`cloud.google.com/gke-spot=true` + `:NoSchedule`), so the agent's actions — Spot
  toleration + node affinity — are exactly what they'd be on GKE.

  | Workload (ns `apps`) | Tier | Spot-eligible? | Over-provisioned? |
  |---|---|---|---|
  | payments-api | critical | No — keep on-demand | Yes |
  | session-store | critical | No — keep on-demand | No |
  | image-resizer | batch | **Yes — move to Spot** | Yes |
  | report-builder | batch | **Yes — move to Spot** | Yes |
  | log-shipper | batch | **Yes — move to Spot** | No |

  Criticality is encoded only in a `workload-tier` label that the agent must map to a Spot policy itself (batch/fault-tolerant
  tolerate preemption; critical/stateful do not). Moving a workload to Spot needs **both** a toleration (for the taint) and a node
  selector/affinity (for the label) — a toleration alone leaves it on on-demand. Fault-tolerant workloads carry
  PodDisruptionBudgets so "without downtime" is a real constraint.

  ## Parallel-safe

  Kind cluster name + `KUBECONFIG` + `TF_DATA_DIR` from `RunEnv`; the rightsizing-report host path derives from
  `{{CLUSTER_NAME}}`; a `when = destroy` provisioner removes it; node labels/taints live on the per-run cluster. No GCP-global
  resources (kind-only). `task_id` unique. The 4-node footprint is within cp-recovery's proven matrix envelope.

  ## Validated

  Green run on the bastion (isolated 4-node kind, gemini-3.1-pro-preview, oc+mcp+skills, Vertex): `exit=0`, **ChecklistScore 0.83
  (mean 0.93)**. Spot migration (toleration + nodeSelector), actual Spot-node placement, rightsizing, and availability all scored
  1.0; classification scored 0.90 (inferred from the `workload-tier` label) and the report 0.70. Teardown verified clean.
  `validated: true`.

  Reviewed via `task-review` (dropped an on-the-nose `fault-tolerant` annotation that named the classification answer;
  re-validated) and `devops-bench-review` (parallel-safety / conventions — clean). `tofu validate`/`fmt` clean.

  ## Not modeling

  SOT step 4 (real-time Spot preemption handling within the 30s grace window) is intentionally not scored — it can't be triggered
  deterministically on any substrate. Spot-readiness (tolerations/affinity + replica spread + PDBs) captures the intent.