### PR TITLE
fix(agents): forward KUBECONFIG/CLOUDSDK_CONFIG to spawned MCP servers

### DIFF
--- a/devops_bench/agents/api/agent.py
+++ b/devops_bench/agents/api/agent.py
@@ -291,6 +291,7 @@ async def _run_async(
     client: LLMClient,
     prompt: str,
     mcp_server_path: str | None,
+    mcp_server_env: tuple[tuple[str, str], ...],
     skills_paths: tuple[str, ...],
     rules_text: str | None,
     max_turns: int,
@@ -307,6 +308,9 @@ async def _run_async(
         prompt: Task prompt seeding the loop.
         mcp_server_path: Command launching the MCP server, or ``None`` to skip
             MCP entirely.
+        mcp_server_env: Extra ``(key, value)`` pairs for the spawned MCP
+            server's environment (``McpBinding.env``); ignored when
+            ``mcp_server_path`` is ``None``.
         skills_paths: Filesystem locations to discover local skills under.
         rules_text: Operator-brief text (the ``AgentRules.text`` payload)
             handed to the provider as the ``system_instruction``; ``None`` /
@@ -336,7 +340,7 @@ async def _run_async(
         )
         return loop_result, errors, skill_names
 
-    async with MCPClient(mcp_server_path) as mcp_client:
+    async with MCPClient(mcp_server_path, env=mcp_server_env) as mcp_client:
         tools = await _gather_tools(mcp_client, skill_tools)
         formatted = client.format_tools(tools)
         dispatch = _build_dispatch(mcp_client, skill_resources, errors)
@@ -408,7 +412,10 @@ class ApiAgent(AgentHarness):
         # an empty-command binding is treated as "no MCP". ``shlex.join``
         # round-trips ``MCPClient``'s ``shlex.split`` so a spaced argv token
         # (``("uv run", "mcp-server")``) is rebuilt as a single quoted word.
-        mcp_server_path = shlex.join(mcp_binding.command) if mcp_binding and mcp_binding.command else None
+        mcp_server_path = (
+            shlex.join(mcp_binding.command) if mcp_binding and mcp_binding.command else None
+        )
+        mcp_server_env = mcp_binding.env if mcp_binding else ()
         skills_paths = self.config.capabilities.skills.paths
         rules_text = self.config.capabilities.rules.text
 
@@ -418,6 +425,7 @@ class ApiAgent(AgentHarness):
                     llm_client,
                     prompt,
                     mcp_server_path,
+                    mcp_server_env,
                     skills_paths,
                     rules_text,
                     max_turns,

--- a/devops_bench/agents/api/mcp.py
+++ b/devops_bench/agents/api/mcp.py
@@ -36,6 +36,11 @@ class MCPClient:
 
     Attributes:
         server_path: Command used to launch the MCP server over stdio.
+        env: Extra ``(key, value)`` pairs added to the server's environment,
+            on top of the ``mcp`` SDK's own safe default — never the full
+            process environment (config flows through ``AgentConfig``, never
+            a direct ``os.environ`` read, and a spawned MCP server must not
+            see credentials it wasn't explicitly given).
         session: The active ``ClientSession`` once entered, else ``None``.
 
     Raises:
@@ -43,15 +48,20 @@ class MCPClient:
         ValueError: If ``server_path`` is empty or whitespace-only (on enter).
     """
 
-    def __init__(self, server_path: str) -> None:
+    def __init__(self, server_path: str, env: tuple[tuple[str, str], ...] = ()) -> None:
         self.server_path = server_path
+        self.env = env
         self.exit_stack = AsyncExitStack()
         self.session: Any = None
 
     async def __aenter__(self) -> MCPClient:
         try:
             from mcp.client.session import ClientSession
-            from mcp.client.stdio import StdioServerParameters, stdio_client
+            from mcp.client.stdio import (
+                StdioServerParameters,
+                get_default_environment,
+                stdio_client,
+            )
         except ImportError as exc:  # pragma: no cover - exercised via MissingDependencyError
             raise MissingDependencyError("the API agent's MCP client", "mcp") from exc
 
@@ -65,10 +75,13 @@ class MCPClient:
                 "MCP server_path is empty; set AGENT_TARGET/MCP_SERVER_PATH to the "
                 "MCP server command."
             )
-        server_params = StdioServerParameters(command=parts[0], args=parts[1:])
-        stdio_transport = await self.exit_stack.enter_async_context(
-            stdio_client(server_params)
-        )
+        # Layer the caller-supplied env (McpBinding.env, e.g. KUBECONFIG) on top
+        # of the SDK's own safe default (PATH/HOME/etc.) rather than the full
+        # process environment, which would leak credentials to an arbitrary
+        # task/operator-configured binary.
+        server_env = {**get_default_environment(), **dict(self.env)}
+        server_params = StdioServerParameters(command=parts[0], args=parts[1:], env=server_env)
+        stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
         self.read_stream, self.write_stream = stdio_transport
         self.session = await self.exit_stack.enter_async_context(
             ClientSession(self.read_stream, self.write_stream)

--- a/devops_bench/agents/capabilities/mcp.py
+++ b/devops_bench/agents/capabilities/mcp.py
@@ -41,11 +41,18 @@ class McpBinding:
             passes these via ``--allowed-tools``; the API agent advertises
             whatever the live MCP server lists (this field acts as
             documentation / pre-approval there).
+        env: Extra ``(key, value)`` pairs to add to the MCP server's process
+            environment, layered on top of the ``mcp`` SDK's own safe default
+            (``PATH``/``HOME``/etc.) — never the full parent environment, so a
+            spawned MCP server never sees API keys / credentials it wasn't
+            explicitly given. A tuple (not a dict) so the frozen dataclass
+            stays hashable.
     """
 
     name: str = ""
     command: tuple[str, ...] = ()
     tools: tuple[str, ...] = ()
+    env: tuple[tuple[str, str], ...] = ()
 
 
 @runtime_checkable

--- a/devops_bench/agents/config.py
+++ b/devops_bench/agents/config.py
@@ -38,6 +38,31 @@ def _parse_csv(raw: str | None) -> tuple[str, ...]:
     return tuple(item.strip() for item in raw.split(",") if item.strip())
 
 
+# Env vars an MCP server's k8s/cloud tools need to target the run's cluster.
+# Deliberately a short, explicit allowlist rather than the full environment:
+# an MCP server is an arbitrary task/operator-configured binary, and it must
+# never see credentials (AGENT_API_KEY, GOOGLE_APPLICATION_CREDENTIALS, ...) it
+# wasn't explicitly given. Both vars are set by RunEnv for per-run isolation.
+_MCP_INHERITED_ENV_VARS = ("KUBECONFIG", "CLOUDSDK_CONFIG")
+
+
+def _mcp_env(env: Mapping[str, str] | None) -> tuple[tuple[str, str], ...]:
+    """Collect the allowlisted env vars an MCP server process should inherit.
+
+    Args:
+        env: Optional mapping read from (defaults to ``os.environ``).
+
+    Returns:
+        ``(key, value)`` pairs for each allowlisted var that is actually set;
+        empty when none are.
+    """
+    return tuple(
+        (key, value)
+        for key in _MCP_INHERITED_ENV_VARS
+        if (value := get_env(key, env=env)) is not None
+    )
+
+
 def _build_capabilities_from_env(env: Mapping[str, str] | None) -> AllCapabilities:
     """Build an :class:`AllCapabilities` aggregate from ``AGENT_*`` env vars.
 
@@ -63,7 +88,7 @@ def _build_capabilities_from_env(env: Mapping[str, str] | None) -> AllCapabiliti
         # ``name="default"`` is generic: env-driven from_env has no catalog to
         # pull a real name from, and the agent never inspects it.
         mcp_servers = (
-            McpBinding(name="default", command=mcp_command, tools=allowed_tools),
+            McpBinding(name="default", command=mcp_command, tools=allowed_tools, env=_mcp_env(env)),
         )
 
     skills_paths = _parse_csv(get_env("AGENT_SKILLS_PATHS", env=env))

--- a/tests/unit/agents/api/test_agents_api_agent.py
+++ b/tests/unit/agents/api/test_agents_api_agent.py
@@ -500,7 +500,7 @@ def test_execute_folds_assistant_tool_pairs_into_canonical_trajectory(monkeypatc
     mcp_advertised = [SimpleNamespace(name="do_thing", description="d", inputSchema=None)]
     mcp = _FakeMCPClient(tools=mcp_advertised)
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
-    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path, env=(): mcp)
 
     result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("ping")
 
@@ -548,7 +548,7 @@ def test_execute_dispatch_error_lands_in_errors_and_continues(monkeypatch):
     )
     mcp = _ExplodingMCP(tools=[SimpleNamespace(name="boom", description="d", inputSchema=None)])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
-    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path, env=(): mcp)
 
     result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("ping")
 
@@ -658,7 +658,7 @@ def test_execute_returns_errored_on_mcpclient_value_error(monkeypatch):
     """
 
     class _BoomMCP:
-        def __init__(self, _path: str) -> None: ...
+        def __init__(self, _path: str, env: tuple = ()) -> None: ...
 
         async def __aenter__(self) -> _BoomMCP:
             raise ValueError(
@@ -866,7 +866,7 @@ def test_execute_runs_with_mcp_only_no_skills(monkeypatch):
     mcp_tools = [SimpleNamespace(name="do_thing", description="d", inputSchema=None)]
     mcp = _FakeMCPClient(tools=mcp_tools)
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
-    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path, env=(): mcp)
 
     result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("p")
     assert result.errors == []
@@ -886,7 +886,7 @@ def test_execute_runs_with_both_mcp_and_skills(monkeypatch, tmp_path):
     fake = _FakeLLMClient([_Turn(text="working", calls=fc), _Turn(text="done")])
     mcp = _FakeMCPClient(tools=[SimpleNamespace(name="do_thing", description="d", inputSchema=None)])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
-    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path, env=(): mcp)
 
     caps = AllCapabilities(
         mcp_servers=(McpBinding(name="t", command=("server",)),),
@@ -968,7 +968,7 @@ def test_execute_preserves_spaced_command_token_through_shlex_roundtrip(monkeypa
     captured: dict = {}
 
     class _RecordingMCP(_FakeMCPClient):
-        def __init__(self, path: str) -> None:
+        def __init__(self, path: str, env: tuple = ()) -> None:
             super().__init__(tools=[])
             captured["path"] = path
 

--- a/tests/unit/agents/api/test_agents_api_mcp.py
+++ b/tests/unit/agents/api/test_agents_api_mcp.py
@@ -55,6 +55,54 @@ def test_mcp_client_enter_rejects_empty_server_path():
         asyncio.run(client.__aenter__())
 
 
+def test_mcp_client_enter_layers_binding_env_over_sdk_default(monkeypatch):
+    """The spawned server's env is the SDK's safe default plus ``McpBinding.env``.
+
+    Regression for a fix that first read ``os.environ`` directly (forwarding
+    every secret in the harness process to an arbitrary MCP server binary,
+    and violating the "config flows through AgentConfig" convention). The
+    correct behavior layers the caller-supplied env on top of the SDK's own
+    curated default — never the full process environment.
+    """
+    import mcp.client.session as session_mod
+    import mcp.client.stdio as stdio_mod
+
+    captured: dict = {}
+
+    class _FakeStdioCtx:
+        async def __aenter__(self):
+            return (SimpleNamespace(), SimpleNamespace())
+
+        async def __aexit__(self, *_a):
+            return False
+
+    class _FakeSession:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def initialize(self):
+            pass
+
+    def fake_stdio_client(server_params):
+        captured["env"] = server_params.env
+        return _FakeStdioCtx()
+
+    monkeypatch.setattr(stdio_mod, "get_default_environment", lambda: {"PATH": "/safe/bin"})
+    monkeypatch.setattr(stdio_mod, "stdio_client", fake_stdio_client)
+    monkeypatch.setattr(session_mod, "ClientSession", _FakeSession)
+
+    client = MCPClient("does-not-matter", env=(("KUBECONFIG", "/run/kubeconfig"),))
+    asyncio.run(client.__aenter__())
+
+    assert captured["env"] == {"PATH": "/safe/bin", "KUBECONFIG": "/run/kubeconfig"}
+
+
 def test_call_tool_degrades_gracefully_when_deepeval_missing(monkeypatch):
     """If ``deepeval`` is not installed, ``call_tool`` still works (untraced).
 

--- a/tests/unit/agents/test_agents_config.py
+++ b/tests/unit/agents/test_agents_config.py
@@ -118,6 +118,32 @@ def test_from_env_skips_mcp_binding_when_neither_command_nor_tools_set():
     assert cfg.capabilities.mcp_servers == ()
 
 
+def test_from_env_mcp_binding_forwards_only_the_kubeconfig_allowlist():
+    """The MCP binding's ``env`` carries KUBECONFIG/CLOUDSDK_CONFIG when set,
+    but never an unrelated (and potentially secret) var like AGENT_API_KEY —
+    the spawned MCP server must not see credentials it wasn't explicitly
+    given."""
+    cfg = AgentConfig.from_env(
+        {
+            "AGENT_MCP_SERVER": "/usr/local/bin/mcp-gke",
+            "AGENT_API_KEY": "super-secret",
+            "KUBECONFIG": "/run/kubeconfig",
+            "CLOUDSDK_CONFIG": "/run/gcloud",
+        }
+    )
+    (binding,) = cfg.capabilities.mcp_servers
+    assert dict(binding.env) == {
+        "KUBECONFIG": "/run/kubeconfig",
+        "CLOUDSDK_CONFIG": "/run/gcloud",
+    }
+
+
+def test_from_env_mcp_binding_env_omits_unset_allowlist_vars():
+    cfg = AgentConfig.from_env({"AGENT_MCP_SERVER": "/usr/local/bin/mcp-gke"})
+    (binding,) = cfg.capabilities.mcp_servers
+    assert binding.env == ()
+
+
 def test_from_env_blank_rules_text_yields_default_rules():
     cfg = AgentConfig.from_env({"AGENT_RULES_TEXT": ""})
     assert cfg.capabilities.rules == AgentRules()


### PR DESCRIPTION
## Summary
- The API agent's `MCPClient` spawns MCP servers over stdio using the `mcp` SDK, which does **not** inherit the parent process environment by default — `StdioServerParameters.env=None` falls back to a minimal safety allowlist (`PATH`/`HOME`/etc.), so `KUBECONFIG` never reached the spawned server and kubectl-backed MCP tools (e.g. `gke-mcp`) silently fell back to the ambient `~/.kube/config` instead of the run's isolated cluster.
- Fixed by threading env through `AgentConfig` rather than reading `os.environ` inside `agents/api/` (an architectural convention enforced by `test_agent_source_has_no_bench_use_mcp_or_environ_reads`): `McpBinding` gains an `env` field, populated in `config.py` from a short explicit allowlist (`KUBECONFIG`, `CLOUDSDK_CONFIG` — the vars `RunEnv` manages for per-run isolation), threaded through `ApiAgent` to `MCPClient`, which layers it on top of the SDK's own safe default rather than the full environment.
- Deliberately **not** a blanket `env=dict(os.environ)` — that would leak `AGENT_API_KEY`/`ANTHROPIC_API_KEY`/etc. to an arbitrary MCP server binary. Caught this exact regression via the architecture guardrail test and a security review pass; the final version passes both.

## Test plan
- [x] `pytest tests/unit -q` — 802/802 pass, including the architecture guardrail test
- [x] `ruff check` / `ruff format --check` clean on all touched files
- [x] Verified end-to-end against a real kind cluster + `gke-mcp`: confirmed `KUBECONFIG` now reaches the spawned MCP server and it successfully drives real `get_k8s_resource`/`list_k8s_events`/`delete_k8s_resource` tool calls against the live cluster
- [x] New unit tests: `test_mcp_client_enter_layers_binding_env_over_sdk_default` (mcp.py merges binding env over SDK default), `test_from_env_mcp_binding_forwards_only_the_kubeconfig_allowlist` / `test_from_env_mcp_binding_env_omits_unset_allowlist_vars` (config.py forwards only the allowlist, never secrets)