### PR TITLE
Unify agent model/provider config consumption across harnesses (#147)

### DIFF
--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -226,14 +226,10 @@ class GeminiCliAgent(AgentHarness):
         with tempfile.TemporaryDirectory(prefix="gemini-run-") as tmpdir:
             workdir = Path(tmpdir)
             if rules_text:
-                (workdir / _GEMINI_RULES_FILE).write_text(
-                    rules_text, encoding="utf-8"
-                )
+                (workdir / _GEMINI_RULES_FILE).write_text(rules_text, encoding="utf-8")
 
             gemini_dir = workdir / _GEMINI_CONFIG_DIR
-            skill_names = materialize_skills(
-                gemini_dir / _GEMINI_SKILLS_DIR, caps.skills.paths
-            )
+            skill_names = materialize_skills(gemini_dir / _GEMINI_SKILLS_DIR, caps.skills.paths)
             settings = _build_settings(caps.mcp_servers, skills_enabled=bool(skill_names))
             if settings:
                 gemini_dir.mkdir(parents=True, exist_ok=True)

--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -154,6 +154,9 @@ def _build_env(config: AgentConfig) -> dict[str, str]:
     Raises:
         ConfigError: If ``config.provider`` is not a known provider.
     """
+    # Resolve unconditionally so an unknown provider fails loud even on a keyless
+    # (Vertex/ADC) run, not only when a key happens to be set.
+    spec = resolve_provider(config.provider)
     overlay: dict[str, str] = {
         # Disable the Gemini CLI's OTLP exporters; otherwise they block/hang
         # trying to reach an unreachable collector endpoint in headless runs.
@@ -163,7 +166,7 @@ def _build_env(config: AgentConfig) -> dict[str, str]:
         "OTEL_SDK_DISABLED": "true",
     }
     if config.api_key:
-        for var in resolve_provider(config.provider).api_key_envs:
+        for var in spec.api_key_envs:
             overlay[var] = config.api_key
     if config.model:
         overlay["GEMINI_MODEL"] = config.model

--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -48,6 +48,7 @@ from devops_bench.agents.shared.cli_capabilities import (
     materialize_skills,
 )
 from devops_bench.core import SubprocessError, get_logger
+from devops_bench.core.model_providers import resolve_provider
 from devops_bench.core.subprocess import run
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
@@ -136,15 +137,22 @@ def _build_env(config: AgentConfig) -> dict[str, str]:
     """Build the env overlay that makes the Gemini CLI run model-agnostic.
 
     Maps the benchmark's neutral ``AGENT_*`` fields onto the variables the
-    Gemini CLI expects (``GOOGLE_API_KEY``/``GEMINI_API_KEY``/``GEMINI_MODEL``)
-    and disables OTLP telemetry exporters that otherwise hang on broken
-    endpoints. The model is never hardcoded; it flows from ``config.model``.
+    Gemini CLI expects: ``config.api_key`` is routed onto the provider's API-key
+    env var(s) via the shared contract
+    (:func:`~devops_bench.core.model_providers.resolve_provider`), and
+    ``config.model`` onto ``GEMINI_MODEL``. OTLP telemetry exporters are disabled
+    so they don't hang on broken endpoints. The model is never hardcoded; it
+    flows from ``config.model``. A keyless backend (e.g. Vertex/ADC) writes no
+    key.
 
     Args:
         config: Resolved :class:`AgentConfig` for this run.
 
     Returns:
         A mapping suitable for ``core.subprocess.run``'s ``extra_env``.
+
+    Raises:
+        ConfigError: If ``config.provider`` is not a known provider.
     """
     overlay: dict[str, str] = {
         # Disable the Gemini CLI's OTLP exporters; otherwise they block/hang
@@ -155,8 +163,8 @@ def _build_env(config: AgentConfig) -> dict[str, str]:
         "OTEL_SDK_DISABLED": "true",
     }
     if config.api_key:
-        overlay["GOOGLE_API_KEY"] = config.api_key
-        overlay["GEMINI_API_KEY"] = config.api_key
+        for var in resolve_provider(config.provider).api_key_envs:
+            overlay[var] = config.api_key
     if config.model:
         overlay["GEMINI_MODEL"] = config.model
     if config.extra_env:

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -73,6 +73,8 @@ from devops_bench.agents.shared.cli_capabilities import (
     materialize_skills,
 )
 from devops_bench.core import SubprocessError, get_logger
+from devops_bench.core.errors import ConfigError
+from devops_bench.core.model_providers import resolve_provider
 from devops_bench.core.subprocess import run
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
@@ -91,6 +93,7 @@ _OPENCLAW_CONFIG_FILE = "openclaw.json"
 
 # Bare model ids (the part after ``provider/``) absent from openclaw's built-in
 # catalog; the harness registers these per-run (see :func:`_build_model_override`).
+# TODO(deferred): supported-model-name maintenance is tracked separately (#147).
 _CATALOG_OVERRIDES: frozenset[str] = frozenset({"gemini-3.5-flash"})
 
 # Transport each per-run provider entry must pin: such an entry *replaces* oc's
@@ -112,11 +115,15 @@ def _oc_model_id(config: AgentConfig) -> str:
     """Resolve the canonical ``provider/model`` id ``oc agent --model`` expects.
 
     Returns ``""`` when no model is configured (oc's stored default is left
-    untouched). A model id already containing ``/`` passes through; otherwise
-    ``config.provider`` is prefixed (defaulting to ``google``, with ``gemini``
-    normalized to ``google``).
+    untouched). The provider is normalized through the shared contract
+    (:func:`~devops_bench.core.model_providers.resolve_provider`) so the openclaw
+    id matches the rest of the pipeline (e.g. ``gemini`` → ``google``). A full id
+    (``provider/model``) has its provider segment normalized too; an unknown wire
+    passes through unchanged for oc to validate.
 
     >>> _oc_model_id(AgentConfig(model="gemini-2.5-pro", provider="gemini"))
+    'google/gemini-2.5-pro'
+    >>> _oc_model_id(AgentConfig(model="gemini/gemini-2.5-pro"))
     'google/gemini-2.5-pro'
     >>> _oc_model_id(AgentConfig(model="anthropic/claude-opus-4"))
     'anthropic/claude-opus-4'
@@ -128,12 +135,14 @@ def _oc_model_id(config: AgentConfig) -> str:
     model = (config.model or "").strip()
     if not model:
         return ""
-    if "/" in model:  # already a full oc id
-        return model
-    provider = (config.provider or "google").strip().lower()
-    if provider == "gemini":
-        provider = "google"
-    return f"{provider}/{model}"
+    if "/" in model:  # already a full oc id; normalize the provider segment
+        wire, _, bare = model.partition("/")
+        try:
+            wire = resolve_provider(wire, default=wire).oc_provider
+        except ConfigError:
+            return model  # unknown wire: leave as-is, let oc validate
+        return f"{wire}/{bare}"
+    return f"{resolve_provider(config.provider).oc_provider}/{model}"
 
 
 def _build_model_override(config: AgentConfig) -> dict:
@@ -169,7 +178,17 @@ def _build_model_override(config: AgentConfig) -> dict:
     provider, _, bare = model_id.partition("/")
     if bare not in _CATALOG_OVERRIDES:
         return {}
