### PR TITLE
tasks: add mesh-federation — cross-cluster Istio mTLS federation (kind)

### DIFF
--- a/tasks/common/mesh-federation/README.md
+++ b/tasks/common/mesh-federation/README.md
@@ -1,0 +1,116 @@
+# Cross-Cluster Service Mesh Federation (Istio multi-primary)
+
+This task evaluates an agent's ability to **operate a federated Istio service mesh
+spanning two clusters** — diagnose a broken cross-cluster call, reconcile a mutual
+TLS misconfiguration across the cluster boundary, and restore secure connectivity.
+
+Two kind clusters are joined as an Istio **multi-primary / multi-network** mesh
+(shared root CA, east-west gateways, cross-cluster endpoint discovery). A client in
+the first cluster calls a backend in the second. An mTLS mismatch is injected so
+the cross-cluster call fails the handshake; the agent must find and fix it.
+
+Runs on **kind** (two local clusters, on the runner VM) — no cloud dependency, no
+GKE quota. **It is the heaviest task in the suite** (two clusters + full Istio on
+each); run it at a **low `MAX_PARALLEL`**.
+
+## How it works
+
+- **Infrastructure** (`tf/prebuilt/mesh-federation-kind`) provisions **two** kind
+  clusters on the shared `kind` Docker network — `{{CLUSTER_NAME}}` (client) and
+  `{{CLUSTER_NAME}}-peer` (backend) — then runs `scripts/setup.sh`, which builds a
+  real federation:
+  - downloads a pinned `istioctl` + samples (the bastion has none),
+  - installs **MetalLB** on both clusters with non-overlapping pools carved from the
+    kind subnet, so the east-west gateways get mutually-reachable LoadBalancer IPs,
+  - installs a **shared root CA** (`cacerts`) in `istio-system` on both (federated
+    trust domain),
+  - installs **Istio multi-primary** control planes (mesh `mesh1`; per-cluster
+    name + network),
+  - installs **east-west gateways** + `expose-services` on both,
+  - exchanges **remote secrets** both directions (with the kind API-server IP
+    patched so the peer kubeconfig is reachable),
+  - deploys the `backend` (cluster-2) and a `sleep` client (cluster-1), with the
+    `backend` Service present in both clusters.
+- **The injected fault:** cluster-2's `sample` namespace enforces
+  `PeerAuthentication: STRICT`, while cluster-1 has a `DestinationRule` for the
+  backend host with `tls.mode: DISABLE`. The client therefore sends plaintext and
+  the server rejects it — the textbook STRICT-vs-DISABLE mTLS handshake failure.
+- **The agent** reproduces the failing call, localizes the mTLS mismatch across the
+  two clusters, reconciles it to a consistent mutual-TLS posture (without weakening
+  security), verifies the cross-cluster call is restored over mTLS, and reports.
+
+### How it maps to the source-of-truth scenario (Complex Task #10)
+
+| SOT step | Realization in this task |
+| --- | --- |
+| 1. Network/identity analysis | Diagnose across both clusters: reproduce the failing call, inspect the mesh mTLS config and the two trust domains. |
+| 2. Mesh expansion & trust federation | The shared root CA, east-west gateways, and remote-secret exchange are pre-established as the substrate (a real multi-primary mesh). |
+| 3. Traffic routing & protocol translation | Cross-cluster routing is via Istio endpoint discovery; the client→backend path is the federated route under test. |
+| 4. Real-time protocol validation | **The scored core** — detect the mTLS handshake failure and reconcile `PeerAuthentication`/`DestinationRule` to consistent strict mTLS. |
+| 5. Governance & connectivity report | Write `mesh-federation-report.md` with root cause, fix, and the restored secure posture. |
+
+Steps 2–3's *plumbing* is pre-built (it's kind-specific and not the skill under
+test); the agent's job is the cross-cluster **diagnosis + mTLS reconciliation**
+(steps 1, 4, 5), which is fully observable from cluster state and the trajectory.
+
+## Setup (run on the GCE VM)
+
+Run on the runner VM so both kind clusters and the agent are co-located. Prereqs:
+
+- Docker (running), `kind`, `kubectl`, `tofu`, `make`, `curl`, and the agent binary.
+- Python ≥ 3.10 venv with the repo requirements installed.
+- **Generous host headroom** — two clusters + Istio is heavy. `fs.inotify` bump and
+  **≥ 40 GB free disk** recommended:
+  ```bash
+  echo -e "fs.inotify.max_user_watches=524288\nfs.inotify.max_user_instances=512" | sudo tee /etc/sysctl.d/99-kind.conf
+  sudo sysctl --system
+  ```
+
+## Run
+
+```bash
+export GKE_CLUSTER_NAME="mesh-kind"    # base name; clusters are mesh-kind / mesh-kind-peer
+export NAMESPACE="sample"
+export GCP_PROJECT_ID="local-kind"     # placeholder; only used for prompt/Vertex judge
+export OPENCLAW_LOCAL="true"
+
+export BENCH_AGENT_TYPE="cli"; export AGENT_TARGET="oc"
+export AGENT_PROVIDER="google"; export AGENT_MODEL="gemini-3.1-pro-preview"
+export AGENT_API_KEY="<your-gemini-key>"
+export JUDGE_PROVIDER="google"; export JUDGE_MODEL="gemini-3.1-pro-preview"
+export JUDGE_API_KEY="<your-gemini-key>"
+
+python -m devops_bench tasks/common/mesh-federation/task.yaml
+```
+
+## Verify the environment manually (optional smoke test)
+
+```bash
+cd tf/prebuilt/mesh-federation-kind
+tofu init && tofu apply -auto-approve -var cluster_name=mesh-kind
+export KUBECONFIG=~/.kube/config
+
+# Both clusters + the federation
+kubectl --context kind-mesh-kind get pods -n istio-system
+kubectl --context kind-mesh-kind-peer get pods -n sample        # backend pods
+# Reproduce the failing cross-cluster call (should fail until fixed):
+kubectl --context kind-mesh-kind -n sample exec deploy/sleep -c sleep -- \
+  curl -sS -m 5 backend.sample.svc.cluster.local:8080 || echo "FAILS (as injected)"
+
+tofu destroy -auto-approve -var cluster_name=mesh-kind
+```
+
+## Results
+
+`results/run_<timestamp>/`:
+- `results.json` — per-check scores + the agent's full trajectory (diagnosis + fix).
+- `generated_files/mesh-federation-report.md` — the report the agent wrote.
+
+## Troubleshooting
+
+| Symptom | Cause / Fix |
+| --- | --- |
+| `failed to join node with kubeadm` | inotify limits — apply the sysctl bump (two clusters need more watches). |
+| `no space left on device` | Two clusters + Istio images are heavy — grow disk to ≥ 40 GB. |
+| east-west gateway stuck `<pending>` external IP | MetalLB pool didn't apply / overlaps — check `kubectl -n metallb-system get ipaddresspool`. |
+| cross-cluster call still fails after the agent's fix | Endpoint discovery not converged, or the remote secret's API server isn't reachable — check `istioctl remote-clusters` and that the remote secret server is the node's Docker IP. |

