### PR TITLE
fix(migration): authenticate backsync copybara push (git 2.30-safe)

### DIFF
--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -48,6 +48,11 @@ NEVER_SYNC = [
     ".agents/skills/migration-prep/**",
     ".claude/skills/migration-prep",
     "docs/how-to/leaderboard.md",
+    # TEMP stopgap: core/model_providers.py is in gke-labs core/ but not yet exported to
+    # kubernetes-sigs, so the flipped core/** frontier would make the back-sync delete it. Exclude
+    # it until it lands upstream, then REMOVE these two lines so it reconciles like the rest of core/.
+    "devops_bench/core/model_providers.py",
+    "tests/unit/core/test_model_providers.py",
     "copy.bara.sky",
     "migrated.bara.sky",
     "pyproject.toml",

--- a/hack/backsync.sh
+++ b/hack/backsync.sh
@@ -33,6 +33,17 @@ done
 command -v docker >/dev/null 2>&1 || { echo "error: docker is required but not found on PATH" >&2; exit 1; }
 : "${GITHUB_TOKEN:?set GITHUB_TOKEN (e.g. export GITHUB_TOKEN=\$(gh auth token))}"
 
+# Copybara pushes over HTTPS with the container's git, which won't use GITHUB_TOKEN on its own.
+# The image ships git 2.30, so GIT_CONFIG_* (git >=2.31) is ignored; instead mount a gitconfig with
+# an inline credential helper that echoes the token from the container env. The token is never
+# written to disk — only the helper snippet is (it reads $GITHUB_TOKEN at credential time).
+GITCONFIG="$(mktemp)"
+trap 'rm -f "$GITCONFIG"' EXIT
+cat > "$GITCONFIG" <<'GITCFG'
+[credential "https://github.com"]
+    helper = "!f() { echo username=x-access-token; echo password=$GITHUB_TOKEN; }; f"
+GITCFG
+
 echo ">> copybara $WORKFLOW  (image: $COPYBARA_IMAGE)  args: ${EXTRA_ARGS[*]:-none}"
 
 set +e
@@ -44,6 +55,7 @@ docker run --rm \
   -w /usr/src/app \
   -e GITHUB_TOKEN \
   -e COPYBARA_CONFIG_ROOT=/usr/src/app \
+  -v "$GITCONFIG":/root/.gitconfig:ro \
   --entrypoint java \
   "$COPYBARA_IMAGE" \
   -jar /opt/copybara/copybara_deploy.jar \


### PR DESCRIPTION
## Problem
The scheduled `backsync.yml` (and local `hack/backsync.sh`) fails to push to gke-labs:
```
fatal: could not read Username for 'https://github.com': No such device or address
# → after credentials are present: remote: Permission ... 403
```
Copybara pushes over HTTPS using the **container's** git, which doesn't consume `GITHUB_TOKEN` on its own. The `anipos/copybara` image ships **git 2.30.2**, so the usual `GIT_CONFIG_COUNT/KEY/VALUE` credential-injection (git ≥ 2.31) is silently ignored — the token never reaches git.

## Fix
Mount a `~/.gitconfig` into the container with an **inline credential helper** (works on git 2.30) that echoes `x-access-token` / `$GITHUB_TOKEN` at credential time. The token stays in the container env (passed via `-e GITHUB_TOKEN`) and is **never written to disk** — only the helper snippet is. A `trap` removes the temp gitconfig on exit.

## Validation
- `bash -n` clean.
- Dry-run through the patched script loads copybara and builds the local commit ("skipped push to remote").
- The identical credential mechanism was validated end-to-end manually — it authenticated as `devops-bench-sync-bot` and opened the first back-sync PR (#171).

## Scope / notes
- Works for both CI (docker) and local runs (docker or the podman shim).
- `suggest-flips.yml` is **not** affected — it runs natively on the runner via `actions/checkout` token auth + `gh`, not the copybara container, so it has no git-2.30 / credential-mount issue.
- Requires `SYNC_BOT_TOKEN` to have **Contents + Pull requests: write** on gke-labs (already configured).
