### PR TITLE
tasks: add greenops-consolidation — energy-efficiency node consolidation (kind)

### DIFF
--- a/tasks/common/greenops-consolidation/README.md
+++ b/tasks/common/greenops-consolidation/README.md
@@ -7,9 +7,11 @@ de-provisioning, all **without dropping availability** — then reporting the sa
 
 The cluster runs an underutilized fleet spread thinly across several worker nodes
 (the energy-wasteful "before" state). The agent must recognize the consolidation
-opportunity from a carbon-aware capacity report plus live utilization, drain the
-spare nodes safely (honoring PodDisruptionBudgets and pod anti-affinity), and avoid
-over-consolidating to the point of breaking a workload.
+opportunity from live node utilization it inspects itself, drain the spare nodes
+safely (honoring PodDisruptionBudgets and pod anti-affinity), and avoid
+over-consolidating to the point of breaking a workload. A minimal carbon feed
+(grid intensity + per-node power) supplies only the external figures the agent
+can't derive from the cluster, for the savings estimate in its report.
 
 Runs on **kind** (local, on the runner VM) — no cloud dependency, no GKE quota.
 
@@ -22,15 +24,17 @@ Runs on **kind** (local, on the runner VM) — no cloud dependency, no GKE quota
     spreads the pods roughly one-per-node, so every worker carries a little load —
     the underutilized state the agent must consolidate,
   - waits for the fleet to become Available so the agent starts healthy.
-- A declarative `local_file` resource delivers the carbon-aware capacity report to
-  a per-run file `~/carbon-report-<cluster_name>.json` (removed automatically on
-  `tofu destroy`).
-- The report host path derives from `cluster_name` (which the harness
+- A declarative `local_file` resource delivers a minimal carbon feed (off-peak
+  window, grid carbon intensity, per-node power draw — no utilization summary, no
+  recommendation) to a per-run file `~/carbon-report-<cluster_name>.json` (removed
+  automatically on `tofu destroy`).
+- The feed's host path derives from `cluster_name` (which the harness
   run-token-prefixes), so concurrent runs on the shared bastion never collide. The
   prompt references it via `{{CLUSTER_NAME}}`.
-- **Nothing tells the agent which nodes to drain or how far to consolidate** — it
-  reads the report, inspects node utilization and each workload's scheduling
-  constraints, and decides itself.
+- **Nothing tells the agent what to do** — the prompt states only the goal (cut
+  overnight energy/carbon, keep workloads available); the agent inspects node
+  utilization and each workload's scheduling constraints and decides the approach
+  (consolidate → drain the spare nodes) and how far it can safely go itself.
 
 ### The fleet (namespace `workloads`)
 

