### PR TITLE
docs(tasks): add reference documentation and constraints to noop tasks

### DIFF
--- a/tasks/noop/gateway-https-redirect/task.yaml
+++ b/tasks/noop/gateway-https-redirect/task.yaml
@@ -30,3 +30,13 @@ expected_output: |
         requestRedirect:
           scheme: https
           statusCode: 301
+documentation:
+  - doc_name: "Deploying Gateways - Force HTTPS redirection"
+    url: "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways"
+    constraints:
+      - text: "type: RequestRedirect"
+        critical: true
+      - text: "scheme: https"
+        critical: true
+      - text: "statusCode: 301"
+        critical: true

--- a/tasks/noop/gateway-https-redirect/task.yaml
+++ b/tasks/noop/gateway-https-redirect/task.yaml
@@ -32,7 +32,7 @@ expected_output: |
           statusCode: 301
 documentation:
   - doc_name: "Deploying Gateways - Force HTTPS redirection"
-    url: "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways"
+    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways"
     constraints:
       - text: "type: RequestRedirect"
         critical: true

--- a/tasks/noop/hpa-metric-filtering/task.yaml
+++ b/tasks/noop/hpa-metric-filtering/task.yaml
@@ -27,3 +27,13 @@ expected_output: |
         filter:
           matchLabels:
             version: v2
+documentation:
+  - doc_name: "Expose custom metrics for autoscaling"
+    url: "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/expose-custom-metrics-autoscaling"
+    constraints:
+      - text: "kind: AutoscalingMetric"
+        critical: true
+      - text: "name: http_requests_total"
+        critical: true
+      - text: "version: v2"
+        critical: true

--- a/tasks/noop/hpa-metric-filtering/task.yaml
+++ b/tasks/noop/hpa-metric-filtering/task.yaml
@@ -29,9 +29,11 @@ expected_output: |
             version: v2
 documentation:
   - doc_name: "Expose custom metrics for autoscaling"
-    url: "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/expose-custom-metrics-autoscaling"
+    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/expose-custom-metrics-autoscaling"
     constraints:
       - text: "kind: AutoscalingMetric"
+        critical: true
+      - text: "matchLabels:"
         critical: true
       - text: "name: http_requests_total"
         critical: true

--- a/tasks/noop/hpa-renamed-metric/task.yaml
+++ b/tasks/noop/hpa-renamed-metric/task.yaml
@@ -46,3 +46,14 @@ expected_output: |
         target:
           type: AverageValue
           averageValue: 100
+documentation:
+  - doc_name: "Expose custom metrics for autoscaling"
+    url: "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/expose-custom-metrics-autoscaling"
+    constraints:
+      - text: "autoscaling.gke.io|"
+        critical: true
+  - doc_name: "Expose custom metrics for load balancers"
+    url: "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/expose-custom-metrics-load-balancer"
+    constraints:
+      - text: "exportName"
+        critical: true

--- a/tasks/noop/hpa-renamed-metric/task.yaml
+++ b/tasks/noop/hpa-renamed-metric/task.yaml
@@ -48,12 +48,9 @@ expected_output: |
           averageValue: 100
 documentation:
   - doc_name: "Expose custom metrics for autoscaling"
-    url: "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/expose-custom-metrics-autoscaling"
+    url: "https://cloud.google.com/kubernetes-engine/docs/how-to/expose-custom-metrics-autoscaling"
     constraints:
-      - text: "autoscaling.gke.io|"
+      - text: "autoscaling.gke.io|web-metric|renamed_metric"
         critical: true
-  - doc_name: "Expose custom metrics for load balancers"
-    url: "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/expose-custom-metrics-load-balancer"
-    constraints:
-      - text: "exportName"
+      - text: "prometheusMetricName:"
         critical: true


### PR DESCRIPTION
Add documentation links and critical validation constraints to:
- gateway-https-redirect: Gateway deployment and HTTPS redirection
- hpa-metric-filtering: Custom metrics for autoscaling
- hpa-renamed-metric: Custom metrics for autoscaling and load balancers