-    provider_entry: dict = dict(_PROVIDER_TRANSPORT.get(provider, {}))
+    # A per-run provider entry *replaces* oc's built-in one, so it must pin a
+    # transport; without one oc falls back to the OpenAI transport and 401s. Fail
+    # loud rather than ship a broken (transport-less) entry for a provider we have
+    # not pinned.
+    if provider not in _PROVIDER_TRANSPORT:
+        raise ConfigError(
+            f"openclaw catalog override {model_id!r} has no pinned transport for "
+            f"provider {provider!r}; add it to _PROVIDER_TRANSPORT (known: "
+            f"{', '.join(sorted(_PROVIDER_TRANSPORT))})"
+        )
+    provider_entry: dict = dict(_PROVIDER_TRANSPORT[provider])
     provider_entry["models"] = [{"id": bare, "name": bare}]
     return {
         "models": {"providers": {provider: provider_entry}},
@@ -220,14 +239,15 @@ def _build_env(config: AgentConfig) -> dict[str, str]:
     variable(s) openclaw expects; the model itself is never hardcoded (it flows
     from ``config.model`` via ``oc agent --model``).
 
-    When ``config.api_key`` is unset the overlay carries no key at all — this is
-    the **Vertex / ADC** path: ``google-vertex`` resolves credentials from the
-    metadata-server Application Default Credentials at request time (the matrix
-    exports the ``GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials`` ADC marker that
-    tells oc's vertex transport to use ADC), so no key is threaded here. A
-    provided ``google-vertex`` key lands on ``GOOGLE_CLOUD_API_KEY`` rather than
-    ``GEMINI_API_KEY`` so it reaches the vertex transport, not the google-genai
-    one.
+    The key is routed onto the provider's API-key env var(s) from the shared
+    contract (:func:`~devops_bench.core.model_providers.resolve_provider`). When
+    ``config.api_key`` is unset the overlay carries no key — the **Vertex / ADC**
+    path: ``google-vertex`` resolves credentials from the metadata-server
+    Application Default Credentials at request time (the matrix exports the
+    ``GOOGLE_CLOUD_API_KEY=gcp-vertex-credentials`` ADC marker), and the contract
+    marks such backends keyless (empty ``api_key_envs``) so no key is ever forced
+    onto them. A provided ``google-vertex`` key lands on ``GOOGLE_CLOUD_API_KEY``
+    (the vertex transport), not ``GEMINI_API_KEY`` (google-genai).
 
     Args:
         config: Resolved :class:`AgentConfig` for this run.
@@ -235,21 +255,14 @@ def _build_env(config: AgentConfig) -> dict[str, str]:
     Returns:
         A mapping suitable for the subprocess environment overlay. The caller
         adds ``OPENCLAW_STATE_DIR`` / ``OPENCLAW_CONFIG_PATH`` on top.
+
+    Raises:
+        ConfigError: If ``config.provider`` is not a known provider.
     """
     overlay: dict[str, str] = {}
     if config.api_key:
-        provider = (config.provider or "google").strip().lower()
-        if provider in ("google", "gemini"):
-            overlay["GEMINI_API_KEY"] = config.api_key
-            overlay["GOOGLE_API_KEY"] = config.api_key
-        elif provider == "google-vertex":
-            overlay["GOOGLE_CLOUD_API_KEY"] = config.api_key
-        elif provider == "anthropic":
-            overlay["ANTHROPIC_API_KEY"] = config.api_key
-        elif provider == "openai":
-            overlay["OPENAI_API_KEY"] = config.api_key
-        else:
-            overlay["GEMINI_API_KEY"] = config.api_key
+        for var in resolve_provider(config.provider).api_key_envs:
+            overlay[var] = config.api_key
     if config.extra_env:
         overlay.update(config.extra_env)
     return overlay

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -259,9 +259,12 @@ def _build_env(config: AgentConfig) -> dict[str, str]:
     Raises:
         ConfigError: If ``config.provider`` is not a known provider.
     """
+    # Resolve unconditionally so an unknown provider fails loud even on a keyless
+    # (Vertex/ADC) run, not only when a key happens to be set.
+    spec = resolve_provider(config.provider)
     overlay: dict[str, str] = {}
     if config.api_key:
-        for var in resolve_provider(config.provider).api_key_envs:
+        for var in spec.api_key_envs:
             overlay[var] = config.api_key
     if config.extra_env:
         overlay.update(config.extra_env)

--- a/devops_bench/core/model_providers.py
+++ b/devops_bench/core/model_providers.py
@@ -46,8 +46,10 @@ class ProviderSpec(BaseModel):
             ``MODELS.get`` (e.g. ``gemini`` / ``claude`` / ``ollama``).
         oc_provider: openclaw wire-provider id used in ``provider/model`` and the
             per-run ``_PROVIDER_TRANSPORT`` lookup.
-        api_key_envs: Env var name(s) a CLI harness sets from ``config.api_key``;
-            empty for keyless backends (Vertex ADC, Bedrock, ollama).
+        api_key_envs: Env var name(s) a CLI harness sets from ``config.api_key``.
+            Empty for ``anthropic-vertex`` / ``anthropic-bedrock`` / ``ollama``
+            (no key is ever threaded). ``google-vertex`` is keyless-ok but still
+            routes a *provided* key to ``GOOGLE_CLOUD_API_KEY``.
         keyless_ok: Whether the backend can authenticate without a key (Vertex
             ADC, Bedrock AWS creds, local ollama).
         backend: Adapter backend hint (``"vertex"`` / ``"bedrock"``), or ``None``
@@ -67,8 +69,10 @@ class ProviderSpec(BaseModel):
 # Canonical provider id -> spec. Two axes are encoded here: ``adapter_family``
 # (``google`` and ``google-vertex`` both build the ``gemini`` adapter) and the
 # backend/transport/key-routing (which differ between them). Vertex and Bedrock
-# are keyless (ADC / AWS creds), so they carry no ``api_key_envs`` and must never
-# have an API key forced onto them.
+# are keyless-ok (ADC / AWS creds) and need no key; ``anthropic-vertex`` /
+# ``anthropic-bedrock`` / ``ollama`` carry empty ``api_key_envs`` so a key is
+# never forced onto them, while ``google-vertex`` still routes a provided key to
+# ``GOOGLE_CLOUD_API_KEY`` (the vertex transport var, not the google-genai one).
 _SPECS: dict[str, ProviderSpec] = {
     "google": ProviderSpec(
         canonical="google",
@@ -177,7 +181,6 @@ def resolve_provider(provider: str | None, *, default: str = "google") -> Provid
     canonical = _ALIASES.get(raw)
     if canonical is None:
         raise ConfigError(
-            f"unknown agent provider {provider!r}; known providers: "
-            f"{', '.join(known_providers())}"
+            f"unknown agent provider {provider!r}; known providers: {', '.join(known_providers())}"
         )
     return _SPECS[canonical]

--- a/devops_bench/core/model_providers.py
+++ b/devops_bench/core/model_providers.py
@@ -1,0 +1,183 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The single source of truth for agent model-provider config.
+
+Every harness consumes the same ``AGENT_PROVIDER`` / ``AGENT_MODEL`` /
+``AGENT_API_KEY`` contract through :func:`resolve_provider`, so a config that
+works for one harness behaves identically for the others. A raw provider alias
+resolves to a :class:`ProviderSpec` carrying both axes the harnesses need: the
+adapter family (which models-layer client to build) and the backend / transport
+/ key-routing details (which oc wire-provider, which API-key env var(s), and
+whether the backend authenticates without a key).
+
+Lives in ``core`` (not ``models``/``agents``) so both the models layer and the
+CLI harnesses import it without an import cycle and without pulling any provider
+SDK. Named ``model_providers`` to avoid confusion with
+:mod:`devops_bench.providers` (the cloud/infra OpenTofu providers).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from devops_bench.core.errors import ConfigError
+
+__all__ = ["ProviderSpec", "resolve_provider", "known_providers"]
+
+
+class ProviderSpec(BaseModel):
+    """Resolved config contract for one agent model provider.
+
+    Attributes:
+        canonical: Normalized provider id (the ``_SPECS`` key).
+        adapter_family: Models-layer adapter key for ``get_model`` /
+            ``MODELS.get`` (e.g. ``gemini`` / ``claude`` / ``ollama``).
+        oc_provider: openclaw wire-provider id used in ``provider/model`` and the
+            per-run ``_PROVIDER_TRANSPORT`` lookup.
+        api_key_envs: Env var name(s) a CLI harness sets from ``config.api_key``;
+            empty for keyless backends (Vertex ADC, Bedrock, ollama).
+        keyless_ok: Whether the backend can authenticate without a key (Vertex
+            ADC, Bedrock AWS creds, local ollama).
+        backend: Adapter backend hint (``"vertex"`` / ``"bedrock"``), or ``None``
+            to let the adapter infer the backend from the environment.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    canonical: str
+    adapter_family: str
+    oc_provider: str
+    api_key_envs: tuple[str, ...]
+    keyless_ok: bool
+    backend: str | None = None
+
+
+# Canonical provider id -> spec. Two axes are encoded here: ``adapter_family``
+# (``google`` and ``google-vertex`` both build the ``gemini`` adapter) and the
+# backend/transport/key-routing (which differ between them). Vertex and Bedrock
+# are keyless (ADC / AWS creds), so they carry no ``api_key_envs`` and must never
+# have an API key forced onto them.
+_SPECS: dict[str, ProviderSpec] = {
+    "google": ProviderSpec(
+        canonical="google",
+        adapter_family="gemini",
+        oc_provider="google",
+        api_key_envs=("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        keyless_ok=False,
+        backend=None,
+    ),
+    "google-vertex": ProviderSpec(
+        canonical="google-vertex",
+        adapter_family="gemini",
+        oc_provider="google-vertex",
+        api_key_envs=("GOOGLE_CLOUD_API_KEY",),
+        keyless_ok=True,
+        backend="vertex",
+    ),
+    "anthropic": ProviderSpec(
+        canonical="anthropic",
+        adapter_family="claude",
+        oc_provider="anthropic",
+        api_key_envs=("ANTHROPIC_API_KEY",),
+        keyless_ok=False,
+        backend=None,  # claude infers api/vertex/bedrock from the environment
+    ),
+    "anthropic-vertex": ProviderSpec(
+        canonical="anthropic-vertex",
+        adapter_family="claude",
+        oc_provider="anthropic-vertex",
+        api_key_envs=(),
+        keyless_ok=True,
+        backend="vertex",
+    ),
+    "anthropic-bedrock": ProviderSpec(
+        canonical="anthropic-bedrock",
+        adapter_family="claude",
+        oc_provider="anthropic-bedrock",
+        api_key_envs=(),
+        keyless_ok=True,
+        backend="bedrock",
+    ),
+    "openai": ProviderSpec(
+        canonical="openai",
+        adapter_family="openai",  # no adapter module today: get_model raises NotRegisteredError
+        oc_provider="openai",
+        api_key_envs=("OPENAI_API_KEY",),
+        keyless_ok=False,
+        backend=None,
+    ),
+    "ollama": ProviderSpec(
+        canonical="ollama",
+        adapter_family="ollama",
+        oc_provider="ollama",
+        api_key_envs=(),  # optional key handled by the adapter via AGENT_API_KEY
+        keyless_ok=True,
+        backend=None,
+    ),
+}
+
+# Raw alias (lowercased) -> canonical id. Company/runtime names and underscore
+# spellings map onto the canonical wire ids above.
+_ALIASES: dict[str, str] = {
+    "gemini": "google",
+    "google": "google",
+    "google-vertex": "google-vertex",
+    "google_vertex": "google-vertex",
+    "claude": "anthropic",
+    "anthropic": "anthropic",
+    "anthropic-vertex": "anthropic-vertex",
+    "anthropic_vertex": "anthropic-vertex",
+    "anthropic-bedrock": "anthropic-bedrock",
+    "anthropic_bedrock": "anthropic-bedrock",
+    "openai": "openai",
+    "ollama": "ollama",
+}
+
+
+def known_providers() -> tuple[str, ...]:
+    """Return the sorted raw provider aliases the contract accepts."""
+    return tuple(sorted(_ALIASES))
+
+
+def resolve_provider(provider: str | None, *, default: str = "google") -> ProviderSpec:
+    """Resolve a raw provider alias to its :class:`ProviderSpec`.
+
+    Matching is case-insensitive; a blank or unset value resolves to ``default``.
+
+    Args:
+        provider: Raw ``AGENT_PROVIDER`` value (or a per-call override). ``None``
+            or blank resolves to ``default``.
+        default: Alias used when ``provider`` is blank/unset.
+
+    Returns:
+        The :class:`ProviderSpec` for the resolved provider.
+
+    Raises:
+        ConfigError: If ``provider`` (or ``default``) is not a known alias.
+
+    Example:
+        >>> resolve_provider("gemini").canonical
+        'google'
+        >>> resolve_provider("google-vertex").backend
+        'vertex'
+    """
+    raw = (provider or "").strip().lower() or default.strip().lower()
+    canonical = _ALIASES.get(raw)
+    if canonical is None:
+        raise ConfigError(
+            f"unknown agent provider {provider!r}; known providers: "
+            f"{', '.join(known_providers())}"
+        )
+    return _SPECS[canonical]

--- a/devops_bench/models/base.py
+++ b/devops_bench/models/base.py
@@ -21,23 +21,12 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from devops_bench.core.config import get_env
+from devops_bench.core.model_providers import resolve_provider
 from devops_bench.core.registry import Registry
 
 __all__ = ["LLMClient", "MODELS", "get_model"]
 
 MODELS: Registry[type[LLMClient]] = Registry("models")
-
-# Adapter modules are named by model family (``gemini``, ``claude``) and
-# self-register under that canonical key via ``@MODELS.register``; ``ollama`` is
-# the runtime exception. Company/runtime names are accepted as aliases here.
-# ``google-vertex`` resolves to the gemini adapter, which selects Vertex AI at
-# runtime via ``GOOGLE_GENAI_USE_VERTEXAI`` rather than a distinct adapter.
-_ALIASES = {
-    "google": "gemini",
-    "google-vertex": "gemini",
-    "google_vertex": "gemini",
-    "anthropic": "claude",
-}
 
 
 class LLMClient(ABC):
@@ -107,11 +96,15 @@ def get_model(
     """Construct the LLM client for a provider.
 
     When ``provider`` is omitted it is read from the ``AGENT_PROVIDER``
-    environment variable, defaulting to ``"gemini"``.
+    environment variable, defaulting to ``"google"``. The provider is resolved
+    through the shared contract (:func:`devops_bench.core.model_providers.resolve_provider`),
+    which maps it to the adapter family and a backend hint forwarded to the
+    adapter — the same contract the CLI harnesses use.
 
     Args:
-        provider: Registry key such as ``"gemini"``/``"google"``/
-            ``"google-vertex"``, ``"claude"``/``"anthropic"``, or ``"ollama"``.
+        provider: Provider alias such as ``"gemini"``/``"google"``/
+            ``"google-vertex"``, ``"claude"``/``"anthropic"``/
+            ``"anthropic-vertex"``, ``"openai"``, or ``"ollama"``.
             Case-insensitive.
         model_name: Optional model override passed to the adapter; when omitted
             the adapter reads ``AGENT_MODEL`` (or its own default).
@@ -121,15 +114,18 @@ def get_model(
         An instantiated :class:`LLMClient` for the selected provider.
 
     Raises:
-        NotRegisteredError: If ``provider`` has no registered adapter.
+        ConfigError: If ``provider`` is not a known alias.
+        NotRegisteredError: If the resolved adapter family has no registered
+            adapter (e.g. ``openai``).
         MissingDependencyError: If the selected provider's SDK is not installed.
     """
-    key = (provider or get_env("AGENT_PROVIDER", "gemini")).lower()
-    key = _ALIASES.get(key, key)
-    # Import only the requested provider's adapter module so it self-registers.
-    # An unknown key has no module; leave it to surface as NotRegisteredError.
+    spec = resolve_provider(provider if provider is not None else get_env("AGENT_PROVIDER"))
+    key = spec.adapter_family
+    # Import only the resolved adapter family's module so it self-registers. An
+    # unregistered family (e.g. ``openai``) has no module; leave it to surface as
+    # NotRegisteredError from ``MODELS.get``.
     module = f"{__package__}.{key}"
     if importlib.util.find_spec(module) is not None:
         importlib.import_module(module)
     adapter_cls = MODELS.get(key)
-    return adapter_cls(model_name=model_name, **kwargs)
+    return adapter_cls(model_name=model_name, backend=spec.backend, **kwargs)

--- a/devops_bench/models/claude.py
+++ b/devops_bench/models/claude.py
@@ -72,6 +72,9 @@ class ClaudeClientAdapter(LLMClient):
             backend-specific default when omitted.
         max_tokens: Per-response output token cap; falls back to
             ``AGENT_MAX_TOKENS`` and then a sane default when omitted.
+        backend: Backend hint from the provider contract (``"vertex"`` /
+            ``"bedrock"``); overrides env inference. ``None`` infers from the
+            environment (the bare ``anthropic`` provider).
 
     Raises:
         MissingDependencyError: If the ``anthropic`` SDK is not installed.
@@ -79,11 +82,21 @@ class ClaudeClientAdapter(LLMClient):
             backend is selected without ``AGENT_MODEL`` set.
     """
 
-    def __init__(self, model_name: str | None = None, max_tokens: int | None = None) -> None:
+    def __init__(
+        self,
+        model_name: str | None = None,
+        max_tokens: int | None = None,
+        *,
+        backend: str | None = None,
+    ) -> None:
         if AsyncAnthropic is None:
             raise MissingDependencyError("the Anthropic model adapter", "anthropic")
 
-        backend = self._select_backend()
+        # An explicit backend hint from the provider contract
+        # (``anthropic-vertex`` -> ``vertex``, ``anthropic-bedrock`` -> ``bedrock``)
+        # wins, decoupling Vertex/Bedrock auth from API-key presence; the bare
+        # ``anthropic`` provider passes ``None`` and still infers from the env.
+        backend = backend or self._select_backend()
 
         if not model_name:
             model_name = get_env("AGENT_MODEL", _DEFAULT_MODELS.get(backend))

--- a/devops_bench/models/gemini.py
+++ b/devops_bench/models/gemini.py
@@ -72,6 +72,7 @@ def _backoff_delay(attempt: int) -> float:
     ceiling = min(_MAX_DELAY_SEC, _BASE_DELAY_SEC * (2**attempt))
     return random.uniform(0.0, ceiling)
 
+
 _SUPPORTED_SCHEMA_FIELDS = frozenset(
     {
         "type",

--- a/devops_bench/models/gemini.py
+++ b/devops_bench/models/gemini.py
@@ -164,18 +164,21 @@ def filter_schema_for_gemini(schema: Any) -> Any:
 class GeminiClientAdapter(LLMClient):
     """Adapter for the Gemini SDK (google-genai).
 
-    Selects the client backend from the environment: an explicit
-    ``AGENT_API_KEY`` takes precedence, then Vertex via ``GCP_PROJECT_ID``,
-    otherwise the SDK's default credential resolution.
+    The backend is chosen from the ``backend`` hint and the environment:
+    ``backend="vertex"`` (the ``google-vertex`` provider) forces Vertex AI;
+    otherwise an explicit ``AGENT_API_KEY`` takes precedence, then Vertex via
+    ``GCP_PROJECT_ID``, otherwise the SDK's default credential resolution.
 
     Args:
         model_name: Model override; falls back to ``AGENT_MODEL`` when omitted.
+        backend: Backend hint from the provider contract; ``"vertex"`` forces
+            Vertex AI, ``None`` infers from the environment.
 
     Raises:
         MissingDependencyError: If the ``google-genai`` SDK is not installed.
     """
 
-    def __init__(self, model_name: str | None = None) -> None:
+    def __init__(self, model_name: str | None = None, *, backend: str | None = None) -> None:
         if genai is None:
             raise MissingDependencyError("the Gemini model adapter", "google-genai")
 
@@ -186,7 +189,12 @@ class GeminiClientAdapter(LLMClient):
         location = get_env("GCP_VERTEX_LOCATION", "global")
         api_key = get_env("AGENT_API_KEY")
 
-        if api_key:
+        # ``backend == "vertex"`` (the ``google-vertex`` provider) forces Vertex
+        # AI regardless of an API key, so the provider — not key presence —
+        # decides the backend. Otherwise infer as before.
+        if backend == "vertex":
+            self.client = genai.Client(vertexai=True, project=project_id, location=location)
+        elif api_key:
             self.client = genai.Client(api_key=api_key)
         elif project_id:
             self.client = genai.Client(vertexai=True, project=project_id, location=location)

--- a/devops_bench/models/ollama.py
+++ b/devops_bench/models/ollama.py
@@ -46,12 +46,20 @@ class OllamaClientAdapter(LLMClient):
         model_name: Model override; falls back to ``AGENT_MODEL`` when omitted.
         base_url: Endpoint override; falls back to ``OLLAMA_BASE_URL`` and then
             the local default when omitted.
+        backend: Accepted for a uniform adapter signature; ignored (Ollama has no
+            backend variants).
 
     Raises:
         MissingDependencyError: If the ``openai`` SDK is not installed.
     """
 
-    def __init__(self, model_name: str | None = None, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        model_name: str | None = None,
+        base_url: str | None = None,
+        *,
+        backend: str | None = None,
+    ) -> None:
         if AsyncOpenAI is None:
             raise MissingDependencyError("the Ollama model adapter", "openai")
 
@@ -60,8 +68,11 @@ class OllamaClientAdapter(LLMClient):
         if not base_url:
             base_url = get_env("OLLAMA_BASE_URL", _DEFAULT_BASE_URL)
 
-        # api_key is required by the openai client but unused by Ollama.
-        self.client = AsyncOpenAI(base_url=base_url, api_key="ollama")
+        # Ollama supports optional key-based auth (e.g. a remote/hosted endpoint);
+        # use ``AGENT_API_KEY`` when set, else a dummy the local server ignores
+        # (the openai client requires a non-empty key).
+        api_key = get_env("AGENT_API_KEY") or "ollama"
+        self.client = AsyncOpenAI(base_url=base_url, api_key=api_key)
         self.model_name = model_name
 
     async def generate_content(

--- a/docs/components/agents.md
+++ b/docs/components/agents.md
@@ -40,12 +40,14 @@ Three harnesses ship today. Each self-registers under a canonical key.
 A harness does **not** hardcode a model. It reads `AGENT_PROVIDER` and
 `AGENT_MODEL` from its config and maps them onto whatever it drives.
 
-Only the `api` harness talks to the models layer directly — it calls
-`get_model(provider, model)` and runs the tool-use loop in-process. The CLI
-harnesses (`gemini`, `openclaw`) pass the model and provider through to their
-binaries instead: the Gemini CLI gets `GEMINI_MODEL` in its environment, and
-openclaw gets a `--model provider/id` flag. Either way, the model is a runtime
-input, never baked into the harness.
+Every harness resolves `AGENT_PROVIDER` through one shared contract
+(`devops_bench/core/model_providers.py`), so the same `AGENT_*` config behaves
+identically across them. The `api` harness uses it to pick the adapter family and
+backend for `get_model(provider, model)` and runs the tool-use loop in-process.
+The CLI harnesses (`gemini`, `openclaw`) use it to route `AGENT_API_KEY` onto the
+binary's provider-specific env var(s) and pass the model through: the Gemini CLI
+gets `GEMINI_MODEL`, and openclaw gets a `--model provider/id` flag. Either way,
+the model is a runtime input, never baked into the harness.
 
 For everything about providers, model ids, and how `get_model` resolves them, see
 [Model providers](./model_providers.md).
@@ -67,7 +69,7 @@ each harness maps them onto its target.
 | --- | --- | --- |
 | `AGENT_MODEL` | unset | Model id; flows to the harness's target. |
 | `AGENT_PROVIDER` | unset | Provider key (e.g. `gemini`, `anthropic`, `google-vertex`). |
-| `AGENT_API_KEY` | unset | Mapped onto the provider-specific key var by the harness. |
+| `AGENT_API_KEY` | unset | Routed onto the provider's key env var(s) via the shared contract; omitted for keyless backends (Vertex/Bedrock ADC). |
 | `AGENT_TARGET` | unset | Path to the CLI binary (`gemini` / `oc`). Ignored by `api`. |
 | `AGENT_TIMEOUT_SEC` | `600` | Wall-clock budget for each external call. |
 | `AGENT_MAX_TURNS` | harness default (50 for `api`) | Caps the `api` tool-use loop. |

--- a/docs/components/model_providers.md
+++ b/docs/components/model_providers.md
@@ -104,8 +104,7 @@ final fallback.
 > `AGENT_API_KEY` onto the binary's provider-specific env var(s) (e.g. `google` →
 > `GEMINI_API_KEY` + `GOOGLE_API_KEY`, `google-vertex` → `GOOGLE_CLOUD_API_KEY`)
 > and, for openclaw, to pin the per-run model-catalog transport. A keyless
-> provider routes no key. (This unifies the former per-harness divergence,
-> [#147](https://github.com/gke-labs/devops-bench/issues/147).)
+> provider routes no key.
 
 ## Configuration examples
 

--- a/docs/components/model_providers.md
+++ b/docs/components/model_providers.md
@@ -40,9 +40,6 @@ Default models: `gemini` → `gemini-3.1-pro-preview`; `claude` → backend-spec
 
 A few things worth calling out:
 
-- **`google-vertex` is not a separate adapter.** It resolves to the `gemini`
-  adapter with a `vertex` backend hint, so the *provider key* — not key presence
-  — selects Vertex AI. There is no distinct Vertex module.
 - **Vertex and Bedrock are keyless.** `google-vertex`, `anthropic-vertex`, and
   `anthropic-bedrock` authenticate via ADC / AWS credentials; the contract never
   forces an API key onto them (their key-env list is empty). The bare

--- a/docs/components/model_providers.md
+++ b/docs/components/model_providers.md
@@ -16,22 +16,39 @@ change.
 
 ## Supported providers and models
 
-A provider key selects an adapter. Aliases are alternate spellings that resolve
-to the same adapter. Backends are the transports a single adapter can reach,
-chosen at runtime from the environment.
+Every harness — the `api` runner and the `gemini`/`openclaw` CLIs — resolves
+`AGENT_PROVIDER` through one shared contract
+(`devops_bench/core/model_providers.py`). A provider resolves to an *adapter
+family* (which `LLMClient` the `api` harness builds), a *backend* hint
+(genai/vertex/bedrock), the *openclaw wire-provider*, and the *API-key env
+var(s)* a CLI harness sets — so the same `AGENT_*` config behaves identically
+across harnesses.
 
-| Provider key | Aliases | Backends | Default model | SDK / install extra |
-| --- | --- | --- | --- | --- |
-| `gemini` | `google`, `google-vertex`, `google_vertex` | Google AI Studio API key, Vertex AI | `gemini-3.1-pro-preview` | `google-genai` |
-| `claude` | `anthropic` | Anthropic API, Vertex AI, Amazon Bedrock | backend-specific (`api` → `claude-sonnet-4-5`; Bedrock requires `AGENT_MODEL`) | `anthropic` |
-| `ollama` | — | local OpenAI-compatible server | `gemma4:2b` | `openai` |
+| Provider key | Aliases | Adapter family | Backend | Key env var(s) | Keyless |
+| --- | --- | --- | --- | --- | --- |
+| `google` | `gemini` | `gemini` | genai (API key) | `GEMINI_API_KEY`, `GOOGLE_API_KEY` | no |
+| `google-vertex` | `google_vertex` | `gemini` | Vertex AI | `GOOGLE_CLOUD_API_KEY` | yes (ADC) |
+| `anthropic` | `claude` | `claude` | inferred (api/vertex/bedrock) | `ANTHROPIC_API_KEY` | no |
+| `anthropic-vertex` | `anthropic_vertex` | `claude` | Vertex AI | — | yes (ADC) |
+| `anthropic-bedrock` | `anthropic_bedrock` | `claude` | Amazon Bedrock | — | yes (AWS creds) |
+| `openai` | — | `openai` | — | `OPENAI_API_KEY` | no |
+| `ollama` | — | `ollama` | local OpenAI-compatible server | optional `AGENT_API_KEY` | yes |
+
+Default models: `gemini` → `gemini-3.1-pro-preview`; `claude` → backend-specific
+(`api` → `claude-sonnet-4-5`; Bedrock requires `AGENT_MODEL`); `ollama` →
+`gemma4:2b`.
 
 A few things worth calling out:
 
-- **`google-vertex` is not a separate adapter.** It is an alias that resolves to
-  the `gemini` adapter, which then picks Vertex AI at runtime based on the
-  environment (a `GCP_PROJECT_ID` with no API key). There is no distinct Vertex
-  module.
+- **`google-vertex` is not a separate adapter.** It resolves to the `gemini`
+  adapter with a `vertex` backend hint, so the *provider key* — not key presence
+  — selects Vertex AI. There is no distinct Vertex module.
+- **Vertex and Bedrock are keyless.** `google-vertex`, `anthropic-vertex`, and
+  `anthropic-bedrock` authenticate via ADC / AWS credentials; the contract never
+  forces an API key onto them (their key-env list is empty). The bare
+  `anthropic` provider still infers its backend from the environment.
+- **Ollama accepts an optional key.** It defaults to a dummy the local server
+  ignores, but uses `AGENT_API_KEY` when set (for remote/hosted endpoints).
 - **Install extras are named by PyPI package, not by provider key.** The extras
   are `google-genai`, `anthropic`, `openai`, and `all` — a different axis from
   the provider keys above. The most surprising consequence: the `openai` extra
@@ -55,33 +72,40 @@ There are three roles, and each reads its own environment variables.
 | Judge | `JUDGE_PROVIDER` | `JUDGE_MODEL` | Also settable via the `--judge-provider` / `--judge-model` CLI flags. |
 | Chaos agent | `CHAOS_PROVIDER` | `CHAOS_MODEL` | Falls back to `AGENT_PROVIDER` / `AGENT_MODEL` when unset. |
 
-When no provider is given anywhere, `get_model()` defaults to `gemini`.
+When no provider is given anywhere, the contract defaults to `google`.
 
-### Backend-selecting variables
+### Backend selection
 
-Within a provider, these variables choose the transport:
+The cleanest way to pick a backend is the **provider key** itself —
+`google-vertex`, `anthropic-vertex`, and `anthropic-bedrock` select Vertex AI /
+Bedrock deterministically, independent of which keys happen to be in the
+environment. These also flow consistently into the CLI harnesses.
+
+These variables still influence backend/transport details:
 
 | Variable | Effect |
 | --- | --- |
-| `GCP_PROJECT_ID` + `GCP_VERTEX_LOCATION` | Selects Vertex AI for both `gemini` and `claude`. `GCP_VERTEX_LOCATION` defaults to `global`. |
-| `ANTHROPIC_BACKEND` | Forces the Claude backend: `api`, `vertex`, or `bedrock`. Overrides the inference below. |
-| `AWS_REGION` / `AWS_DEFAULT_REGION` | Selects the Claude Bedrock backend. |
+| `GCP_PROJECT_ID` + `GCP_VERTEX_LOCATION` | Vertex project/region (`GCP_VERTEX_LOCATION` defaults to `global`). |
+| `ANTHROPIC_BACKEND` | Forces the Claude backend (`api`/`vertex`/`bedrock`) for the bare `anthropic` provider. |
+| `AWS_REGION` / `AWS_DEFAULT_REGION` | Region for the Claude Bedrock backend. |
 | `OLLAMA_BASE_URL` | Endpoint for the Ollama server (defaults to `http://localhost:11434/v1`). |
 
-For Claude, if you don't force `ANTHROPIC_BACKEND`, the adapter infers a backend:
-an API key (`AGENT_API_KEY` / `ANTHROPIC_API_KEY`) selects `api`, then
-`GCP_PROJECT_ID` selects `vertex`, then an AWS region selects `bedrock`, with
-`vertex` as the final fallback.
+For the bare `anthropic` provider (no explicit `-vertex`/`-bedrock` key and no
+`ANTHROPIC_BACKEND`), the adapter still infers a backend: an API key
+(`AGENT_API_KEY` / `ANTHROPIC_API_KEY`) selects `api`, then `GCP_PROJECT_ID`
+selects `vertex`, then an AWS region selects `bedrock`, with `vertex` as the
+final fallback.
 
 > [!NOTE]
-> When the agent harness is a CLI (the `gemini` or `openclaw` agents),
-> `AGENT_PROVIDER` / `AGENT_MODEL` / `AGENT_API_KEY` are mapped onto that CLI's
-> own environment variables instead of going through `get_model()`. For example,
-> the gemini CLI agent receives `GEMINI_MODEL`, `GOOGLE_API_KEY`, and
-> `GEMINI_API_KEY`. Only the `api` harness calls `get_model()` directly. This
-> per-harness divergence is a known inconsistency we plan to unify (tracked in
-> [#147](https://github.com/gke-labs/devops-bench/issues/147)). See
-> [agents.md](./agents.md) for how each harness consumes its config today.
+> **All harnesses share one provider contract.** The `api` runner and the
+> `gemini`/`openclaw` CLIs all resolve `AGENT_PROVIDER` through
+> `devops_bench/core/model_providers.py`. The `api` harness uses it to pick the
+> adapter family and backend for `get_model()`; the CLI harnesses use it to route
+> `AGENT_API_KEY` onto the binary's provider-specific env var(s) (e.g. `google` →
+> `GEMINI_API_KEY` + `GOOGLE_API_KEY`, `google-vertex` → `GOOGLE_CLOUD_API_KEY`)
+> and, for openclaw, to pin the per-run model-catalog transport. A keyless
+> provider routes no key. (This unifies the former per-harness divergence,
+> [#147](https://github.com/gke-labs/devops-bench/issues/147).)
 
 ## Configuration examples
 
@@ -114,14 +138,14 @@ export AGENT_MODEL=claude-sonnet-4-5
 export AGENT_API_KEY="$YOUR_ANTHROPIC_KEY"
 ```
 
-**Claude on Vertex AI:**
+**Claude on Vertex AI (no key — uses ADC + project):**
 
 ```bash
-export AGENT_PROVIDER=claude
-export ANTHROPIC_BACKEND=vertex
+export AGENT_PROVIDER=anthropic-vertex
 export AGENT_MODEL=claude-sonnet-4-5@20250929
 export GCP_PROJECT_ID=my-gcp-project
 export GCP_VERTEX_LOCATION=global
+# The provider key selects Vertex; no AGENT_API_KEY is needed or used.
 ```
 
 **Ollama (local server):**

--- a/docs/how-to/add-a-model-provider.md
+++ b/docs/how-to/add-a-model-provider.md
@@ -66,17 +66,29 @@ yourprovider-sdk = ["yourprovider-sdk>=1.0.0"]
 all = ["devops-bench[google-genai,anthropic,openai,yourprovider-sdk]"]
 ```
 
-### 4. (Optional) add an alias
+### 4. (Optional) register it in the provider contract
 
-If your provider is known by more than one name, map the alternates to your
-canonical key in `_ALIASES` in `devops_bench/models/base.py`:
+`AGENT_PROVIDER` resolves through the shared contract in
+`devops_bench/core/model_providers.py` — the one place every harness (the `api`
+runner and the `gemini`/`openclaw` CLIs) reads. If your provider needs aliases, a
+distinct backend, a non-default API-key env var, or keyless (ADC-style) auth, add
+a `ProviderSpec` row to `_SPECS` and its alias(es) to `_ALIASES` there:
 
 ```python
-_ALIASES = {
-    ...
-    "your-alt-name": "<key>",
-}
+_SPECS["your-key"] = ProviderSpec(
+    canonical="your-key",
+    adapter_family="<key>",          # the MODELS.get() key from step 1
+    oc_provider="your-key",          # openclaw wire-provider id
+    api_key_envs=("YOURPROVIDER_API_KEY",),  # () if keyless
+    keyless_ok=False,
+    backend=None,                    # or a backend hint your adapter reads
+)
+_ALIASES["your-alt-name"] = "your-key"
 ```
+
+A provider whose `adapter_family` maps to your new module's registered key works
+through `get_model()` automatically. An unknown provider raises `ConfigError`
+listing the known ones.
 
 ### 5. Nothing else to wire up
 

--- a/scripts/bastion/configure-oc.sh
+++ b/scripts/bastion/configure-oc.sh
@@ -45,6 +45,12 @@ GKE_MCP_BIN="${GKE_MCP_BIN:-${HOME}/gke-mcp}"
 SECRETS_ENV="${SECRETS_ENV:-${HOME}/secrets.env}"
 SKILLS_SRC="${SKILLS_SRC:-${HOME}/devops-bench/skills}"
 OC_SKILLS_DIR="${OC_SKILLS_DIR:-${HOME}/oc-skills}"
+# VERTEX_MODELS and GENAI_MODELS differ on purpose: oc ships NO built-in
+# google-vertex catalog, so every Vertex model must be registered; for google
+# (google-genai) oc already ships most ids, so only the ones it lacks need
+# listing (the legacy-arm analogue of the harness's _CATALOG_OVERRIDES). The
+# refactored arm self-registers per-run and ignores these lists entirely.
+# TODO(deferred): supported-model-name maintenance is tracked separately (#147).
 VERTEX_MODELS="${VERTEX_MODELS:-gemini-3.1-pro-preview gemini-3-flash-preview gemini-3.5-flash}"
 GENAI_MODELS="${GENAI_MODELS:-gemini-3.5-flash}"
 OPENCLAW_AGENT="${OPENCLAW_AGENT:-main}"

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -321,7 +321,12 @@ def test_parse_stream_json_real_cli_schema():
         {
             "type": "result",
             "status": "success",
-            "stats": {"total_tokens": 31489, "input_tokens": 31225, "output_tokens": 35, "cached": 12173},
+            "stats": {
+                "total_tokens": 31489,
+                "input_tokens": 31225,
+                "output_tokens": 35,
+                "cached": 12173,
+            },
         },
     )
     output, trajectory, tokens, errors = parse_stream_json(blob)
@@ -353,6 +358,7 @@ def test_parse_stream_json_marks_failed_tool_result_status_field():
 
 def test_run_does_not_invoke_subprocess_when_skipped(monkeypatch):
     """Sanity: parse_stream_json must not shell out (catches an import-time hazard)."""
+
     def boom(*_a, **_kw):
         raise AssertionError("parse_stream_json should not run subprocess")
 
@@ -362,6 +368,7 @@ def test_run_does_not_invoke_subprocess_when_skipped(monkeypatch):
 
 # Tests for the now-deleted legacy surface — these documents what is gone for
 # good and will fail-fast if the dead modules are ever reintroduced.
+
 
 def test_legacy_run_cli_agent_is_gone():
     assert not hasattr(gemini_mod, "run_cli_agent")
@@ -459,9 +466,7 @@ def test_execute_writes_gemini_md_with_rules_text_before_subprocess(monkeypatch)
         gemini_md = Path(cwd) / "GEMINI.md" if cwd else None
         captured["gemini_md_exists"] = bool(gemini_md and gemini_md.exists())
         captured["gemini_md_text"] = (
-            gemini_md.read_text(encoding="utf-8")
-            if captured["gemini_md_exists"]
-            else None
+            gemini_md.read_text(encoding="utf-8") if captured["gemini_md_exists"] else None
         )
         return SimpleNamespace(stdout="", stderr="", returncode=0)
 

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -164,6 +164,20 @@ def test_build_env_threads_api_key_and_model_into_gemini_vars():
     assert env["X"] == "y"
 
 
+def test_build_env_vertex_key_routes_to_cloud_api_key():
+    # google-vertex routes a provided key to GOOGLE_CLOUD_API_KEY (the vertex
+    # transport var), not the google-genai vars.
+    env = _build_env(AgentConfig(model="gemini-2.5-pro", api_key="abc", provider="google-vertex"))
+    assert env["GOOGLE_CLOUD_API_KEY"] == "abc"
+    assert "GEMINI_API_KEY" not in env and "GOOGLE_API_KEY" not in env
+
+
+def test_build_env_keyless_writes_no_key_var():
+    # No api_key (Vertex/ADC): no key env var is written regardless of provider.
+    env = _build_env(AgentConfig(model="gemini-2.5-pro", provider="google-vertex"))
+    assert not {"GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_CLOUD_API_KEY"} & env.keys()
+
+
 def test_gemini_agent_registered_under_canonical_key():
     assert AGENTS.get("gemini") is GeminiCliAgent
 

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -21,6 +21,8 @@ import os
 import subprocess
 from types import SimpleNamespace
 
+import pytest
+
 from devops_bench.agents import AGENTS, AgentConfig
 from devops_bench.agents.capabilities import (
     AgentRules,
@@ -38,7 +40,7 @@ from devops_bench.agents.cli.gemini_cli.agent import (
     _build_env,
     _build_settings,
 )
-from devops_bench.core.errors import SubprocessError
+from devops_bench.core.errors import ConfigError, SubprocessError
 
 
 def _stream(*events: dict) -> str:
@@ -176,6 +178,12 @@ def test_build_env_keyless_writes_no_key_var():
     # No api_key (Vertex/ADC): no key env var is written regardless of provider.
     env = _build_env(AgentConfig(model="gemini-2.5-pro", provider="google-vertex"))
     assert not {"GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_CLOUD_API_KEY"} & env.keys()
+
+
+def test_build_env_unknown_provider_raises_even_when_keyless():
+    # Validation is unconditional — a typoed provider fails loud on a keyless run.
+    with pytest.raises(ConfigError):
+        _build_env(AgentConfig(model="gemini-2.5-pro", provider="google-vertyx"))
 
 
 def test_gemini_agent_registered_under_canonical_key():

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -215,9 +215,7 @@ def test_oc_model_id_preserves_full_id():
 
 def test_oc_model_id_normalizes_full_id_provider_segment():
     # A full id whose wire is an alias is normalized through the contract.
-    assert _oc_model_id(AgentConfig(model="gemini/gemini-2.5-pro")) == (
-        "google/gemini-2.5-pro"
-    )
+    assert _oc_model_id(AgentConfig(model="gemini/gemini-2.5-pro")) == ("google/gemini-2.5-pro")
 
 
 def test_oc_model_id_passes_through_unknown_full_id_wire():

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -654,6 +654,13 @@ def test_build_env_unknown_provider_raises():
         _build_env(AgentConfig(api_key="k", provider="mystery"))
 
 
+def test_build_env_unknown_provider_raises_even_when_keyless():
+    """Validation is unconditional — a typoed provider fails loud on a keyless
+    (Vertex/ADC) run too, not only when a key is set."""
+    with pytest.raises(ConfigError):
+        _build_env(AgentConfig(provider="google-vertyx"))
+
+
 def test_model_override_raises_for_unpinned_transport():
     """A catalog-override model whose provider has no pinned transport fails loud
     rather than shipping a transport-less entry (which would 401 via the OpenAI

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -22,6 +22,8 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from devops_bench.agents import AGENTS, AgentConfig
 from devops_bench.agents.capabilities import (
     AgentRules,
@@ -42,7 +44,7 @@ from devops_bench.agents.cli.openclaw.agent import (
     _oc_model_id,
 )
 from devops_bench.agents.cli.openclaw.parsing import _pick_session_key, _strip_ansi
-from devops_bench.core.errors import SubprocessError
+from devops_bench.core.errors import ConfigError, SubprocessError
 
 
 def _events(*entries: dict) -> str:
@@ -209,6 +211,18 @@ def test_oc_model_id_preserves_full_id():
     assert _oc_model_id(AgentConfig(model="anthropic/claude-opus-4-7")) == (
         "anthropic/claude-opus-4-7"
     )
+
+
+def test_oc_model_id_normalizes_full_id_provider_segment():
+    # A full id whose wire is an alias is normalized through the contract.
+    assert _oc_model_id(AgentConfig(model="gemini/gemini-2.5-pro")) == (
+        "google/gemini-2.5-pro"
+    )
+
+
+def test_oc_model_id_passes_through_unknown_full_id_wire():
+    # An unrecognized wire is left for oc to validate, not rejected here.
+    assert _oc_model_id(AgentConfig(model="mystery/some-model")) == "mystery/some-model"
 
 
 def test_oc_model_id_returns_empty_when_no_model():
@@ -634,6 +648,20 @@ def test_build_env_routes_vertex_key_to_cloud_api_key():
     transport's var), not ``GEMINI_API_KEY`` (the google-genai one)."""
     vertex = _build_env(AgentConfig(api_key="marker", provider="google-vertex"))
     assert vertex == {"GOOGLE_CLOUD_API_KEY": "marker"}
+
+
+def test_build_env_unknown_provider_raises():
+    """An unknown provider fails loud instead of silently writing a Gemini key."""
+    with pytest.raises(ConfigError):
+        _build_env(AgentConfig(api_key="k", provider="mystery"))
+
+
+def test_model_override_raises_for_unpinned_transport():
+    """A catalog-override model whose provider has no pinned transport fails loud
+    rather than shipping a transport-less entry (which would 401 via the OpenAI
+    fallback). A full-id with an unknown wire reaches this path."""
+    with pytest.raises(ConfigError):
+        _build_model_override(AgentConfig(model="mystery/gemini-3.5-flash"))
 
 
 def _empty_sessions_run(argv, **kwargs):

--- a/tests/unit/core/test_model_providers.py
+++ b/tests/unit/core/test_model_providers.py
@@ -15,10 +15,10 @@
 """Unit tests for the model-provider contract."""
 
 import pytest
+from pydantic import ValidationError
 
 from devops_bench.core.errors import ConfigError
 from devops_bench.core.model_providers import (
-    ProviderSpec,
     known_providers,
     resolve_provider,
 )
@@ -27,8 +27,24 @@ from devops_bench.core.model_providers import (
 _ROWS = [
     ("gemini", "google", "gemini", "google", ("GEMINI_API_KEY", "GOOGLE_API_KEY"), False, None),
     ("google", "google", "gemini", "google", ("GEMINI_API_KEY", "GOOGLE_API_KEY"), False, None),
-    ("google-vertex", "google-vertex", "gemini", "google-vertex", ("GOOGLE_CLOUD_API_KEY",), True, "vertex"),
-    ("google_vertex", "google-vertex", "gemini", "google-vertex", ("GOOGLE_CLOUD_API_KEY",), True, "vertex"),
+    (
+        "google-vertex",
+        "google-vertex",
+        "gemini",
+        "google-vertex",
+        ("GOOGLE_CLOUD_API_KEY",),
+        True,
+        "vertex",
+    ),
+    (
+        "google_vertex",
+        "google-vertex",
+        "gemini",
+        "google-vertex",
+        ("GOOGLE_CLOUD_API_KEY",),
+        True,
+        "vertex",
+    ),
     ("anthropic", "anthropic", "claude", "anthropic", ("ANTHROPIC_API_KEY",), False, None),
     ("claude", "anthropic", "claude", "anthropic", ("ANTHROPIC_API_KEY",), False, None),
     ("anthropic-vertex", "anthropic-vertex", "claude", "anthropic-vertex", (), True, "vertex"),
@@ -39,9 +55,7 @@ _ROWS = [
 ]
 
 
-@pytest.mark.parametrize(
-    "raw,canonical,family,oc_provider,api_key_envs,keyless,backend", _ROWS
-)
+@pytest.mark.parametrize("raw,canonical,family,oc_provider,api_key_envs,keyless,backend", _ROWS)
 def test_resolve_provider_table(
     raw, canonical, family, oc_provider, api_key_envs, keyless, backend
 ):
@@ -87,7 +101,7 @@ def test_only_vertex_bedrock_ollama_are_keyless():
 
 def test_provider_spec_is_frozen():
     spec = resolve_provider("google")
-    with pytest.raises(Exception):  # pydantic raises on mutation of a frozen model
+    with pytest.raises(ValidationError):  # frozen pydantic model rejects mutation
         spec.canonical = "other"
 
 

--- a/tests/unit/core/test_model_providers.py
+++ b/tests/unit/core/test_model_providers.py
@@ -1,0 +1,97 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the model-provider contract."""
+
+import pytest
+
+from devops_bench.core.errors import ConfigError
+from devops_bench.core.model_providers import (
+    ProviderSpec,
+    known_providers,
+    resolve_provider,
+)
+
+# (raw alias, canonical, adapter_family, oc_provider, api_key_envs, keyless_ok, backend)
+_ROWS = [
+    ("gemini", "google", "gemini", "google", ("GEMINI_API_KEY", "GOOGLE_API_KEY"), False, None),
+    ("google", "google", "gemini", "google", ("GEMINI_API_KEY", "GOOGLE_API_KEY"), False, None),
+    ("google-vertex", "google-vertex", "gemini", "google-vertex", ("GOOGLE_CLOUD_API_KEY",), True, "vertex"),
+    ("google_vertex", "google-vertex", "gemini", "google-vertex", ("GOOGLE_CLOUD_API_KEY",), True, "vertex"),
+    ("anthropic", "anthropic", "claude", "anthropic", ("ANTHROPIC_API_KEY",), False, None),
+    ("claude", "anthropic", "claude", "anthropic", ("ANTHROPIC_API_KEY",), False, None),
+    ("anthropic-vertex", "anthropic-vertex", "claude", "anthropic-vertex", (), True, "vertex"),
+    ("anthropic_vertex", "anthropic-vertex", "claude", "anthropic-vertex", (), True, "vertex"),
+    ("anthropic-bedrock", "anthropic-bedrock", "claude", "anthropic-bedrock", (), True, "bedrock"),
+    ("openai", "openai", "openai", "openai", ("OPENAI_API_KEY",), False, None),
+    ("ollama", "ollama", "ollama", "ollama", (), True, None),
+]
+
+
+@pytest.mark.parametrize(
+    "raw,canonical,family,oc_provider,api_key_envs,keyless,backend", _ROWS
+)
+def test_resolve_provider_table(
+    raw, canonical, family, oc_provider, api_key_envs, keyless, backend
+):
+    spec = resolve_provider(raw)
+    assert spec.canonical == canonical
+    assert spec.adapter_family == family
+    assert spec.oc_provider == oc_provider
+    assert spec.api_key_envs == api_key_envs
+    assert spec.keyless_ok is keyless
+    assert spec.backend == backend
+
+
+def test_resolve_provider_is_case_insensitive():
+    assert resolve_provider("GEMINI").canonical == "google"
+    assert resolve_provider("Google-Vertex").canonical == "google-vertex"
+
+
+@pytest.mark.parametrize("blank", [None, "", "   "])
+def test_blank_resolves_to_default(blank):
+    assert resolve_provider(blank).canonical == "google"
+    assert resolve_provider(blank, default="anthropic").canonical == "anthropic"
+
+
+def test_unknown_provider_raises_with_known_list():
+    with pytest.raises(ConfigError) as exc:
+        resolve_provider("mystery")
+    msg = str(exc.value)
+    assert "mystery" in msg
+    assert "gemini" in msg and "anthropic" in msg
+
+
+def test_only_vertex_bedrock_ollama_are_keyless():
+    keyless = {raw for raw, *_ in _ROWS if resolve_provider(raw).keyless_ok}
+    assert keyless == {
+        "google-vertex",
+        "google_vertex",
+        "anthropic-vertex",
+        "anthropic_vertex",
+        "anthropic-bedrock",
+        "ollama",
+    }
+
+
+def test_provider_spec_is_frozen():
+    spec = resolve_provider("google")
+    with pytest.raises(Exception):  # pydantic raises on mutation of a frozen model
+        spec.canonical = "other"
+
+
+def test_known_providers_sorted_and_complete():
+    known = known_providers()
+    assert known == tuple(sorted(known))
+    assert "google-vertex" in known and "ollama" in known

--- a/tests/unit/models/test_models_base.py
+++ b/tests/unit/models/test_models_base.py
@@ -20,7 +20,7 @@ import os
 
 import pytest
 
-from devops_bench.core.errors import NotRegisteredError
+from devops_bench.core.errors import ConfigError, NotRegisteredError
 from devops_bench.models.base import MODELS, LLMClient, get_model
 
 
@@ -130,5 +130,37 @@ def test_get_model_passes_model_name(mocker):
 def test_get_model_unknown_provider_raises(mocker):
     from devops_bench.models import claude, gemini  # noqa: F401
 
-    with pytest.raises(NotRegisteredError):
+    with pytest.raises(ConfigError):
         get_model(provider="does-not-exist")
+
+
+def test_get_model_openai_resolves_but_has_no_adapter():
+    # ``openai`` is a known provider in the contract but ships no adapter module,
+    # so resolution succeeds and the registry lookup raises NotRegisteredError.
+    with pytest.raises(NotRegisteredError):
+        get_model(provider="openai")
+
+
+def test_get_model_passes_vertex_backend_to_gemini(mocker):
+    from devops_bench.models import gemini
+
+    client_cls = mocker.patch.object(gemini.genai, "Client")
+    mocker.patch.dict(os.environ, {"GCP_PROJECT_ID": "p"}, clear=True)
+    get_model(provider="google-vertex")
+
+    # google-vertex -> backend="vertex" -> the adapter builds the Vertex client.
+    client_cls.assert_called_once_with(vertexai=True, project="p", location="global")
+
+
+def test_get_model_passes_vertex_backend_to_claude(mocker):
+    from devops_bench.models import claude
+
+    vertex_cls = mocker.patch.object(claude, "AsyncAnthropicVertex")
+    # An API key is present, but the anthropic-vertex provider must still use
+    # Vertex (backend hint decouples auth from key presence).
+    mocker.patch.dict(
+        os.environ, {"AGENT_API_KEY": "sk-test", "AGENT_MODEL": "claude-x"}, clear=True
+    )
+    get_model(provider="anthropic-vertex")
+
+    vertex_cls.assert_called_once()

--- a/tests/unit/models/test_models_claude.py
+++ b/tests/unit/models/test_models_claude.py
@@ -120,6 +120,41 @@ def test_init_backend_override_invalid_raises(mocker):
         ClaudeClientAdapter()
 
 
+def test_init_backend_arg_forces_vertex_over_api_key(mocker):
+    api_cls = mocker.patch.object(claude, "AsyncAnthropic")
+    vertex_cls = mocker.patch.object(claude, "AsyncAnthropicVertex")
+    # anthropic-vertex provider passes backend="vertex"; a stray API key must not
+    # flip it to the api backend (decoupling Vertex auth from the key).
+    mocker.patch.dict(
+        os.environ, {"AGENT_API_KEY": "sk-test", "AGENT_MODEL": "claude-x"}, clear=True
+    )
+
+    ClaudeClientAdapter(backend="vertex")
+
+    vertex_cls.assert_called_once()
+    api_cls.assert_not_called()
+
+
+def test_init_backend_arg_forces_bedrock(mocker):
+    bedrock_cls = mocker.patch.object(claude, "AsyncAnthropicBedrock")
+    mocker.patch.dict(
+        os.environ, {"AWS_REGION": "us-west-2", "AGENT_MODEL": "anthropic.claude-x"}, clear=True
+    )
+
+    ClaudeClientAdapter(backend="bedrock")
+
+    bedrock_cls.assert_called_once_with(aws_region="us-west-2")
+
+
+def test_init_backend_none_still_infers(mocker):
+    api_cls = mocker.patch.object(claude, "AsyncAnthropic")
+    mocker.patch.dict(os.environ, {"AGENT_API_KEY": "sk-test"}, clear=True)
+
+    ClaudeClientAdapter(backend=None)
+
+    api_cls.assert_called_once_with(api_key="sk-test")
+
+
 def test_init_without_sdk_raises(mocker):
     mocker.patch.object(claude, "AsyncAnthropic", None)
 

--- a/tests/unit/models/test_models_gemini.py
+++ b/tests/unit/models/test_models_gemini.py
@@ -96,9 +96,7 @@ def test_backend_vertex_forces_vertex_even_with_api_key(mocker):
     client_cls = mocker.patch.object(gemini.genai, "Client")
     # An API key is present, but backend="vertex" (the google-vertex provider)
     # must still build the Vertex client — provider decides, not key presence.
-    mocker.patch.dict(
-        os.environ, {"AGENT_API_KEY": "k", "GCP_PROJECT_ID": "proj"}, clear=True
-    )
+    mocker.patch.dict(os.environ, {"AGENT_API_KEY": "k", "GCP_PROJECT_ID": "proj"}, clear=True)
 
     GeminiClientAdapter(backend="vertex")
 
@@ -211,9 +209,7 @@ def test_generate_content_retries_on_429_then_succeeds(mocker):
     client.aio.models.generate_content = generate
 
     adapter = GeminiClientAdapter()
-    result = asyncio.run(
-        adapter.generate_content([{"role": "user", "content": "hi"}], None, None)
-    )
+    result = asyncio.run(adapter.generate_content([{"role": "user", "content": "hi"}], None, None))
 
     assert result == "resp"
     assert generate.await_count == 2

--- a/tests/unit/models/test_models_gemini.py
+++ b/tests/unit/models/test_models_gemini.py
@@ -92,6 +92,28 @@ def test_client_selection_default(mocker):
     assert adapter.model_name == "gemini-3.1-pro-preview"
 
 
+def test_backend_vertex_forces_vertex_even_with_api_key(mocker):
+    client_cls = mocker.patch.object(gemini.genai, "Client")
+    # An API key is present, but backend="vertex" (the google-vertex provider)
+    # must still build the Vertex client — provider decides, not key presence.
+    mocker.patch.dict(
+        os.environ, {"AGENT_API_KEY": "k", "GCP_PROJECT_ID": "proj"}, clear=True
+    )
+
+    GeminiClientAdapter(backend="vertex")
+
+    client_cls.assert_called_once_with(vertexai=True, project="proj", location="global")
+
+
+def test_backend_none_keeps_inference(mocker):
+    client_cls = mocker.patch.object(gemini.genai, "Client")
+    mocker.patch.dict(os.environ, {"AGENT_API_KEY": "k"}, clear=True)
+
+    GeminiClientAdapter(backend=None)
+
+    client_cls.assert_called_once_with(api_key="k")
+
+
 # --- format_tools -------------------------------------------------------------
 
 

--- a/tests/unit/models/test_models_ollama.py
+++ b/tests/unit/models/test_models_ollama.py
@@ -74,6 +74,16 @@ def test_init_args_override_env(mocker):
     assert adapter.model_name == "mistral"
 
 
+def test_init_uses_agent_api_key_when_set(mocker):
+    client_cls = mocker.patch.object(ollama, "AsyncOpenAI")
+    mocker.patch.dict(os.environ, {"AGENT_API_KEY": "sk-remote"}, clear=True)
+
+    OllamaClientAdapter()
+
+    # Ollama supports optional key-based auth (remote/hosted endpoints).
+    client_cls.assert_called_once_with(base_url="http://localhost:11434/v1", api_key="sk-remote")
+
+
 def test_init_without_sdk_raises(mocker):
     mocker.patch.object(ollama, "AsyncOpenAI", None)
 


### PR DESCRIPTION
## Summary

Closes #147. Makes `AGENT_PROVIDER` / `AGENT_MODEL` / `AGENT_API_KEY` consumption **consistent across every harness** by introducing one source-of-truth provider contract that the `api` runner *and* the `gemini`/`openclaw` CLIs share. Also resolves the three review comments deferred from #149.

## The contract

New `devops_bench/core/model_providers.py` — a frozen Pydantic `ProviderSpec` + `resolve_provider()`. One alias→spec table encodes the two axes the harnesses need:
- **adapter family** (which `LLMClient` `get_model` builds), and
- **backend / transport / key-routing** (the oc wire-provider, the API-key env var(s) a CLI sets, whether the backend is keyless).

It lives in `core/` so both `models/` and `agents/cli/` import it with no cycle and no SDK pull; named `model_providers` to avoid colliding with the cloud `providers/` package.

## What changed

- **`get_model` + adapters** route through the contract. `get_model` forwards a `backend` hint; `gemini`/`claude` honor it so the **provider key** (not stray env keys) selects Vertex/Bedrock. `ollama` now accepts an **optional** `AGENT_API_KEY`.
- **CLI harnesses** (`openclaw`, `gemini_cli`) route the key via the contract. openclaw normalizes the provider on **both** `_oc_model_id` paths and **fails loud** when a per-run catalog override has no pinned transport — closing the OpenAI-fallback 401 footgun.
- **New keyless providers** `anthropic-vertex` / `anthropic-bedrock` (ADC / AWS creds): the contract never forces `ANTHROPIC_API_KEY` onto them.
- **`configure-oc.sh`** (comment-only): documents why the genai vs vertex model lists legitimately differ (genai lists only models oc doesn't ship; vertex lists all, since oc ships no built-in vertex catalog), with a `TODO(deferred)` for model-name upkeep.
- **Docs synced**: `model_providers.md`, `agents.md`, `add-a-model-provider.md`.

## Deferred #149 comments resolved

1. openclaw transport-less catalog entry → normalize + fail loud.
2. Vertex auth decoupled from the api-key flow (keyless specs).
3. genai vs vertex model-list divergence → documented as intentional.

## Testing

- `pytest tests/unit` — 797 passed; doctests pass; `ruff check` + `ruff format --check` clean on the changed files.
- Import smoke confirms no provider SDK / deepeval / mcp is pulled by importing the contract or the harnesses.
- Cross-model review (devops-bench-review on a non-authoring model) found no correctness or parallel-safety issues; its findings are addressed.
- e2e auth on the bastion (google / google-vertex / anthropic) is out of band.

## Notes

- Supported-model-name maintenance is intentionally **deferred** (`TODO(deferred)` at the two hardcoded lists); no dynamic catalog in this PR.
- Pre-existing (not introduced here): `test_execute_writes_model_override_config_without_mcp` fails only when `GEMINI_API_KEY` is set in the ambient shell (it merges `os.environ`); it also fails on clean `main`.