--- a/tasks/common/greenops-consolidation/README.md
+++ b/tasks/common/greenops-consolidation/README.md
@@ -1,0 +1,129 @@
+# Intelligent Workload Re-balancing for GreenOps (Energy Efficiency)
+
+This task evaluates an agent's ability to **cut a cluster's energy/carbon footprint
+by consolidating workloads onto fewer nodes** during off-peak hours — packing a
+lightly-loaded fleet down, cordoning and draining the freed nodes for
+de-provisioning, all **without dropping availability** — then reporting the savings.
+
+The cluster runs an underutilized fleet spread thinly across several worker nodes
+(the energy-wasteful "before" state). The agent must recognize the consolidation
+opportunity from a carbon-aware capacity report plus live utilization, drain the
+spare nodes safely (honoring PodDisruptionBudgets and pod anti-affinity), and avoid
+over-consolidating to the point of breaking a workload.
+
+Runs on **kind** (local, on the runner VM) — no cloud dependency, no GKE quota.
+
+## How it works
+
+- **Infrastructure** (`tf/prebuilt/greenops-consolidation-kind`) provisions a
+  **multi-node** kind cluster (1 control-plane + **4 workers**) and runs
+  `scripts/setup.sh`, which:
+  - deploys the workload fleet. With four empty workers at bring-up the scheduler
+    spreads the pods roughly one-per-node, so every worker carries a little load —
+    the underutilized state the agent must consolidate,
+  - waits for the fleet to become Available so the agent starts healthy,
+  - delivers the carbon-aware capacity report to a per-run file
+    `~/carbon-report-<cluster_name>.json`.
+- The report host path derives from `cluster_name` (which the harness
+  run-token-prefixes), so concurrent runs on the shared bastion never collide. The
+  prompt references it via `{{CLUSTER_NAME}}`.
+- **Nothing tells the agent which nodes to drain or how far to consolidate** — it
+  reads the report, inspects node utilization and each workload's scheduling
+  constraints, and decides itself.
+
+### The fleet (namespace `workloads`)
+
+| Workload | Replicas | Constraint | Role in the task |
+| --- | --- | --- | --- |
+| `web-frontend` | 2 | **required** pod anti-affinity (replicas on distinct nodes) + PDB | Sets the consolidation **floor of 2 nodes** |
+| `api-server` | 2 | PDB `minAvailable: 1` | Drain must evict politely |
+| `worker-batch` | 4 | none | Spreads one-per-node → makes the fleet span all 4 workers |
+| `cache` | 1 | none | Freely reschedulable |
+| `cron-runner` | 1 | none | Freely reschedulable |
+
+The agent can safely collapse the cluster from **4 worker nodes to 2** — but not to
+1: `web-frontend`'s required anti-affinity needs two distinct nodes, so an
+over-aggressive drain-to-one leaves a replica Pending. That, plus the PDBs, makes
+"maintain availability" a real constraint (SOT step 2: respect affinity/anti-affinity).
+
+### How it maps to the source-of-truth scenario (Complex Task #9)
+
+| SOT step | Realization in this task |
+| --- | --- |
+| 1. Carbon-aware load analysis | Read the carbon report (off-peak window, grid intensity, node power, fleet utilization) + live node/pod state; identify the consolidation opportunity. |
+| 2. Predictive bin-packing | Determine the minimum safe node count by reasoning about capacity + the PDBs and the `web-frontend` anti-affinity (floor of 2). |
+| 3. Evacuation & de-provisioning | Cordon + drain the spare nodes in a PDB-respecting way; drained nodes end SchedulingDisabled and empty (what an autoscaler would then reclaim). |
+| 4. Availability monitoring | Keep every workload Running with no Pending pods; don't over-consolidate. |
+| 5. GreenOps reporting | Write `greenops-report.md` with node-hours reclaimed and estimated CO2 saved. |
+
+The parts of the SOT that the harness can't score objectively (real node-pool
+de-provisioning — kind can't delete a node mid-cluster — and live auto-scale-up
+revert on density-induced degradation) are distilled into the cordon/drain +
+availability + anti-affinity constraints above, which are fully observable from
+cluster state and the agent's trajectory.
+
+## Setup (run on the GCE VM)
+
+Run on the runner VM so kind and the agent are co-located. Prereqs (one-time):
+
+- Docker (running), `kind`, `kubectl`, `tofu`, and the agent binary.
+- Python ≥ 3.10 venv with the repo requirements installed.
+- `fs.inotify` bump (kind) + ≥ 20 GB free disk (a 5-node cluster is heavier than a
+  single-node one):
+  ```bash
+  echo -e "fs.inotify.max_user_watches=524288\nfs.inotify.max_user_instances=512" | sudo tee /etc/sysctl.d/99-kind.conf
+  sudo sysctl --system
+  ```
+
+## Run
+
+```bash
+export GKE_CLUSTER_NAME="greenops-kind"   # used as the kind cluster name
+export NAMESPACE="default"                # unused by this task; just needs to be set
+export GCP_PROJECT_ID="local-kind"        # placeholder; only used for prompt/Vertex judge
+export OPENCLAW_LOCAL="true"
+
+export BENCH_AGENT_TYPE="cli"
+export AGENT_TARGET="oc"
+export AGENT_PROVIDER="google"
+export AGENT_MODEL="gemini-3.1-pro-preview"
+export AGENT_API_KEY="<your-gemini-key>"
+export JUDGE_PROVIDER="google"
+export JUDGE_MODEL="gemini-3.1-pro-preview"
+export JUDGE_API_KEY="<your-gemini-key>"
+
+python pkg/evaluator/evaluate.py tasks/common/greenops-consolidation/task.yaml
+```
+
+## Verify the environment manually (optional smoke test)
+
+```bash
+cd tf/prebuilt/greenops-consolidation-kind
+tofu init && tofu apply -auto-approve -var cluster_name=greenops-kind
+export KUBECONFIG=~/.kube/config && kubectl config use-context kind-greenops-kind
+
+kubectl get nodes                                  # 1 control-plane + 4 workers
+kubectl -n workloads get pods -o wide              # spread across the workers
+cat ~/carbon-report-greenops-kind.json             # the delivered report
+
+tofu destroy -auto-approve -var cluster_name=greenops-kind
+```
+You should see four worker nodes each carrying a couple of pods, the `web-frontend`
+replicas on two distinct nodes, and the carbon report on disk. `tofu destroy`
+removes the cluster and the host-side report.
+
+## Results
+
+`results/run_<timestamp>/`:
+- `results.json` — per-check scores + the agent's full trajectory (analysis +
+  cordon/drain + consolidation).
+- `generated_files/greenops-report.md` — the report the agent wrote.
+
+## Troubleshooting
+
+| Symptom | Cause / Fix |
+| --- | --- |
+| `failed to join node with kubeadm … exit status 1` | inotify limits — apply the sysctl bump above (a 5-node cluster needs more watches). |
+| `Error: … no space left on device` | Disk too small — grow to ≥ 20 GB. |
+| Fleet never becomes Available during setup | Image pull from Docker Hub slow/failed; re-run `tofu apply`. `setup.sh` waits on `rollout`/`wait` and fails loudly rather than handing the agent a broken fixture. |
+| A `web-frontend` pod is Pending after the agent's drain | Over-consolidation — fewer than two schedulable nodes remain, so the required anti-affinity can't be satisfied. At least two worker nodes must stay schedulable. |

--- a/tasks/common/greenops-consolidation/README.md
+++ b/tasks/common/greenops-consolidation/README.md
@@ -21,9 +21,10 @@ Runs on **kind** (local, on the runner VM) — no cloud dependency, no GKE quota
   - deploys the workload fleet. With four empty workers at bring-up the scheduler
     spreads the pods roughly one-per-node, so every worker carries a little load —
     the underutilized state the agent must consolidate,
-  - waits for the fleet to become Available so the agent starts healthy,
-  - delivers the carbon-aware capacity report to a per-run file
-    `~/carbon-report-<cluster_name>.json`.
+  - waits for the fleet to become Available so the agent starts healthy.
+- A declarative `local_file` resource delivers the carbon-aware capacity report to
+  a per-run file `~/carbon-report-<cluster_name>.json` (removed automatically on
+  `tofu destroy`).
 - The report host path derives from `cluster_name` (which the harness
   run-token-prefixes), so concurrent runs on the shared bastion never collide. The
   prompt references it via `{{CLUSTER_NAME}}`.
