### PR TITLE
chore(migration): flip core/ frontier to migrated

### DIFF
--- a/migrated.bara.sky
+++ b/migrated.bara.sky
@@ -18,8 +18,8 @@
 
 MIGRATED = [
     # --- Wave 2: foundation (core/), imported everywhere ---
-    # "devops_bench/core/**",
-    # "tests/unit/core/**",
+    "devops_bench/core/**",
+    "tests/unit/core/**",
 
     # --- Wave 3: leaves + bases (parallel) ---
     # tasks contracts (schema, loader)


### PR DESCRIPTION
Flips the migration frontier for the foundation package by uncommenting
`devops_bench/core/**` and `tests/unit/core/**` in `migrated.bara.sky`.

Effect once merged:
- Locks these paths **read-only** in gke-labs (the `check-migrated-readonly.sh` guard blocks further edits here — changes go upstream and mirror back).
- Activates the **back-sync** bot for `core/`.
- Unblocks Wave 3 PRs that import `core/`.

> [!IMPORTANT]
> **Do not merge until** the corresponding upstream change has landed.