### PR TITLE
verification: add pods_on_node_with_label verifier

### DIFF
--- a/devops_bench/verification/verifiers/__init__.py
+++ b/devops_bench/verification/verifiers/__init__.py
@@ -15,6 +15,13 @@
 """Concrete single-condition verifiers."""
 
 from devops_bench.verification.verifiers.pod_healthy import PodHealthyVerifier
+from devops_bench.verification.verifiers.pods_on_node_label import (
+    PodsOnNodeWithLabelVerifier,
+)
 from devops_bench.verification.verifiers.scaling_complete import ScalingCompleteVerifier
 
-__all__ = ["PodHealthyVerifier", "ScalingCompleteVerifier"]
+__all__ = [
+    "PodHealthyVerifier",
+    "PodsOnNodeWithLabelVerifier",
+    "ScalingCompleteVerifier",
+]

--- a/devops_bench/verification/verifiers/pods_on_node_label.py
+++ b/devops_bench/verification/verifiers/pods_on_node_label.py
@@ -1,0 +1,123 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verifier that selected pods are scheduled on nodes carrying a given label."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from devops_bench.core import SubprocessError, get_logger
+from devops_bench.k8s import get_resource
+from devops_bench.verification.base import VERIFIERS, BaseVerifier, VerificationResult
+
+__all__ = ["PodsOnNodeWithLabelVerifier"]
+
+_log = get_logger("verification.pods_on_node_with_label")
+
+
+@VERIFIERS.register("pods_on_node_with_label")
+class PodsOnNodeWithLabelVerifier(BaseVerifier):
+    """Verify every pod matched by ``selector`` runs on a node with ``node_label``.
+
+    Resolves the set of nodes whose labels match ``node_label`` (a ``key=value``
+    or bare ``key`` selector), then confirms each Running pod matched by
+    ``selector`` is scheduled onto one of them. Polls until the placement holds
+    or the timeout elapses, so it tolerates pods still rescheduling. Useful for
+    asserting placement outcomes such as "the Spot-eligible workloads landed on
+    Spot-labeled nodes".
+
+    Attributes:
+        type: Discriminator literal, always ``"pods_on_node_with_label"``.
+        selector: Pod label selector (``-l``) identifying the pods to check.
+        node_label: Node label selector the pods' nodes must match (e.g.
+            ``"cloud.google.com/gke-spot=true"``).
+        namespace: Optional namespace for the pods; defaults to the active one.
+    """
+
+    type: Literal["pods_on_node_with_label"] = "pods_on_node_with_label"
+    selector: str
+    node_label: str
+    namespace: str | None = None
+
+    def verify(self, timeout_sec: float) -> VerificationResult:
+        """Poll until every matched, Running pod sits on a labeled node.
+
+        Args:
+            timeout_sec: Maximum seconds to keep polling.
+
+        Returns:
+            A result that is successful once at least one pod matches the
+            selector and all such Running pods are scheduled on nodes carrying
+            ``node_label``.
+        """
+        return self._poll_to_result(self._check_placement, timeout_sec)
+
+    def _check_placement(self) -> tuple[bool, str, dict[str, Any] | None]:
+        """Read pods + labeled nodes once and compare placement.
+
+        Returns:
+            A ``(success, reason, raw)`` triple. ``raw`` carries the labeled
+            node set and the observed pod-to-node placement once both could be
+            read, else ``None``.
+        """
+        try:
+            labeled = get_resource(
+                "nodes", selector=self.node_label, kubeconfig=self.kubeconfig
+            )
+            pods = get_resource(
+                "pods",
+                selector=self.selector,
+                namespace=self.namespace,
+                kubeconfig=self.kubeconfig,
+            )
+        except SubprocessError as exc:
+            return False, f"kubectl get failed: {(exc.stderr or '').strip()}", None
+
+        labeled_nodes = {
+            (node.get("metadata") or {}).get("name") for node in labeled.get("items", [])
+        }
+        # Only Running pods have a settled node; Pending/terminating pods are not
+        # yet placed and would spuriously fail (or pass) a placement check.
+        running = [
+            pod
+            for pod in pods.get("items", [])
+            if (pod.get("status") or {}).get("phase") == "Running"
+        ]
+        placement = {
+            (pod.get("metadata") or {}).get("name"): (pod.get("spec") or {}).get("nodeName")
+            for pod in running
+        }
+        raw: dict[str, Any] = {
+            "labeled_nodes": sorted(name for name in labeled_nodes if name),
+            "placement": placement,
+        }
+        if not running:
+            return False, f"no Running pods matched selector {self.selector!r}", raw
+        misplaced = {
+            name: node for name, node in placement.items() if node not in labeled_nodes
+        }
+        if misplaced:
+            return (
+                False,
+                f"{len(misplaced)}/{len(running)} pod(s) not on a node matching "
+                f"{self.node_label!r}: {misplaced}",
+                raw,
+            )
+        return (
+            True,
+            f"all {len(running)} pod(s) matching {self.selector!r} are on nodes "
+            f"matching {self.node_label!r}",
+            raw,
+        )