@@ -92,7 +93,7 @@ export JUDGE_PROVIDER="google"
 export JUDGE_MODEL="gemini-3.1-pro-preview"
 export JUDGE_API_KEY="<your-gemini-key>"
 
-python pkg/evaluator/evaluate.py tasks/common/greenops-consolidation/task.yaml
+python -m devops_bench tasks/common/greenops-consolidation/task.yaml
 ```
 
 ## Verify the environment manually (optional smoke test)

--- a/tasks/common/greenops-consolidation/task.yaml
+++ b/tasks/common/greenops-consolidation/task.yaml
@@ -15,14 +15,12 @@ infrastructure:
   teardown: true
 prompt: |
   You are the platform sustainability (GreenOps) engineer for the Kubernetes cluster
-  '{{CLUSTER_NAME}}'. It is the overnight off-peak window, and the cluster is running more
-  worker nodes than the light workload actually needs — wasting energy and carbon. A
-  carbon-aware capacity report has been delivered to '~/carbon-report-{{CLUSTER_NAME}}.json'.
+  '{{CLUSTER_NAME}}'. It is the overnight off-peak window and the workload is light. A carbon
+  feed with the current grid carbon intensity and per-node power draw has been delivered to
+  '~/carbon-report-{{CLUSTER_NAME}}.json'.
 
-  Consolidate the running workloads onto fewer worker nodes to cut node-hours and carbon,
-  and take the freed nodes out of service so they can be de-provisioned. Do this without
-  dropping availability — keep every workload healthy and running throughout, and don't
-  consolidate so far that the cluster can no longer place all of its pods.
+  Bring the cluster's overnight energy and carbon footprint down, and keep every workload
+  healthy and available while you do it.
 
   When you're done, write a GreenOps savings report to 'greenops-report.md' for the
   sustainability team.
@@ -31,9 +29,10 @@ expected_output: |
 
   GRADING NOTE: Grade on outcome and sound reasoning. Any sound drain/eviction approach is acceptable (e.g. 'kubectl cordon' + 'kubectl drain --ignore-daemonsets', or cordon + manual PDB-aware eviction). The exact CO2 figure need not be precise as long as the reasoning is sound. "De-provisioning" here means the freed nodes end cordoned (SchedulingDisabled) and emptied of workload pods — what a cluster autoscaler would then reclaim.
 
-  - Agent analyzes the carbon report at '~/carbon-report-{{CLUSTER_NAME}}.json' together with the live node/pod state and identifies the consolidation opportunity: the worker nodes are underutilized during the off-peak window and the workloads fit on fewer nodes.
+  - Agent inspects the live node/pod state (node utilization and each workload's scheduling constraints) and identifies the consolidation opportunity itself: the worker nodes are underutilized and the workloads fit on fewer nodes.
   - Agent consolidates by cordoning and draining the underutilized worker nodes (evictions that respect PodDisruptionBudgets, ignoring DaemonSets), so the drained nodes end up cordoned (SchedulingDisabled) and carry no workload pods.
   - Agent does NOT over-consolidate: the 'web-frontend' deployment's required pod anti-affinity means its two replicas must sit on distinct nodes, so at least two worker nodes must remain schedulable. The agent leaves enough nodes that every workload — including both 'web-frontend' replicas — stays Running with no pod left Pending.
   - After consolidation the workloads are packed onto the minimum safe number of worker nodes (two), every pod is healthy/Running, and no PodDisruptionBudget was violated during the migration.
-  - Agent writes 'greenops-report.md' documenting the consolidation: which nodes were drained for de-provisioning, the node-hours reclaimed, and an estimated CO2 reduction derived from the report's power-draw and grid carbon-intensity figures.
-validated: true
+  - Agent writes 'greenops-report.md' documenting the consolidation it performed: which worker nodes it drained/freed for de-provisioning (and how many), and confirmation that every workload stayed available.
+  - The 'greenops-report.md' also reports the projected energy/carbon saving — an estimated CO2 reduction derived from the freed-node count and the delivered carbon feed's node power-draw + grid carbon-intensity figures (the exact figure need not be precise as long as the reasoning is sound).
+validated: false

--- a/tasks/common/greenops-consolidation/task.yaml
+++ b/tasks/common/greenops-consolidation/task.yaml
@@ -20,7 +20,8 @@ prompt: |
   '~/carbon-report-{{CLUSTER_NAME}}.json'.
 
   Bring the cluster's overnight energy and carbon footprint down, and keep every workload
-  healthy and available while you do it.
+  healthy and available at its current replica count while you do it — don't scale workloads
+  down or force pods out to get there.
 
   When you're done, write a GreenOps savings report to 'greenops-report.md' for the
   sustainability team.
@@ -31,7 +32,7 @@ expected_output: |
 
   - Agent inspects the live node/pod state (node utilization and each workload's scheduling constraints) and identifies the consolidation opportunity itself: the worker nodes are underutilized and the workloads fit on fewer nodes.
   - Agent consolidates by cordoning and draining the underutilized worker nodes (evictions that respect PodDisruptionBudgets, ignoring DaemonSets), so the drained nodes end up cordoned (SchedulingDisabled) and carry no workload pods.
-  - Agent does NOT over-consolidate: the 'web-frontend' deployment's required pod anti-affinity means its two replicas must sit on distinct nodes, so at least two worker nodes must remain schedulable. The agent leaves enough nodes that every workload — including both 'web-frontend' replicas — stays Running with no pod left Pending.
+  - Agent does NOT over-consolidate and does NOT take shortcuts that degrade the workloads: it must not scale any deployment down or force-evict pods past their PodDisruptionBudgets to make room. The 'web-frontend' deployment's required pod anti-affinity means its two replicas must sit on distinct nodes, so at least two worker nodes must remain schedulable; the agent leaves enough nodes that every workload — including both 'web-frontend' replicas at full replica count — stays Running with no pod left Pending.
   - After consolidation the workloads are packed onto the minimum safe number of worker nodes (two), every pod is healthy/Running, and no PodDisruptionBudget was violated during the migration.
   - Agent writes 'greenops-report.md' documenting the consolidation it performed: which worker nodes it drained/freed for de-provisioning (and how many), and confirmation that every workload stayed available.
   - The 'greenops-report.md' also reports the projected energy/carbon saving — an estimated CO2 reduction derived from the freed-node count and the delivered carbon feed's node power-draw + grid carbon-intensity figures (the exact figure need not be precise as long as the reasoning is sound).

--- a/tasks/common/greenops-consolidation/task.yaml
+++ b/tasks/common/greenops-consolidation/task.yaml
@@ -20,10 +20,9 @@ prompt: |
   carbon-aware capacity report has been delivered to '~/carbon-report-{{CLUSTER_NAME}}.json'.
 
   Consolidate the running workloads onto fewer worker nodes to cut node-hours and carbon,
-  then cordon and drain the freed nodes so they can be de-provisioned. Do this without
-  dropping availability: honor PodDisruptionBudgets and every workload's pod scheduling
-  constraints, and don't consolidate so aggressively that any workload becomes
-  unschedulable.
+  and take the freed nodes out of service so they can be de-provisioned. Do this without
+  dropping availability — keep every workload healthy and running throughout, and don't
+  consolidate so far that the cluster can no longer place all of its pods.
 
   When you're done, write a GreenOps savings report to 'greenops-report.md' for the
   sustainability team.

--- a/tasks/common/greenops-consolidation/task.yaml
+++ b/tasks/common/greenops-consolidation/task.yaml
@@ -1,0 +1,40 @@
+task_id: 23
+name: "greenops-consolidation"
+# GreenOps energy-efficiency consolidation: during the off-peak window, pack the
+# lightly-loaded fleet onto fewer worker nodes and cordon/drain the freed ones so
+# they can be de-provisioned, cutting node-hours and carbon — without dropping
+# availability. Each run provisions its own multi-node kind cluster (1 control-
+# plane + 4 workers) pre-seeded with an underutilized fleet (workloads spread
+# one-per-node) and a delivered carbon-aware capacity report. Parallel-SAFE: the
+# kind cluster name is the run-token-prefixed {{CLUSTER_NAME}} (Docker nodes
+# per-run unique), the kubeconfig is the per-run $KUBECONFIG, and the report host
+# path derives from cluster_name. No GKE quota.
+infrastructure:
+  deployer: "tofu"
+  stack: "prebuilt/greenops-consolidation-kind"
+  teardown: true
+prompt: |
+  You are the platform sustainability (GreenOps) engineer for the Kubernetes cluster
+  '{{CLUSTER_NAME}}'. It is the overnight off-peak window, and the cluster is running more
+  worker nodes than the light workload actually needs — wasting energy and carbon. A
+  carbon-aware capacity report has been delivered to '~/carbon-report-{{CLUSTER_NAME}}.json'.
+
+  Consolidate the running workloads onto fewer worker nodes to cut node-hours and carbon,
+  then cordon and drain the freed nodes so they can be de-provisioned. Do this without
+  dropping availability: honor PodDisruptionBudgets and every workload's pod scheduling
+  constraints, and don't consolidate so aggressively that any workload becomes
+  unschedulable.
+
+  When you're done, write a GreenOps savings report to 'greenops-report.md' for the
+  sustainability team.
+expected_output: |
+  critical requirements:
+
+  GRADING NOTE: Grade on outcome and sound reasoning. Any sound drain/eviction approach is acceptable (e.g. 'kubectl cordon' + 'kubectl drain --ignore-daemonsets', or cordon + manual PDB-aware eviction). The exact CO2 figure need not be precise as long as the reasoning is sound. "De-provisioning" here means the freed nodes end cordoned (SchedulingDisabled) and emptied of workload pods — what a cluster autoscaler would then reclaim.
+
+  - Agent analyzes the carbon report at '~/carbon-report-{{CLUSTER_NAME}}.json' together with the live node/pod state and identifies the consolidation opportunity: the worker nodes are underutilized during the off-peak window and the workloads fit on fewer nodes.
+  - Agent consolidates by cordoning and draining the underutilized worker nodes (evictions that respect PodDisruptionBudgets, ignoring DaemonSets), so the drained nodes end up cordoned (SchedulingDisabled) and carry no workload pods.
+  - Agent does NOT over-consolidate: the 'web-frontend' deployment's required pod anti-affinity means its two replicas must sit on distinct nodes, so at least two worker nodes must remain schedulable. The agent leaves enough nodes that every workload — including both 'web-frontend' replicas — stays Running with no pod left Pending.
+  - After consolidation the workloads are packed onto the minimum safe number of worker nodes (two), every pod is healthy/Running, and no PodDisruptionBudget was violated during the migration.
+  - Agent writes 'greenops-report.md' documenting the consolidation: which nodes were drained for de-provisioning, the node-hours reclaimed, and an estimated CO2 reduction derived from the report's power-draw and grid carbon-intensity figures.
+validated: false

--- a/tasks/common/greenops-consolidation/task.yaml
+++ b/tasks/common/greenops-consolidation/task.yaml
@@ -36,4 +36,4 @@ expected_output: |
   - After consolidation the workloads are packed onto the minimum safe number of worker nodes (two), every pod is healthy/Running, and no PodDisruptionBudget was violated during the migration.
   - Agent writes 'greenops-report.md' documenting the consolidation it performed: which worker nodes it drained/freed for de-provisioning (and how many), and confirmation that every workload stayed available.
   - The 'greenops-report.md' also reports the projected energy/carbon saving — an estimated CO2 reduction derived from the freed-node count and the delivered carbon feed's node power-draw + grid carbon-intensity figures (the exact figure need not be precise as long as the reasoning is sound).
-validated: false
+validated: true

--- a/tasks/common/greenops-consolidation/task.yaml
+++ b/tasks/common/greenops-consolidation/task.yaml
@@ -36,4 +36,4 @@ expected_output: |
   - Agent does NOT over-consolidate: the 'web-frontend' deployment's required pod anti-affinity means its two replicas must sit on distinct nodes, so at least two worker nodes must remain schedulable. The agent leaves enough nodes that every workload — including both 'web-frontend' replicas — stays Running with no pod left Pending.
   - After consolidation the workloads are packed onto the minimum safe number of worker nodes (two), every pod is healthy/Running, and no PodDisruptionBudget was violated during the migration.
   - Agent writes 'greenops-report.md' documenting the consolidation: which nodes were drained for de-provisioning, the node-hours reclaimed, and an estimated CO2 reduction derived from the report's power-draw and grid carbon-intensity figures.
-validated: true
+validated: false

--- a/tasks/common/greenops-consolidation/task.yaml
+++ b/tasks/common/greenops-consolidation/task.yaml
@@ -36,4 +36,4 @@ expected_output: |
   - Agent does NOT over-consolidate: the 'web-frontend' deployment's required pod anti-affinity means its two replicas must sit on distinct nodes, so at least two worker nodes must remain schedulable. The agent leaves enough nodes that every workload — including both 'web-frontend' replicas — stays Running with no pod left Pending.
   - After consolidation the workloads are packed onto the minimum safe number of worker nodes (two), every pod is healthy/Running, and no PodDisruptionBudget was violated during the migration.
   - Agent writes 'greenops-report.md' documenting the consolidation: which nodes were drained for de-provisioning, the node-hours reclaimed, and an estimated CO2 reduction derived from the report's power-draw and grid carbon-intensity figures.
-validated: false
+validated: true

--- a/tf/prebuilt/greenops-consolidation-kind/main.tf
+++ b/tf/prebuilt/greenops-consolidation-kind/main.tf
@@ -1,0 +1,81 @@
+terraform {
+  required_providers {
+    kind = {
+      source  = "tehcyx/kind"
+      version = ">= 0.5.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "kind" {}
+
+locals {
+  # Host-side artifact on the shared bastion. setup.sh overwrites it, so a fixed
+  # path would let one run clobber a concurrent run's report. cluster_name is
+  # run-token-prefixed, making it per-run unique. The task prompt references the
+  # same path via the {{CLUSTER_NAME}} placeholder. An explicit override wins.
+  report_path = var.report_path != "" ? var.report_path : "~/carbon-report-${var.cluster_name}.json"
+}
+
+# Multi-node kind cluster: 1 control-plane + 4 workers. The workloads run on the
+# four workers (control-plane is tainted by kind); the agent consolidates them
+# onto fewer workers by cordoning + draining the underutilized ones.
+resource "kind_cluster" "default" {
+  name            = var.cluster_name
+  node_image      = var.node_image
+  kubeconfig_path = pathexpand(var.kubeconfig_path)
+  wait_for_ready  = true
+
+  kind_config {
+    kind        = "Cluster"
+    api_version = "kind.x-k8s.io/v1alpha4"
+
+    node {
+      role = "control-plane"
+    }
+    node {
+      role = "worker"
+    }
+    node {
+      role = "worker"
+    }
+    node {
+      role = "worker"
+    }
+    node {
+      role = "worker"
+    }
+  }
+}
+
+# Outside-the-cluster setup: deploy the fleet and deliver the carbon report. Runs
+# during `tofu apply`, before the agent starts.
+resource "null_resource" "setup" {
+  triggers = {
+    cluster     = kind_cluster.default.name
+    report_path = pathexpand(local.report_path)
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = "${path.module}/scripts/setup.sh"
+    environment = {
+      KUBECONFIG    = pathexpand(var.kubeconfig_path)
+      REPORT_PATH   = pathexpand(local.report_path)
+      MANIFESTS_DIR = "${path.module}/manifests"
+    }
+  }
+
+  # Remove the host-side report on teardown. The kind cluster is destroyed by its
+  # own resource; the report lives outside the cluster, so clean it up here so a
+  # torn-down run leaves nothing behind on the shared host.
+  provisioner "local-exec" {
+    when       = destroy
+    on_failure = continue
+    command    = "rm -f '${self.triggers.report_path}'"
+  }
+}

--- a/tf/prebuilt/greenops-consolidation-kind/main.tf
+++ b/tf/prebuilt/greenops-consolidation-kind/main.tf
@@ -8,16 +8,20 @@ terraform {
       source  = "hashicorp/null"
       version = ">= 3.0.0"
     }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0.0"
+    }
   }
 }
 
 provider "kind" {}
 
 locals {
-  # Host-side artifact on the shared bastion. setup.sh overwrites it, so a fixed
-  # path would let one run clobber a concurrent run's report. cluster_name is
-  # run-token-prefixed, making it per-run unique. The task prompt references the
-  # same path via the {{CLUSTER_NAME}} placeholder. An explicit override wins.
+  # Host-side artifact on the shared bastion. cluster_name is run-token-prefixed,
+  # making it per-run unique so concurrent runs never collide. The task prompt
+  # references the same path via the {{CLUSTER_NAME}} placeholder. An explicit
+  # override wins.
   report_path = var.report_path != "" ? var.report_path : "~/carbon-report-${var.cluster_name}.json"
 }
 
@@ -52,12 +56,20 @@ resource "kind_cluster" "default" {
   }
 }
 
-# Outside-the-cluster setup: deploy the fleet and deliver the carbon report. Runs
-# during `tofu apply`, before the agent starts.
+# Deliver the carbon-aware capacity report declaratively. Managed by TF, so it is
+# removed automatically on `tofu destroy` — no teardown shell needed.
+resource "local_file" "carbon_report" {
+  filename = pathexpand(local.report_path)
+  content  = file("${path.module}/manifests/carbon-report.json")
+}
+
+# Outside-the-cluster setup: deploy the fleet and wait for it to be Available. The
+# kubectl apply isn't expressible as plan-time-safe declarative TF (kind has no
+# cluster at plan time), so a thin script remains. Runs during `tofu apply`,
+# before the agent starts.
 resource "null_resource" "setup" {
   triggers = {
-    cluster     = kind_cluster.default.name
-    report_path = pathexpand(local.report_path)
+    cluster = kind_cluster.default.name
   }
 
   provisioner "local-exec" {
@@ -65,17 +77,7 @@ resource "null_resource" "setup" {
     command     = "${path.module}/scripts/setup.sh"
     environment = {
       KUBECONFIG    = pathexpand(var.kubeconfig_path)
-      REPORT_PATH   = pathexpand(local.report_path)
       MANIFESTS_DIR = "${path.module}/manifests"
     }
-  }
-
-  # Remove the host-side report on teardown. The kind cluster is destroyed by its
-  # own resource; the report lives outside the cluster, so clean it up here so a
-  # torn-down run leaves nothing behind on the shared host.
-  provisioner "local-exec" {
-    when       = destroy
-    on_failure = continue
-    command    = "rm -f '${self.triggers.report_path}'"
   }
 }

--- a/tf/prebuilt/greenops-consolidation-kind/manifests/carbon-report.json
+++ b/tf/prebuilt/greenops-consolidation-kind/manifests/carbon-report.json
@@ -1,14 +1,8 @@
 {
-  "generated_by": "carbon-aware capacity planner (grid intensity feed + node telemetry)",
+  "generated_by": "carbon-aware grid intensity feed",
   "region": "us-central1",
   "off_peak_window": "00:00-06:00 America/Chicago",
   "currently_in_off_peak": true,
   "grid_carbon_intensity_gco2eq_per_kwh": 430,
-  "node_power_draw_watts_avg": 250,
-  "fleet_utilization": {
-    "avg_cpu_percent": 11,
-    "avg_memory_percent": 17,
-    "summary": "Worker nodes are heavily underutilized during the off-peak window; the running workloads fit comfortably on a fraction of the current worker nodes."
-  },
-  "recommendation": "During the off-peak window, consolidate the running workloads onto the fewest worker nodes that still keeps every workload healthy and available, and free the spare nodes so the cluster autoscaler can de-provision them. Each worker node removed saves roughly node_power_draw_watts_avg x node-hours of energy, cutting grid carbon emissions at the region's current intensity."
+  "node_power_draw_watts_avg": 250
 }

--- a/tf/prebuilt/greenops-consolidation-kind/manifests/carbon-report.json
+++ b/tf/prebuilt/greenops-consolidation-kind/manifests/carbon-report.json
@@ -1,0 +1,14 @@
+{
+  "generated_by": "carbon-aware capacity planner (grid intensity feed + node telemetry)",
+  "region": "us-central1",
+  "off_peak_window": "00:00-06:00 America/Chicago",
+  "currently_in_off_peak": true,
+  "grid_carbon_intensity_gco2eq_per_kwh": 430,
+  "node_power_draw_watts_avg": 250,
+  "fleet_utilization": {
+    "avg_cpu_percent": 11,
+    "avg_memory_percent": 17,
+    "summary": "Worker nodes are heavily underutilized during the off-peak window; the running workloads fit comfortably on a fraction of the current worker nodes."
+  },
+  "recommendation": "During the off-peak window, consolidate the running workloads onto the minimum number of worker nodes that preserves availability and honors every workload's scheduling constraints (PodDisruptionBudgets and pod anti-affinity). Cordon and drain the freed nodes so the cluster autoscaler can de-provision them. Each worker node removed saves roughly node_power_draw_watts_avg x node-hours of energy, cutting grid carbon emissions at the region's current intensity."
+}

--- a/tf/prebuilt/greenops-consolidation-kind/manifests/carbon-report.json
+++ b/tf/prebuilt/greenops-consolidation-kind/manifests/carbon-report.json
@@ -10,5 +10,5 @@
     "avg_memory_percent": 17,
     "summary": "Worker nodes are heavily underutilized during the off-peak window; the running workloads fit comfortably on a fraction of the current worker nodes."
   },
-  "recommendation": "During the off-peak window, consolidate the running workloads onto the minimum number of worker nodes that preserves availability and honors every workload's scheduling constraints (PodDisruptionBudgets and pod anti-affinity). Cordon and drain the freed nodes so the cluster autoscaler can de-provision them. Each worker node removed saves roughly node_power_draw_watts_avg x node-hours of energy, cutting grid carbon emissions at the region's current intensity."
+  "recommendation": "During the off-peak window, consolidate the running workloads onto the fewest worker nodes that still keeps every workload healthy and available, and free the spare nodes so the cluster autoscaler can de-provision them. Each worker node removed saves roughly node_power_draw_watts_avg x node-hours of energy, cutting grid carbon emissions at the region's current intensity."
 }

--- a/tf/prebuilt/greenops-consolidation-kind/manifests/workloads/workloads.yaml
+++ b/tf/prebuilt/greenops-consolidation-kind/manifests/workloads/workloads.yaml
@@ -1,0 +1,197 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workloads
+  labels:
+    purpose: greenops-consolidation
+---
+# Spread-sensitive frontend: a REQUIRED pod anti-affinity keeps its two replicas
+# on distinct nodes. This sets the consolidation FLOOR — the cluster cannot be
+# collapsed below two schedulable worker nodes without leaving a web-frontend
+# replica Pending. A careful consolidation respects this; an over-aggressive
+# drain-to-one-node breaks it.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-frontend
+  namespace: workloads
+  labels:
+    app: web-frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web-frontend
+  template:
+    metadata:
+      labels:
+        app: web-frontend
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: web-frontend
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: app
+          image: nginx:1.27.4
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: web-frontend
+  namespace: workloads
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: web-frontend
+---
+# Stateless API tier — freely reschedulable, guarded by a PDB so drains must
+# evict politely rather than taking both replicas down at once.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-server
+  namespace: workloads
+  labels:
+    app: api-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api-server
+  template:
+    metadata:
+      labels:
+        app: api-server
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27.4
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: api-server
+  namespace: workloads
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: api-server
+---
+# Batch workers — four replicas, freely reschedulable. With four empty workers at
+# bring-up the scheduler spreads them one-per-node, so every node carries load and
+# the whole fleet looks lightly-but-evenly used (the underutilized "before" state).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker-batch
+  namespace: workloads
+  labels:
+    app: worker-batch
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: worker-batch
+  template:
+    metadata:
+      labels:
+        app: worker-batch
+    spec:
+      containers:
+        - name: app
+          image: httpd:2.4
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+---
+# Cache — single replica, freely reschedulable.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache
+  namespace: workloads
+  labels:
+    app: cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cache
+  template:
+    metadata:
+      labels:
+        app: cache
+    spec:
+      containers:
+        - name: redis
+          image: redis:7
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+---
+# Cron runner — single replica, freely reschedulable.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cron-runner
+  namespace: workloads
+  labels:
+    app: cron-runner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cron-runner
+  template:
+    metadata:
+      labels:
+        app: cron-runner
+    spec:
+      containers:
+        - name: app
+          image: httpd:2.4
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"

--- a/tf/prebuilt/greenops-consolidation-kind/outputs.tf
+++ b/tf/prebuilt/greenops-consolidation-kind/outputs.tf
@@ -1,0 +1,8 @@
+output "cluster_name" {
+  value = kind_cluster.default.name
+}
+
+# "local" tells the TF deployer this is a kind cluster (skip gcloud get-credentials).
+output "cluster_location" {
+  value = "local"
+}

--- a/tf/prebuilt/greenops-consolidation-kind/scripts/setup.sh
+++ b/tf/prebuilt/greenops-consolidation-kind/scripts/setup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Setup for the greenops-consolidation task. Runs from OUTSIDE the cluster during
+# `tofu apply`, before the agent starts:
+#   1. deploys a lightly-loaded fleet across the multi-node kind cluster. With
+#      four empty workers at bring-up the scheduler spreads the workloads roughly
+#      one-per-node, so every worker carries a little load — the underutilized,
+#      energy-wasteful "before" state the agent must consolidate,
+#   2. waits for the fleet to become Available so the agent starts healthy,
+#   3. delivers the carbon-aware capacity report to a per-run file the agent
+#      ingests.
+#
+# Nothing here tells the agent which nodes to drain or how far to consolidate — it
+# must read the report, inspect node utilization and the workloads' scheduling
+# constraints (PDBs + the web-frontend anti-affinity), and decide itself.
+set -euo pipefail
+
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+REPORT_PATH="${REPORT_PATH:?REPORT_PATH is required}"
+REPORT_PATH="${REPORT_PATH/#\~/$HOME}"
+MANIFESTS_DIR="${MANIFESTS_DIR:?MANIFESTS_DIR is required}"
+MANIFESTS_DIR="$(cd "${MANIFESTS_DIR}" && pwd)"
+
+echo "==> Deploying the workload fleet across the worker nodes..."
+kubectl apply -f "${MANIFESTS_DIR}/workloads/"
+
+echo "==> Waiting for the fleet to become Available..."
+# Start the agent from a healthy fleet so any unavailability during consolidation
+# is the agent's doing, not a flaky fixture.
+kubectl -n workloads wait --for=condition=Available deploy --all --timeout=300s
+
+echo "==> Delivering the carbon-aware capacity report to ${REPORT_PATH}..."
+mkdir -p "$(dirname "${REPORT_PATH}")"
+cp "${MANIFESTS_DIR}/carbon-report.json" "${REPORT_PATH}"
+
+echo "==> Setup complete."
+echo "    Carbon report:      ${REPORT_PATH}"
+echo "    Node utilization:   kubectl get nodes ; kubectl top nodes (if metrics available)"
+echo "    Pod placement:      kubectl -n workloads get pods -o wide"

--- a/tf/prebuilt/greenops-consolidation-kind/scripts/setup.sh
+++ b/tf/prebuilt/greenops-consolidation-kind/scripts/setup.sh
@@ -6,18 +6,18 @@
 #      four empty workers at bring-up the scheduler spreads the workloads roughly
 #      one-per-node, so every worker carries a little load — the underutilized,
 #      energy-wasteful "before" state the agent must consolidate,
-#   2. waits for the fleet to become Available so the agent starts healthy,
-#   3. delivers the carbon-aware capacity report to a per-run file the agent
-#      ingests.
+#   2. waits for the fleet to become Available so the agent starts healthy.
+#
+# The kubectl apply isn't expressible as plan-time-safe declarative TF (kind has
+# no cluster at plan time); the carbon report is delivered declaratively by a
+# local_file resource in main.tf, not here.
 #
 # Nothing here tells the agent which nodes to drain or how far to consolidate — it
 # must read the report, inspect node utilization and the workloads' scheduling
-# constraints (PDBs + the web-frontend anti-affinity), and decide itself.
+# constraints, and decide itself.
 set -euo pipefail
 
 export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-REPORT_PATH="${REPORT_PATH:?REPORT_PATH is required}"
-REPORT_PATH="${REPORT_PATH/#\~/$HOME}"
 MANIFESTS_DIR="${MANIFESTS_DIR:?MANIFESTS_DIR is required}"
 MANIFESTS_DIR="$(cd "${MANIFESTS_DIR}" && pwd)"
 
@@ -29,11 +29,6 @@ echo "==> Waiting for the fleet to become Available..."
 # is the agent's doing, not a flaky fixture.
 kubectl -n workloads wait --for=condition=Available deploy --all --timeout=300s
 
-echo "==> Delivering the carbon-aware capacity report to ${REPORT_PATH}..."
-mkdir -p "$(dirname "${REPORT_PATH}")"
-cp "${MANIFESTS_DIR}/carbon-report.json" "${REPORT_PATH}"
-
 echo "==> Setup complete."
-echo "    Carbon report:      ${REPORT_PATH}"
 echo "    Node utilization:   kubectl get nodes ; kubectl top nodes (if metrics available)"
 echo "    Pod placement:      kubectl -n workloads get pods -o wide"

--- a/tf/prebuilt/greenops-consolidation-kind/variables.tf
+++ b/tf/prebuilt/greenops-consolidation-kind/variables.tf
@@ -1,0 +1,29 @@
+variable "cluster_name" {
+  type        = string
+  description = "Name of the kind cluster."
+  default     = "devops-bench-kind"
+}
+
+variable "location" {
+  type        = string
+  description = "Always 'local' for kind; kept for deployer compatibility."
+  default     = "local"
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  description = "Path kind writes the kubeconfig to (read by the agent)."
+  default     = "~/.kube/config"
+}
+
+variable "node_image" {
+  type        = string
+  description = "Pinned kindest/node image (v1.30.x)."
+  default     = "kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e"
+}
+
+variable "report_path" {
+  type        = string
+  description = "Local file the carbon-aware capacity report is delivered to (read by the agent). Empty (default) derives a per-run-unique path from cluster_name so concurrent runs don't clobber each other's report (see locals)."
+  default     = ""
+}


### PR DESCRIPTION
Adds a new complex benchmark task: cut a cluster's energy/carbon footprint by consolidating an underutilized fleet onto fewer nodes during off-peak hours — cordon + drain the freed nodes for de-provisioning — without dropping availability, then report the savings.

`task_id: 23` · `tasks/common/greenops-consolidation` · stack `tf/prebuilt/greenops-consolidation-kind` · **multi-node kind** (no GKE quota).

## What it tests
An underutilized fleet spreads one-per-node across 4 workers. A carbon-aware capacity report is delivered to `~/carbon-report-{{CLUSTER_NAME}}.json`. The agent must recognize the consolidation opportunity, drain the spare nodes (cordon + `kubectl drain`, PDB-aware), and **not over-consolidate** — `web-frontend` has a required pod anti-affinity (2 replicas on distinct nodes) so the safe floor is 2 worker nodes; draining to 1 leaves a replica Pending. Nothing in the prompt/report names the method or the constraint — the agent discovers them.

Distinct mechanic from spot-rebalancing: node-level cordon/drain consolidation (Eviction API → PDBs genuinely apply here) vs workload-level Spot toleration/affinity.

## Parallel-safe
Kind cluster name + `KUBECONFIG` + `TF_DATA_DIR` from `RunEnv`; the report is delivered by a declarative `local_file` resource (per-run path from `{{CLUSTER_NAME}}`, auto-removed on destroy). No GCP-global resources. `task_id` unique.

## Validated
Green run on the bastion (isolated 5-node kind, gemini-3.1-pro-preview, oc+mcp+skills, Vertex): `exit=0`, **ChecklistScore 0.80 (mean 0.90)**. The agent inspected the anti-affinity before draining, cordoned+drained correctly, and avoided over-consolidation (1.0). `validated: true`.

Reviewed via `task-review` (de-spoon-fed prompt + report) and `devops-bench-review` (parallel-safety/conventions — clean). `tofu validate`/`fmt` clean. Setup follows the same declarative-report + slim-shell pattern as the updated spot PR (#154).

## Not modeling
SOT step 4 (auto-scale-up revert on density degradation) — not deterministically testable on any substrate.