--- a/tasks/common/mesh-federation/task.yaml
+++ b/tasks/common/mesh-federation/task.yaml
@@ -40,4 +40,4 @@ expected_output: |
   - Agent reconciles the conflict so client and server agree on mutual TLS for the backend host (e.g. removes the offending DestinationRule or sets its tls mode to 'ISTIO_MUTUAL'), without simply disabling security (it does not weaken the backend to PERMISSIVE/disable mTLS to "fix" it).
   - After the fix, the cross-cluster call from the 'sleep' client succeeds (returns the backend's response from the peer cluster) and is served over mTLS.
   - Agent writes 'mesh-federation-report.md' documenting the root cause (the STRICT vs DISABLE mTLS mismatch across the two clusters), the remediation applied, and confirmation that cross-cluster traffic is restored and mutually authenticated.
-validated: false
+validated: true

--- a/tasks/common/mesh-federation/task.yaml
+++ b/tasks/common/mesh-federation/task.yaml
@@ -1,0 +1,43 @@
+task_id: 24
+name: "mesh-federation"
+# Cross-cluster Istio service-mesh federation. Each run provisions TWO kind
+# clusters joined as an Istio multi-primary / multi-network mesh (shared root CA,
+# east-west gateways, cross-cluster endpoint discovery), with a client workload in
+# cluster '{{CLUSTER_NAME}}' and a backend in cluster '{{CLUSTER_NAME}}-peer'. An
+# mTLS misconfiguration is injected so the cross-cluster call fails the handshake;
+# the agent must diagnose and restore secure connectivity.
+#
+# HEAVIEST task in the suite: two kind clusters + full Istio (istiod, east-west
+# gateways, MetalLB) on each. Run with a LOW MAX_PARALLEL — host disk/inotify/pods
+# sum across concurrent runs. No GKE quota (kind). Parallel-SAFE: both kind cluster
+# names derive from the run-token-prefixed {{CLUSTER_NAME}}, and the kubeconfig is
+# the per-run $KUBECONFIG.
+infrastructure:
+  deployer: "tofu"
+  stack: "prebuilt/mesh-federation-kind"
+  teardown: true
+prompt: |
+  You are the platform engineer on call for a federated Istio service mesh that spans two
+  Kubernetes clusters joined as a multi-primary mesh: '{{CLUSTER_NAME}}' (the client cluster)
+  and '{{CLUSTER_NAME}}-peer' (the backend cluster). Both are in your kubeconfig as the
+  contexts 'kind-{{CLUSTER_NAME}}' and 'kind-{{CLUSTER_NAME}}-peer'.
+
+  A 'sleep' client in the 'sample' namespace of the client cluster is supposed to reach the
+  'backend' service (hostname 'backend.sample.svc.cluster.local') whose pods run in the
+  'sample' namespace of the backend cluster. Right now that cross-cluster call is failing.
+
+  Investigate the failure across both clusters, restore secure cross-cluster communication so
+  the client can reach the backend again, and make sure the path is protected by mutual TLS
+  consistently across the mesh. When you're done, write a 'mesh-federation-report.md'
+  documenting the root cause, the fix, and the resulting security posture.
+expected_output: |
+  critical requirements:
+
+  GRADING NOTE: Grade on outcome — is the cross-cluster call restored AND served over mutual TLS? Any sound reconciliation of the conflicting mTLS configuration is acceptable (align the client to mesh mTLS, or otherwise make the client↔server mTLS posture consistent); do not require one specific edit. The federation plumbing (shared CA, east-west gateways, remote secrets) is already in place — the task is to diagnose and fix the mTLS break, not to rebuild the mesh.
+
+  - Agent diagnoses the failing cross-cluster call by inspecting both clusters (e.g. exec'ing the 'sleep' client to reproduce the failure, and examining the Istio mTLS configuration), rather than assuming a generic app bug.
+  - Agent identifies the mTLS mismatch: the backend cluster's 'sample' namespace enforces 'PeerAuthentication' STRICT, while the client cluster has a 'DestinationRule' for the backend host that DISABLES TLS — so the client sends plaintext and the server rejects the handshake.
+  - Agent reconciles the conflict so client and server agree on mutual TLS for the backend host (e.g. removes the offending DestinationRule or sets its tls mode to 'ISTIO_MUTUAL'), without simply disabling security (it does not weaken the backend to PERMISSIVE/disable mTLS to "fix" it).
+  - After the fix, the cross-cluster call from the 'sleep' client succeeds (returns the backend's response from the peer cluster) and is served over mTLS.
+  - Agent writes 'mesh-federation-report.md' documenting the root cause (the STRICT vs DISABLE mTLS mismatch across the two clusters), the remediation applied, and confirmation that cross-cluster traffic is restored and mutually authenticated.
+validated: false

--- a/tf/prebuilt/mesh-federation-kind/main.tf
+++ b/tf/prebuilt/mesh-federation-kind/main.tf
@@ -46,8 +46,9 @@ resource "kind_cluster" "c2" {
 # clusters and inject the mTLS fault. Runs during `tofu apply`, before the agent.
 resource "null_resource" "setup" {
   triggers = {
-    c1 = kind_cluster.c1.name
-    c2 = kind_cluster.c2.name
+    c1            = kind_cluster.c1.name
+    c2            = kind_cluster.c2.name
+    kubeconfig_c2 = pathexpand("${var.kubeconfig_path}-c2")
   }
 
   provisioner "local-exec" {
@@ -60,5 +61,13 @@ resource "null_resource" "setup" {
       MANIFESTS_DIR = "${path.module}/manifests"
       ISTIO_VERSION = var.istio_version
     }
+  }
+
+  # cluster-2 writes its own kubeconfig file; the kind cluster is destroyed by its
+  # resource, but that stray file would linger — remove it on teardown.
+  provisioner "local-exec" {
+    when       = destroy
+    on_failure = continue
+    command    = "rm -f '${self.triggers.kubeconfig_c2}'"
   }
 }

--- a/tf/prebuilt/mesh-federation-kind/main.tf
+++ b/tf/prebuilt/mesh-federation-kind/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  required_providers {
+    kind = {
+      source  = "tehcyx/kind"
+      version = ">= 0.5.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "kind" {}
+
+locals {
+  # Two run-scoped kind clusters. cluster-1 IS the harness-supplied
+  # (run-token-prefixed) cluster_name — the client/primary returned to the harness
+  # and addressable in the prompt as {{CLUSTER_NAME}}. cluster-2 appends "-peer"
+  # ({{CLUSTER_NAME}}-peer) and hosts the backend. Both are run-unique, so
+  # concurrent runs never collide on Docker container/node names.
+  c1 = var.cluster_name
+  c2 = "${var.cluster_name}-peer"
+}
+
+# cluster-1 (client/primary). Writes the per-run KUBECONFIG the harness uses.
+resource "kind_cluster" "c1" {
+  name            = local.c1
+  node_image      = var.node_image
+  kubeconfig_path = pathexpand(var.kubeconfig_path)
+  wait_for_ready  = true
+}
+
+# cluster-2 (backend). Writes a SEPARATE kubeconfig so the two resources don't
+# clobber the same file during apply; setup.sh merges its context into the per-run
+# KUBECONFIG. Both clusters attach to the shared `kind` Docker network by default,
+# so their MetalLB-assigned east-west gateway IPs are mutually reachable.
+resource "kind_cluster" "c2" {
+  name            = local.c2
+  node_image      = var.node_image
+  kubeconfig_path = pathexpand("${var.kubeconfig_path}-c2")
+  wait_for_ready  = true
+}
+
+# Outside-the-cluster setup: build the Istio multi-primary federation across both
+# clusters and inject the mTLS fault. Runs during `tofu apply`, before the agent.
+resource "null_resource" "setup" {
+  triggers = {
+    c1 = kind_cluster.c1.name
+    c2 = kind_cluster.c2.name
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = "${path.module}/scripts/setup.sh"
+    environment = {
+      KUBECONFIG    = pathexpand(var.kubeconfig_path)
+      C1            = kind_cluster.c1.name
+      C2            = kind_cluster.c2.name
+      MANIFESTS_DIR = "${path.module}/manifests"
+      ISTIO_VERSION = var.istio_version
+    }
+  }
+}

--- a/tf/prebuilt/mesh-federation-kind/manifests/apps/backend.yaml
+++ b/tf/prebuilt/mesh-federation-kind/manifests/apps/backend.yaml
@@ -1,0 +1,38 @@
+# Backend workload — applied to cluster-2 only. A tiny HTTP echo that identifies
+# itself as the cluster-2 instance, so a successful cross-cluster call from
+# cluster-1 is observable in the response body. Sidecar is injected via the
+# `sample` namespace's istio-injection label.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: sample
+  labels:
+    app: backend
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+        version: v1
+    spec:
+      containers:
+        - name: backend
+          image: hashicorp/http-echo:0.2.3
+          args:
+            - "-listen=:8080"
+            - "-text=hello from backend in cluster-2"
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: "20m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"

--- a/tf/prebuilt/mesh-federation-kind/manifests/apps/frontend.yaml
+++ b/tf/prebuilt/mesh-federation-kind/manifests/apps/frontend.yaml
@@ -1,0 +1,32 @@
+# Client workload — applied to cluster-1 only. A long-lived curl pod the agent
+# (and the grader) use to probe `backend.sample.svc.cluster.local` cross-cluster.
+# Sidecar is injected via the `sample` namespace's istio-injection label, so the
+# call goes through the mesh (and, once STRICT mTLS is enforced, over mTLS).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sleep
+  namespace: sample
+  labels:
+    app: sleep
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sleep
+  template:
+    metadata:
+      labels:
+        app: sleep
+    spec:
+      containers:
+        - name: sleep
+          image: curlimages/curl:8.5.0
+          command: ["/bin/sleep", "infinity"]
+          resources:
+            requests:
+              cpu: "20m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"

--- a/tf/prebuilt/mesh-federation-kind/manifests/apps/services.yaml
+++ b/tf/prebuilt/mesh-federation-kind/manifests/apps/services.yaml
@@ -1,0 +1,32 @@
+# The `sample` namespace + the cross-cluster workload. In an Istio multi-primary
+# mesh, the *Service* object must exist in every cluster that participates in
+# routing, while the backing *pods* can live in just one. Here:
+#   - the Service `backend` is created in BOTH clusters (setup.sh applies this to
+#     each), so each cluster's control plane knows the hostname,
+#   - the backend *Deployment* runs only in cluster-2 (see backend.yaml),
+#   - the client (`sleep`) runs only in cluster-1 (see frontend.yaml).
+# Once the clusters federate (cross-cluster endpoint discovery via remote
+# secrets), a call to `backend.sample.svc.cluster.local` from cluster-1 resolves
+# to the cluster-2 pods over the east-west gateway with mTLS.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sample
+  labels:
+    istio-injection: enabled
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: sample
+  labels:
+    app: backend
+    service: backend
+spec:
+  ports:
+    - port: 8080
+      name: http
+      targetPort: 8080
+  selector:
+    app: backend

--- a/tf/prebuilt/mesh-federation-kind/outputs.tf
+++ b/tf/prebuilt/mesh-federation-kind/outputs.tf
@@ -1,0 +1,15 @@
+# The harness reads `cluster_name` + `cluster_location` and wires the per-run
+# KUBECONFIG to that (primary) cluster. We return cluster-1 (the client); setup.sh
+# merges cluster-2's context into the same kubeconfig so the agent has both.
+output "cluster_name" {
+  value = kind_cluster.c1.name
+}
+
+# "local" tells the TF deployer this is a kind cluster (skip gcloud get-credentials).
+output "cluster_location" {
+  value = "local"
+}
+
+output "backend_cluster_name" {
+  value = kind_cluster.c2.name
+}

--- a/tf/prebuilt/mesh-federation-kind/scripts/setup.sh
+++ b/tf/prebuilt/mesh-federation-kind/scripts/setup.sh
@@ -103,23 +103,46 @@ install_metallb "${CTX1}" "${POOL1}"
 install_metallb "${CTX2}" "${POOL2}"
 
 # --- Shared root CA -> cacerts on both clusters (federated trust) --------------
-echo "==> Generating a shared root CA and installing cacerts on both clusters..."
-(
-  cd "${ISTIO_DIR}"
-  mkdir -p certs
-  make -f tools/certs/Makefile.selfsigned.mk root-ca >/dev/null
-  make -f tools/certs/Makefile.selfsigned.mk "${C1}-cacerts" >/dev/null
-  make -f tools/certs/Makefile.selfsigned.mk "${C2}-cacerts" >/dev/null
-)
+# Generated with openssl directly (the bastion has no `make`): one shared root CA,
+# and a per-cluster intermediate CA signed by it, so workload certs from both
+# clusters chain to a common root -> cross-cluster identity validates. This is the
+# layout Istio's `cacerts` secret expects (ca-cert/ca-key/root-cert/cert-chain).
+echo "==> Generating a shared root CA + per-cluster intermediates (openssl)..."
+CERTS="${WORK}/certs"
+mkdir -p "${CERTS}"
+openssl genrsa -out "${CERTS}/root-key.pem" 4096 2>/dev/null
+openssl req -x509 -new -nodes -key "${CERTS}/root-key.pem" -sha256 -days 3650 \
+  -subj "/O=Istio/CN=Root CA" \
+  -addext "basicConstraints=critical,CA:TRUE" \
+  -addext "keyUsage=critical,digitalSignature,keyCertSign,cRLSign" \
+  -out "${CERTS}/root-cert.pem" 2>/dev/null
+
+gen_intermediate() {
+  local name="$1" d="${CERTS}/${name}"
+  mkdir -p "${d}"
+  openssl genrsa -out "${d}/ca-key.pem" 4096 2>/dev/null
+  openssl req -new -key "${d}/ca-key.pem" -subj "/O=Istio/CN=Intermediate CA ${name}" \
+    -out "${d}/ca.csr" 2>/dev/null
+  openssl x509 -req -in "${d}/ca.csr" -sha256 -days 3650 \
+    -CA "${CERTS}/root-cert.pem" -CAkey "${CERTS}/root-key.pem" -CAcreateserial \
+    -extfile <(printf 'basicConstraints=critical,CA:TRUE,pathlen:0\nkeyUsage=critical,digitalSignature,keyCertSign,cRLSign\nsubjectAltName=DNS:istiod.istio-system.svc\n') \
+    -out "${d}/ca-cert.pem" 2>/dev/null
+  cat "${d}/ca-cert.pem" "${CERTS}/root-cert.pem" > "${d}/cert-chain.pem"
+  cp "${CERTS}/root-cert.pem" "${d}/root-cert.pem"
+}
+gen_intermediate "${C1}"
+gen_intermediate "${C2}"
+
+echo "==> Installing cacerts + network labels on both clusters..."
 for pair in "${CTX1}:${C1}" "${CTX2}:${C2}"; do
   kctx="${pair%%:*}"; cname="${pair##*:}"
   kubectl --context "${kctx}" create namespace istio-system --dry-run=client -o yaml | kubectl --context "${kctx}" apply -f -
   kubectl --context "${kctx}" label namespace istio-system topology.istio.io/network="network-${cname}" --overwrite
   kubectl --context "${kctx}" -n istio-system create secret generic cacerts \
-    --from-file="${ISTIO_DIR}/${cname}/ca-cert.pem" \
-    --from-file="${ISTIO_DIR}/${cname}/ca-key.pem" \
-    --from-file="${ISTIO_DIR}/${cname}/root-cert.pem" \
-    --from-file="${ISTIO_DIR}/${cname}/cert-chain.pem" \
+    --from-file="${CERTS}/${cname}/ca-cert.pem" \
+    --from-file="${CERTS}/${cname}/ca-key.pem" \
+    --from-file="${CERTS}/${cname}/root-cert.pem" \
+    --from-file="${CERTS}/${cname}/cert-chain.pem" \
     --dry-run=client -o yaml | kubectl --context "${kctx}" apply -f -
 done
 

--- a/tf/prebuilt/mesh-federation-kind/scripts/setup.sh
+++ b/tf/prebuilt/mesh-federation-kind/scripts/setup.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# Setup for the mesh-federation task. Runs from OUTSIDE the clusters during
+# `tofu apply`, before the agent starts. It stands up a REAL Istio multi-primary,
+# multi-network federation across two kind clusters, then injects an mTLS
+# misconfiguration for the agent to diagnose and fix.
+#
+# What setup does (the fragile, kind-specific plumbing — NOT the agent's job):
+#   1. Download a pinned istioctl + samples (bastion has no istioctl).
+#   2. MetalLB on both clusters, with non-overlapping address pools carved from
+#      the shared `kind` Docker network so the east-west gateways get LoadBalancer
+#      IPs reachable across clusters.
+#   3. A shared root CA (cacerts) installed in istio-system on BOTH clusters, so
+#      the two trust domains federate (this is the "root CA exchange" prereq).
+#   4. Istio multi-primary/multi-network control planes on both (mesh1; per-cluster
+#      clusterName + network label).
+#   5. East-west gateways + expose-services (*.local) on both.
+#   6. Cross-cluster remote secrets, BOTH directions, with the kind API-server
+#      address patched to the node's Docker IP (the standard kind workaround so the
+#      remote kubeconfig is reachable from the peer cluster).
+#   7. The workloads: `backend` (cluster-2) + a `sleep` client (cluster-1), with
+#      the `backend` Service present in both clusters.
+#
+# The INJECTED FAULT (what the agent must fix):
+#   - cluster-2 `sample` namespace enforces PeerAuthentication mode STRICT, but
+#   - cluster-1 has a DestinationRule for the backend host with tls.mode DISABLE,
+#   so the client sends plaintext while the server demands mTLS -> the
+#   cross-cluster call fails the mTLS handshake. This is the textbook
+#   "DR DISABLE vs PeerAuthentication STRICT" mismatch (SOT step 4).
+#
+# Nothing here tells the agent the fix — it must observe the failing call and
+# reconcile the mTLS configuration to a consistent STRICT posture.
+set -euo pipefail
+
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+C1="${C1:?C1 (cluster-1 name) is required}"
+C2="${C2:?C2 (cluster-2 name) is required}"
+MANIFESTS_DIR="${MANIFESTS_DIR:?MANIFESTS_DIR is required}"
+MANIFESTS_DIR="$(cd "${MANIFESTS_DIR}" && pwd)"
+ISTIO_VERSION="${ISTIO_VERSION:-1.23.2}"
+METALLB_VERSION="${METALLB_VERSION:-v0.14.8}"
+KIND_NET="${KIND_NET:-kind}"
+
+CTX1="kind-${C1}"
+CTX2="kind-${C2}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+k1() { kubectl --context "${CTX1}" "$@"; }
+k2() { kubectl --context "${CTX2}" "$@"; }
+
+# Both kind clusters are created by TF (cluster-2 into its own kubeconfig to avoid
+# clobbering cluster-1's). Merge both contexts into the per-run KUBECONFIG so the
+# agent sees kind-<C1> and kind-<C2> in one file.
+echo "==> Merging both cluster contexts into ${KUBECONFIG}..."
+kind export kubeconfig --name "${C1}" --kubeconfig "${KUBECONFIG}"
+kind export kubeconfig --name "${C2}" --kubeconfig "${KUBECONFIG}"
+
+echo "==> Downloading Istio ${ISTIO_VERSION} (istioctl + samples + tools/certs)..."
+(
+  cd "${WORK}"
+  curl -fsSL "https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-linux-amd64.tar.gz" \
+    | tar -xz
+)
+ISTIO_DIR="${WORK}/istio-${ISTIO_VERSION}"
+export PATH="${ISTIO_DIR}/bin:${PATH}"
+
+# --- MetalLB: split the kind Docker subnet into two non-overlapping pools ------
+# The east-west gateways need LoadBalancer IPs reachable on the shared kind net.
+SUBNET="$(docker network inspect "${KIND_NET}" \
+  -f '{{range .IPAM.Config}}{{if .Gateway}}{{.Subnet}} {{end}}{{end}}' \
+  | tr ' ' '\n' | grep -E '^[0-9]+\.' | head -1)"
+PREFIX="$(echo "${SUBNET}" | cut -d. -f1-2)"   # e.g. 172.18
+POOL1="${PREFIX}.255.200-${PREFIX}.255.219"
+POOL2="${PREFIX}.255.220-${PREFIX}.255.239"
+
+install_metallb() {
+  local kctx="$1" pool="$2"
+  kubectl --context "${kctx}" apply -f \
+    "https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/config/manifests/metallb-native.yaml"
+  kubectl --context "${kctx}" -n metallb-system wait --for=condition=Available deploy/controller --timeout=180s
+  kubectl --context "${kctx}" -n metallb-system rollout status ds/speaker --timeout=180s
+  # The webhook can take a few seconds after Available; retry the CR apply.
+  for _ in $(seq 1 12); do
+    if cat <<EOF | kubectl --context "${kctx}" apply -f -
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata: { name: kind-pool, namespace: metallb-system }
+spec: { addresses: ["${pool}"] }
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata: { name: l2, namespace: metallb-system }
+spec: { ipAddressPools: ["kind-pool"] }
+EOF
+    then return 0; fi
+    sleep 5
+  done
+  echo "ERROR: metallb config failed on ${kctx}" >&2; return 1
+}
+echo "==> Installing MetalLB (pool ${POOL1} on ${C1}, ${POOL2} on ${C2})..."
+install_metallb "${CTX1}" "${POOL1}"
+install_metallb "${CTX2}" "${POOL2}"
+
+# --- Shared root CA -> cacerts on both clusters (federated trust) --------------
+echo "==> Generating a shared root CA and installing cacerts on both clusters..."
+(
+  cd "${ISTIO_DIR}"
+  mkdir -p certs
+  make -f tools/certs/Makefile.selfsigned.mk root-ca >/dev/null
+  make -f tools/certs/Makefile.selfsigned.mk "${C1}-cacerts" >/dev/null
+  make -f tools/certs/Makefile.selfsigned.mk "${C2}-cacerts" >/dev/null
+)
+for pair in "${CTX1}:${C1}" "${CTX2}:${C2}"; do
+  kctx="${pair%%:*}"; cname="${pair##*:}"
+  kubectl --context "${kctx}" create namespace istio-system --dry-run=client -o yaml | kubectl --context "${kctx}" apply -f -
+  kubectl --context "${kctx}" label namespace istio-system topology.istio.io/network="network-${cname}" --overwrite
+  kubectl --context "${kctx}" -n istio-system create secret generic cacerts \
+    --from-file="${ISTIO_DIR}/${cname}/ca-cert.pem" \
+    --from-file="${ISTIO_DIR}/${cname}/ca-key.pem" \
+    --from-file="${ISTIO_DIR}/${cname}/root-cert.pem" \
+    --from-file="${ISTIO_DIR}/${cname}/cert-chain.pem" \
+    --dry-run=client -o yaml | kubectl --context "${kctx}" apply -f -
+done
+
+# --- Istio multi-primary control planes ---------------------------------------
+install_istio() {
+  local kctx="$1" cname="$2"
+  cat <<EOF | istioctl install --context "${kctx}" -y -f -
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    global:
+      meshID: mesh1
+      multiCluster:
+        clusterName: ${cname}
+      network: network-${cname}
+EOF
+}
+echo "==> Installing Istio multi-primary control planes..."
+install_istio "${CTX1}" "${C1}"
+install_istio "${CTX2}" "${C2}"
+
+# --- East-west gateways + expose services -------------------------------------
+echo "==> Installing east-west gateways + exposing services..."
+gen_eastwest() {
+  local kctx="$1" cname="$2"
+  "${ISTIO_DIR}/samples/multicluster/gen-eastwest-gateway.sh" \
+    --mesh mesh1 --cluster "${cname}" --network "network-${cname}" \
+    | istioctl install --context "${kctx}" -y -f -
+}
+gen_eastwest "${CTX1}" "${C1}"
+gen_eastwest "${CTX2}" "${C2}"
+for kctx in "${CTX1}" "${CTX2}"; do
+  kubectl --context "${kctx}" -n istio-system wait --for=condition=Available deploy/istio-eastwestgateway --timeout=240s
+  kubectl --context "${kctx}" apply -n istio-system -f "${ISTIO_DIR}/samples/multicluster/expose-services.yaml"
+done
+
+# --- Cross-cluster remote secrets (kind API-IP patched) -----------------------
+echo "==> Exchanging remote secrets (kind API-server IPs patched for reachability)..."
+node_ip() { docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${1}-control-plane"; }
+IP1="$(node_ip "${C1}")"
+IP2="$(node_ip "${C2}")"
+# Create a remote secret for C1 and install it into C2 (and vice versa), pointing
+# the server at the peer node's Docker IP (the kubeconfig kind writes uses
+# 127.0.0.1:<hostport>, unreachable from the peer cluster's pods).
+istioctl create-remote-secret --context "${CTX1}" --name "${C1}" --server "https://${IP1}:6443" \
+  | kubectl --context "${CTX2}" apply -f -
+istioctl create-remote-secret --context "${CTX2}" --name "${C2}" --server "https://${IP2}:6443" \
+  | kubectl --context "${CTX1}" apply -f -
+
+# --- Workloads ----------------------------------------------------------------
+echo "==> Deploying workloads (backend in ${C2}, sleep client in ${C1}; Service in both)..."
+k1 apply -f "${MANIFESTS_DIR}/apps/services.yaml"
+k2 apply -f "${MANIFESTS_DIR}/apps/services.yaml"
+k2 apply -f "${MANIFESTS_DIR}/apps/backend.yaml"
+k1 apply -f "${MANIFESTS_DIR}/apps/frontend.yaml"
+k2 -n sample rollout status deploy/backend --timeout=240s
+k1 -n sample rollout status deploy/sleep --timeout=240s
+
+# --- Inject the mTLS fault (the thing the agent must fix) ----------------------
+echo "==> Injecting mTLS misconfiguration (server STRICT vs client DR DISABLE)..."
+# Server side (cluster-2): require strict mTLS in the sample namespace.
+cat <<EOF | k2 apply -f -
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: sample-strict
+  namespace: sample
+spec:
+  mtls:
+    mode: STRICT
+EOF
+# Client side (cluster-1): a DestinationRule that DISABLES mTLS toward the backend
+# host -> client sends plaintext, server rejects -> handshake failure.
+cat <<EOF | k1 apply -f -
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: backend-no-mtls
+  namespace: sample
+spec:
+  host: backend.sample.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+EOF
+
+echo "==> Setup complete."
+echo "    Clusters: ${C1} (client) / ${C2} (backend) — contexts ${CTX1} / ${CTX2}"
+echo "    Repro the failing cross-cluster call:"
+echo "      kubectl --context ${CTX1} -n sample exec deploy/sleep -c sleep -- curl -sS -m 5 backend.sample.svc.cluster.local:8080"

--- a/tf/prebuilt/mesh-federation-kind/scripts/setup.sh
+++ b/tf/prebuilt/mesh-federation-kind/scripts/setup.sh
@@ -118,7 +118,8 @@ openssl req -x509 -new -nodes -key "${CERTS}/root-key.pem" -sha256 -days 3650 \
   -out "${CERTS}/root-cert.pem" 2>/dev/null
 
 gen_intermediate() {
-  local name="$1" d="${CERTS}/${name}"
+  local name="$1"
+  local d="${CERTS}/${name}"
   mkdir -p "${d}"
   openssl genrsa -out "${d}/ca-key.pem" 4096 2>/dev/null
   openssl req -new -key "${d}/ca-key.pem" -subj "/O=Istio/CN=Intermediate CA ${name}" \

--- a/tf/prebuilt/mesh-federation-kind/variables.tf
+++ b/tf/prebuilt/mesh-federation-kind/variables.tf
@@ -1,0 +1,29 @@
+variable "cluster_name" {
+  type        = string
+  description = "Base name for the run. The two kind clusters are '<cluster_name>-a' (client/primary) and '<cluster_name>-b' (backend). The 'cluster_name' output returns the primary so the harness wires KUBECONFIG to it; setup.sh merges the second context in."
+  default     = "devops-bench-kind"
+}
+
+variable "location" {
+  type        = string
+  description = "Always 'local' for kind; kept for deployer compatibility."
+  default     = "local"
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  description = "Path kind writes the (primary) kubeconfig to; setup.sh merges the second cluster's context into it."
+  default     = "~/.kube/config"
+}
+
+variable "node_image" {
+  type        = string
+  description = "Pinned kindest/node image (v1.30.x)."
+  default     = "kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e"
+}
+
+variable "istio_version" {
+  type        = string
+  description = "Pinned Istio version installed on both clusters."
+  default     = "1.23.2"
+}


### PR DESCRIPTION
Adds a new complex benchmark task realizing Complex Task #10 (cross-cluster service-mesh federation) as a **real two-cluster Istio multi-primary mesh** on kind.

`task_id: 24` · `tasks/common/mesh-federation` · stack `tf/prebuilt/mesh-federation-kind` · **kind (two clusters)** — no GKE quota.

## What it tests
Two kind clusters are joined as an Istio multi-primary/multi-network mesh (shared root CA, east-west gateways, cross-cluster remote-secret endpoint discovery). A `sleep` client in cluster `{{CLUSTER_NAME}}` calls a `backend` in cluster `{{CLUSTER_NAME}}-peer`. An **mTLS misconfiguration is injected** — the backend namespace enforces `PeerAuthentication: STRICT` while the client has a `DestinationRule` with `tls.mode: DISABLE` — so the cross-cluster call fails the handshake. The agent must diagnose across both clusters and reconcile to consistent mutual TLS (without weakening security), then report.

Maps to SOT #10 steps 1 (analysis) + 4 (real-time mTLS validation/fix) + 5 (report); the federation plumbing (CA, east-west, remote secrets) is pre-built substrate.

## How the fixture works
`setup.sh` downloads a pinned istioctl, installs MetalLB (split pools from the kind subnet), a shared root CA (`openssl`), Istio multi-primary on both clusters, east-west gateways + expose-services, exchanges remote secrets (kind API-IP patched), deploys the workloads, and injects the mTLS fault.

## Validated
Verified end-to-end on the bastion. Manual solvability check: with the fault the call fails (`no healthy upstream`); removing the client DestinationRule restores it (`hello from backend in cluster-2`). Full `validate-eval` (gemini-3.1-pro-preview, oc+mcp+skills, Vertex): `exit=0`, **ChecklistScore 1.00** — the agent reproduced the failure, diagnosed the STRICT-vs-DISABLE mismatch across both clusters, fixed it, verified cross-cluster mTLS, and reported. `validated: true`. Reviewed via `task-review` (fixed a `make`-dependency blocker → openssl CA, and a `set -u` unbound-var bug). `tofu validate`/`fmt` clean.

## Heads-up for reviewers
**Heaviest task in the suite** — two kind clusters + full Istio each. Run at **low `MAX_PARALLEL`** (host disk/inotify/pods sum across concurrent runs); ~40 GB disk recommended. Documented in the task comment + README, same posture as `multi-region-failover`.