### PR TITLE
fix(backsync): correct Copybara load label; encode migration-prep guardrails

### DIFF
--- a/.agents/skills/migration-prep/SKILL.md
+++ b/.agents/skills/migration-prep/SKILL.md
@@ -158,13 +158,32 @@ carry their license headers. **Green is the gate.** If it fails on a missing
 import/symbol, go back to step 3 — a dependency didn't travel. Fix, re-run. Never
 open the PR on red.
 
-### 6. Push + open the PR (prep only)
+### 6. Write the commit + PR text as fresh code, review, then push (prep only)
 
-Only after the gate is green:
+Only after the gate is green.
+
+**Frame it as a brand-new addition, not a migration (upstream's point of view).**
+From `kubernetes-sigs`' side this is a new project, not a port — the commit
+message and the PR title/body must read as if this code is being added to the
+repo for the first time:
+
+- Use "**add(s) …**" ("add the foundation package", never "migrate …").
+- **Do not** mention the migration, `gke-labs`, waves, the frontier, back-sync,
+  or dependency reconciliation (intra-repo *or* third-party) anywhere in the
+  upstream commit/PR text. Describe only what the code is and does.
+- `prep-export.sh`'s default message is migration-flavored — override it with
+  `-m "<fresh-code message>"` (or amend before pushing) so it reads as fresh code.
+
+**Review the commit message and PR title/body with the user before pushing.**
+Show them the exact text and get their sign-off (they may edit) — do not
+`git push` or `gh pr create` until they approve.
+
+Then, once approved:
 
 ```bash
 git push origin <branch>
-gh pr create --repo kubernetes-sigs/devops-bench --base main --fill
+gh pr create --repo kubernetes-sigs/devops-bench --base main \
+  --title "<fresh-code title>" --body "<fresh-code body>"   # not --fill
 ```
 
 Report: the PR chosen and why, the exact paths (impl + tests + any carried-along
@@ -188,6 +207,9 @@ the pr-plan principles:
 - [ ] **No cross-border imports** — every internal dependency is upstream or travels along.
 - [ ] **Third-party deps reconciled in-PR** — new external imports are added to
   `pyproject.toml` + `uv.lock` in this PR (manifests are `NEVER_SYNC`; deps land with their code).
+- [ ] **Upstream text reads as fresh code** — commit/PR say "add(s) …"; no
+  migration / `gke-labs` / wave / back-sync / dependency-reconciliation narrative.
+- [ ] **Commit + PR text reviewed with the user** before `git push` / `gh pr create`.
 - [ ] **DCO sign-off** on every commit (`git commit -s`; prep-export.sh does it).
 - [ ] **Boilerplate headers** on new files (where a header checker is installed).
 - [ ] **Superseded files removed** where the plan says so (e.g. chaos → `agents/chaos/`).
@@ -199,7 +221,11 @@ the pr-plan principles:
 
 - **Flipping the frontier after a merge** → don't do it here. The `suggest-flips`
   workflow uncomments merged paths in `migrated.bara.sky` and opens the flip PR
-  (README §2.2). Only fall back to a manual flip if asked.
+  (README §2.2). Only fall back to a manual flip if asked — and if you do, keep
+  the flip PR **self-contained: do not reference the forward/upstream PR** (no
+  `owner/repo#NN` or `#NN`) in its commit message or body, or GitHub will
+  cross-link the two repos. Say "merge after the corresponding upstream change
+  lands" instead.
 - **Editing an already-migrated (flipped) path** → that path is read-only in
   gke-labs; make the change upstream and let the back-sync bot mirror it. The
   `check-migrated-readonly.sh` guard will reject it otherwise.

--- a/.github/workflows/suggest-flips.yml
+++ b/.github/workflows/suggest-flips.yml
@@ -54,6 +54,8 @@ jobs:
           # Check if a PR already exists from this branch to prevent swallowing real token/policy failures
           PR_EXISTS=$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number')
           if [[ -z "$PR_EXISTS" ]]; then
+            # Keep the body self-contained: do NOT reference the forward/upstream PR
+            # (owner/repo#NN or #NN) — GitHub would cross-link gke-labs <-> kubernetes-sigs.
             gh pr create --base main --head "$BRANCH" \
               --title "Migration: flip modules now present upstream" \
               --body $'Auto-suggested flips. These entries were uncommented in `migrated.bara.sky` because their paths now exist in kubernetes-sigs. Review and merge to complete the flip: ownership moves upstream, the back-sync turns on, and the path becomes read-only here.'

--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -4,7 +4,9 @@
 
 # The frontier is the single source of truth in migrated.bara.sky, also parsed by the flip guard
 # and the tracker. (load() must stay at the top of the file.)
-load("//migrated.bara.sky", "MIGRATED")
+# NOTE: Copybara's load() appends ".bara.sky" to the label, so the label is "//migrated"
+# (NOT "//migrated.bara.sky", which would resolve to the non-existent migrated.bara.sky.bara.sky).
+load("//migrated", "MIGRATED")
 
 CANONICAL = "https://github.com/kubernetes-sigs/devops-bench.git"   # origin (public)
 GKE_LABS  = "https://github.com/gke-labs/devops-bench.git"          # destination (ours)

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -119,6 +119,9 @@ If you need to flip the frontier immediately without waiting for the scheduled w
    *Expected Outcome*: The uncommented paths will move from "not started" to the "Migrated" list.
 4. Merge this change into the `gke-labs` `main` branch via a standard pull request.
 
+> [!IMPORTANT]
+> Keep the flip PR **self-contained**: do **not** reference the forward/upstream PR (no `owner/repo#NN` or bare `#NN`) in its commit message or body. GitHub turns such references into a cross-repo backlink between `gke-labs` and `kubernetes-sigs`. Say "merge after the corresponding upstream change lands" instead. (The automated `suggest-flips` PR already avoids this.)
+
 > [!NOTE]
 > Uncommenting a line activates the **Read-Only Guard** in `gke-labs` CI. From this moment, any PR in `gke-labs` that attempts to mutate those paths will be rejected by `check-migrated-readonly.sh`. Edits must now be made upstream.
 


### PR DESCRIPTION
## Backsync fix (root cause)

The back-sync run failed with:

```
ERROR: Cannot find '//migrated.bara.sky.bara.sky'. '/usr/src/app/migrated.bara.sky.bara.sky' does not exist.
```

`copy.bara.sky` used `load("//migrated.bara.sky", "MIGRATED")`. Copybara's `load()` **appends `.bara.sky`** to the label, so `//migrated.bara.sky` resolves to `migrated.bara.sky.bara.sky` (which doesn't exist). Fixed by loading `//migrated` (the file is `migrated.bara.sky`), with a comment so it isn't reintroduced.

## Process guardrails encoded in the migration-prep skill + docs

- **Fresh-code framing**: upstream commit/PR text must read as newly-added code (`add(s) …`), with no migration / `gke-labs` / wave / back-sync / dependency-reconciliation narrative.
- **Review before push**: show the commit message and PR title/body to the user and get sign-off before `git push` / `gh pr create`.
- **No cross-repo linking on manual flips**: a manual frontier-flip PR must not reference the forward/upstream PR (`owner/repo#NN`), or GitHub cross-links the two repos. Reinforced with a comment in `suggest-flips.yml` (the automated flip already avoids it).

Touches only gke-labs-only files (`copy.bara.sky`, migration skill, `docs/migration/`, `suggest-flips.yml`) — nothing migrated/read-only.