--- a/devops_bench/verification/verifiers/pods_on_node_label.py
+++ b/devops_bench/verification/verifiers/pods_on_node_label.py
@@ -44,12 +44,16 @@ class PodsOnNodeWithLabelVerifier(BaseVerifier):
         node_label: Node label selector the pods' nodes must match (e.g.
             ``"cloud.google.com/gke-spot=true"``).
         namespace: Optional namespace for the pods; defaults to the active one.
+        min_pods: Minimum number of correctly-placed Running pods required to
+            pass (default ``1``). Guards against a partial rollout passing while
+            replicas are still Pending and may yet land on the wrong nodes.
     """
 
     type: Literal["pods_on_node_with_label"] = "pods_on_node_with_label"
     selector: str
     node_label: str
     namespace: str | None = None
+    min_pods: int = 1
 
     def verify(self, timeout_sec: float) -> VerificationResult:
         """Poll until every matched, Running pod sits on a labeled node.
@@ -73,9 +77,7 @@ class PodsOnNodeWithLabelVerifier(BaseVerifier):
             read, else ``None``.
         """
         try:
-            labeled = get_resource(
-                "nodes", selector=self.node_label, kubeconfig=self.kubeconfig
-            )
+            labeled = get_resource("nodes", selector=self.node_label, kubeconfig=self.kubeconfig)
             pods = get_resource(
                 "pods",
                 selector=self.selector,
@@ -88,6 +90,7 @@ class PodsOnNodeWithLabelVerifier(BaseVerifier):
         labeled_nodes = {
             (node.get("metadata") or {}).get("name") for node in labeled.get("items", [])
         }
+        labeled_nodes.discard(None)
         # Only Running pods have a settled node; Pending/terminating pods are not
         # yet placed and would spuriously fail (or pass) a placement check.
         running = [
@@ -100,19 +103,35 @@ class PodsOnNodeWithLabelVerifier(BaseVerifier):
             for pod in running
         }
         raw: dict[str, Any] = {
-            "labeled_nodes": sorted(name for name in labeled_nodes if name),
+            "labeled_nodes": sorted(labeled_nodes),
             "placement": placement,
         }
+        # No labeled nodes at all means the label selector is wrong or the node
+        # pool never came up — surface that instead of blaming every pod.
+        if not labeled_nodes:
+            return (
+                False,
+                f"no nodes match node_label {self.node_label!r} "
+                "(check the selector or whether the node pool came up)",
+                raw,
+            )
         if not running:
             return False, f"no Running pods matched selector {self.selector!r}", raw
-        misplaced = {
-            name: node for name, node in placement.items() if node not in labeled_nodes
-        }
+        misplaced = {name: node for name, node in placement.items() if node not in labeled_nodes}
         if misplaced:
             return (
                 False,
                 f"{len(misplaced)}/{len(running)} pod(s) not on a node matching "
                 f"{self.node_label!r}: {misplaced}",
+                raw,
+            )
+        # Every Running pod here is correctly placed; require enough of them so a
+        # partial rollout (replicas still Pending) does not pass prematurely.
+        if len(running) < self.min_pods:
+            return (
+                False,
+                f"only {len(running)} correctly-placed Running pod(s) matching "
+                f"{self.selector!r}; need >= {self.min_pods} (others may still be scheduling)",
                 raw,
             )
         return (

--- a/tests/unit/verification/test_pods_on_node_label.py
+++ b/tests/unit/verification/test_pods_on_node_label.py
@@ -93,6 +93,59 @@ def test_failure_when_no_running_pods_match():
     assert "no Running pods" in result.reason
 
 
+def test_failure_when_no_nodes_match_the_label():
+    # Zero labeled nodes (typo in the label, or the pool never came up) must be
+    # diagnosed as such rather than reported as every pod being misplaced.
+    labeled = _nodes()  # no items
+    pods = _pods(("web-1", "on-demand", "Running"))
+    with patch(
+        "devops_bench.verification.verifiers.pods_on_node_label.get_resource",
+        side_effect=[labeled, pods],
+    ):
+        result = PodsOnNodeWithLabelVerifier(
+            selector="app=web", node_label="cloud.google.com/gke-spot=true"
+        ).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert "no nodes match node_label" in result.reason
+    assert "web-1" not in result.reason  # not blaming the pod
+
+
+def test_failure_when_fewer_than_min_pods_placed():
+    # One replica has settled correctly but the task requires two — a partial
+    # rollout must not pass while others are still scheduling.
+    labeled = _nodes("spot-a", "spot-b")
+    pods = _pods(("web-1", "spot-a", "Running"), ("web-2", "", "Pending"))
+    with patch(
+        "devops_bench.verification.verifiers.pods_on_node_label.get_resource",
+        side_effect=[labeled, pods],
+    ):
+        result = PodsOnNodeWithLabelVerifier(
+            selector="app=web",
+            node_label="cloud.google.com/gke-spot=true",
+            min_pods=2,
+        ).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert "need >= 2" in result.reason
+
+
+def test_success_when_min_pods_satisfied():
+    labeled = _nodes("spot-a", "spot-b")
+    pods = _pods(("web-1", "spot-a", "Running"), ("web-2", "spot-b", "Running"))
+    with patch(
+        "devops_bench.verification.verifiers.pods_on_node_label.get_resource",
+        side_effect=[labeled, pods],
+    ):
+        result = PodsOnNodeWithLabelVerifier(
+            selector="app=web",
+            node_label="cloud.google.com/gke-spot=true",
+            min_pods=2,
+        ).verify(timeout_sec=5)
+
+    assert result.success is True
+
+
 def test_failure_when_kubectl_errors():
     with patch(
         "devops_bench.verification.verifiers.pods_on_node_label.get_resource",

--- a/tests/unit/verification/test_pods_on_node_label.py
+++ b/tests/unit/verification/test_pods_on_node_label.py
@@ -1,0 +1,112 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``PodsOnNodeWithLabelVerifier``.
+
+The two ``kubectl get`` calls (nodes, then pods) are stubbed via
+``unittest.mock.patch`` with a ``side_effect`` so the verifier can be exercised
+without a real cluster.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from devops_bench.core import SubprocessError
+from devops_bench.verification.verifiers import PodsOnNodeWithLabelVerifier
+
+
+def _nodes(*names):
+    return {"items": [{"metadata": {"name": n}} for n in names]}
+
+
+def _pods(*pairs):
+    # pairs of (pod_name, node_name, phase)
+    return {
+        "items": [
+            {
+                "metadata": {"name": name},
+                "spec": {"nodeName": node},
+                "status": {"phase": phase},
+            }
+            for name, node, phase in pairs
+        ]
+    }
+
+
+def test_success_when_all_running_pods_on_labeled_nodes():
+    labeled = _nodes("spot-a", "spot-b")
+    pods = _pods(("web-1", "spot-a", "Running"), ("web-2", "spot-b", "Running"))
+    with patch(
+        "devops_bench.verification.verifiers.pods_on_node_label.get_resource",
+        side_effect=[labeled, pods],
+    ):
+        result = PodsOnNodeWithLabelVerifier(
+            selector="app=web", node_label="cloud.google.com/gke-spot=true"
+        ).verify(timeout_sec=5)
+
+    assert result.success is True
+    assert "are on nodes" in result.reason
+    assert result.raw["labeled_nodes"] == ["spot-a", "spot-b"]
+
+
+def test_failure_when_a_pod_is_on_an_unlabeled_node():
+    labeled = _nodes("spot-a", "spot-b")
+    # web-2 landed on the on-demand node.
+    pods = _pods(("web-1", "spot-a", "Running"), ("web-2", "on-demand", "Running"))
+    with patch(
+        "devops_bench.verification.verifiers.pods_on_node_label.get_resource",
+        side_effect=[labeled, pods],
+    ):
+        result = PodsOnNodeWithLabelVerifier(
+            selector="app=web", node_label="cloud.google.com/gke-spot=true"
+        ).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert "not on a node matching" in result.reason
+    assert "web-2" in result.reason
+
+
+def test_failure_when_no_running_pods_match():
+    labeled = _nodes("spot-a")
+    pods = _pods(("web-1", "", "Pending"))
+    with patch(
+        "devops_bench.verification.verifiers.pods_on_node_label.get_resource",
+        side_effect=[labeled, pods],
+    ):
+        result = PodsOnNodeWithLabelVerifier(
+            selector="app=web", node_label="cloud.google.com/gke-spot=true"
+        ).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert "no Running pods" in result.reason
+
+
+def test_failure_when_kubectl_errors():
+    with patch(
+        "devops_bench.verification.verifiers.pods_on_node_label.get_resource",
+        side_effect=SubprocessError(["kubectl", "get", "nodes"], 1, stderr="nodes is forbidden"),
+    ):
+        result = PodsOnNodeWithLabelVerifier(
+            selector="app=web", node_label="cloud.google.com/gke-spot=true"
+        ).verify(timeout_sec=0)
+
+    assert result.success is False
+    assert "kubectl get failed" in result.reason
+
+
+def test_registered_in_registry():
+    from devops_bench.verification.base import VERIFIERS
+
+    assert "pods_on_node_with_label" in VERIFIERS.keys()

--- a/tests/unit/verification/test_pods_on_node_label.py
+++ b/tests/unit/verification/test_pods_on_node_label.py
@@ -109,4 +109,4 @@ def test_failure_when_kubectl_errors():
 def test_registered_in_registry():
     from devops_bench.verification.base import VERIFIERS
 
-    assert "pods_on_node_with_label" in VERIFIERS.keys()
+    assert "pods_on_node_with_label" in VERIFIERS


### PR DESCRIPTION
Adds a leaf verifier `pods_on_node_with_label` that asserts every Running pod matched by a selector is scheduled on a node carrying a given node-label selector (e.g. `cloud.google.com/gke-spot=true`). Polls until placement holds or times out (tolerates in-flight rescheduling), registered in the `VERIFIERS` registry, with unit tests (success / misplaced-pod / no-running-pods / kubectl-error / registration). Full verification suite green (55 passed).

Motivation: requested in the #154 (spot-rebalancing) review to make placement scoring deterministic.

Note: this PR only adds the verifier. **Wiring it into a task's scoring needs a separate follow-up** — verification currently only runs when a `chaos_spec` triggers it (`start_scenario` returns `None` with no chaos), so standalone (post-agent, non-chaos) verification support is required before a task can score on it. Happy to do that as the next PR.