### PR TITLE
chore: format baseline + CI format check + exact ruff pin

### DIFF
--- a/.agents/skills/migration-prep/SKILL.md
+++ b/.agents/skills/migration-prep/SKILL.md
@@ -146,6 +146,7 @@ cross-border imports from step 3):
 ```bash
 uv sync --frozen                          # strict library-mode build (as CI does)
 uv run ruff check devops_bench tests/unit # lint scope CI uses; or scope to the PR's paths
+uv run ruff format devops_bench tests/unit # upstream CI enforces format --check; export formatted
 uv run pytest tests/unit/<area> -q        # the co-located tests for this PR
 ```
 

--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -46,6 +46,11 @@ jobs:
         # Scoped to the devops_bench component; the rest of the repo is not yet compliant.
         run: uv run ruff check devops_bench tests/unit
 
+      - name: Format
+        # Same scope as Lint. ruff is pinned exactly (==) in pyproject so this check
+        # cannot drift with formatter style changes across ruff releases.
+        run: uv run ruff format --check devops_bench tests/unit
+
       - name: Unit tests
         run: uv run pytest tests/unit -q
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,8 @@ repos:
         entry: uv run ruff format
         language: system
         types: [python]
+        # Match the CI guardrail scope: the rest of the repo is not yet compliant.
+        files: ^(devops_bench|tests/unit)/
         stages: [pre-commit]
 
       - id: ruff
@@ -13,6 +15,7 @@ repos:
         entry: uv run ruff check
         language: system
         types: [python]
+        files: ^(devops_bench|tests/unit)/
         stages: [pre-commit]
 
       - id: uv-lock-check

--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -48,11 +48,6 @@ NEVER_SYNC = [
     ".agents/skills/migration-prep/**",
     ".claude/skills/migration-prep",
     "docs/how-to/leaderboard.md",
-    # TEMP stopgap: core/model_providers.py is in gke-labs core/ but not yet exported to
-    # kubernetes-sigs, so the flipped core/** frontier would make the back-sync delete it. Exclude
-    # it until it lands upstream, then REMOVE these two lines so it reconciles like the rest of core/.
-    "devops_bench/core/model_providers.py",
-    "tests/unit/core/test_model_providers.py",
     "copy.bara.sky",
     "migrated.bara.sky",
     "pyproject.toml",

--- a/devops_bench/agents/api/agent.py
+++ b/devops_bench/agents/api/agent.py
@@ -177,9 +177,7 @@ def extract_tokens(response: Any) -> dict:
 
     # Try the Google attr first, then the OpenAI-style attr, then the Anthropic
     # alias.
-    prompt = _first_int_attr(
-        usage, "prompt_token_count", "prompt_tokens", "input_tokens"
-    )
+    prompt = _first_int_attr(usage, "prompt_token_count", "prompt_tokens", "input_tokens")
     candidates = _first_int_attr(
         usage, "candidates_token_count", "completion_tokens", "output_tokens"
     )
@@ -408,7 +406,9 @@ class ApiAgent(AgentHarness):
         # an empty-command binding is treated as "no MCP". ``shlex.join``
         # round-trips ``MCPClient``'s ``shlex.split`` so a spaced argv token
         # (``("uv run", "mcp-server")``) is rebuilt as a single quoted word.
-        mcp_server_path = shlex.join(mcp_binding.command) if mcp_binding and mcp_binding.command else None
+        mcp_server_path = (
+            shlex.join(mcp_binding.command) if mcp_binding and mcp_binding.command else None
+        )
         skills_paths = self.config.capabilities.skills.paths
         rules_text = self.config.capabilities.rules.text
 

--- a/devops_bench/agents/api/mcp.py
+++ b/devops_bench/agents/api/mcp.py
@@ -66,9 +66,7 @@ class MCPClient:
                 "MCP server command."
             )
         server_params = StdioServerParameters(command=parts[0], args=parts[1:])
-        stdio_transport = await self.exit_stack.enter_async_context(
-            stdio_client(server_params)
-        )
+        stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
         self.read_stream, self.write_stream = stdio_transport
         self.session = await self.exit_stack.enter_async_context(
             ClientSession(self.read_stream, self.write_stream)

--- a/devops_bench/agents/cli/gemini_cli/parsing.py
+++ b/devops_bench/agents/cli/gemini_cli/parsing.py
@@ -108,7 +108,9 @@ def parse_stream_json(stdout: str) -> tuple[str, list[dict], dict, list[str]]:
             if content is None:
                 content = event.get("output")
             if content is not None:
-                target.result = content if isinstance(content, str) else json.dumps(content, default=str)
+                target.result = (
+                    content if isinstance(content, str) else json.dumps(content, default=str)
+                )
             status = str(event.get("status", "")).lower()
             failed = bool(event.get("is_error")) or status in ("error", "failed", "failure")
             target.status = "error" if failed else "completed"

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -110,6 +110,7 @@ def _ensure_node_on_path(env_overlay: dict[str, str]) -> dict[str, str]:
     merged["PATH"] = f"{node_bin}{os.pathsep}{existing}" if existing else node_bin
     return merged
 
+
 _log = get_logger("agents.cli.openclaw.agent")
 
 # Per-run layout under the temp working dir. ``state`` is openclaw's state root

--- a/devops_bench/agents/config.py
+++ b/devops_bench/agents/config.py
@@ -62,9 +62,7 @@ def _build_capabilities_from_env(env: Mapping[str, str] | None) -> AllCapabiliti
     if mcp_command or allowed_tools:
         # ``name="default"`` is generic: env-driven from_env has no catalog to
         # pull a real name from, and the agent never inspects it.
-        mcp_servers = (
-            McpBinding(name="default", command=mcp_command, tools=allowed_tools),
-        )
+        mcp_servers = (McpBinding(name="default", command=mcp_command, tools=allowed_tools),)
 
     skills_paths = _parse_csv(get_env("AGENT_SKILLS_PATHS", env=env))
     skills = SkillBinding(paths=skills_paths)

--- a/devops_bench/chaos/base.py
+++ b/devops_bench/chaos/base.py
@@ -35,14 +35,10 @@ __all__ = [
 #: Registry of concrete :class:`Fault` subclasses, keyed by their ``type``.
 #: ``entry_point_group`` lets external packages register a fault without
 #: touching this tree.
-FAULTS: Registry[type[Fault]] = Registry(
-    "faults", entry_point_group="devops_bench.faults"
-)
+FAULTS: Registry[type[Fault]] = Registry("faults", entry_point_group="devops_bench.faults")
 
 #: Registry of concrete :class:`Trigger` subclasses, keyed by their ``type``.
-TRIGGERS: Registry[type[Trigger]] = Registry(
-    "triggers", entry_point_group="devops_bench.triggers"
-)
+TRIGGERS: Registry[type[Trigger]] = Registry("triggers", entry_point_group="devops_bench.triggers")
 
 
 class ChaosResult(BaseModel):

--- a/devops_bench/chaos/spec.py
+++ b/devops_bench/chaos/spec.py
@@ -98,10 +98,7 @@ def _parse_through(data: Any, registry: Any, *, axis: str) -> BaseModel:
             return data
         raise _validation_error(
             f"chaos_spec_unregistered_{axis}_model",
-            (
-                f"chaos {axis} node {type(data).__name__!r} is not a "
-                f"registered {axis}"
-            ),
+            (f"chaos {axis} node {type(data).__name__!r} is not a registered {axis}"),
             input_value=data,
         )
     if not isinstance(data, dict):
@@ -124,19 +121,14 @@ def _parse_through(data: Any, registry: Any, *, axis: str) -> BaseModel:
     except NotRegisteredError as exc:
         raise _validation_error(
             f"chaos_spec_unknown_{axis}_type",
-            (
-                f"unknown chaos {axis} type {type_key!r}; "
-                f"registered: {sorted(registry.keys())}"
-            ),
+            (f"unknown chaos {axis} type {type_key!r}; registered: {sorted(registry.keys())}"),
             input_value=data,
         ) from exc
 
     return model_cls.model_validate(data)
 
 
-def _validation_error(
-    code: str, message: str, *, input_value: Any
-) -> ValidationError:
+def _validation_error(code: str, message: str, *, input_value: Any) -> ValidationError:
     """Build a :class:`ValidationError` around a single :class:`PydanticCustomError`.
 
     The registry's :class:`NotRegisteredError` carries useful context, but the

--- a/devops_bench/cli.py
+++ b/devops_bench/cli.py
@@ -136,9 +136,7 @@ def args_to_config(args: argparse.Namespace) -> BenchmarkConfig:
         base,
         **overrides,
         no_infra=args.no_infra if args.no_infra is not None else base.no_infra,
-        no_teardown=(
-            args.no_teardown if args.no_teardown is not None else base.no_teardown
-        ),
+        no_teardown=(args.no_teardown if args.no_teardown is not None else base.no_teardown),
         parallel=args.parallel or base.parallel,
     )
 

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -167,9 +167,7 @@ class DefaultEvalHarness(Harness):
         )
         self.agent_type = (resolved_agent_type or _DEFAULT_AGENT_TYPE).lower()
         self.no_infra = no_infra if no_infra is not None else get_bool("BENCH_NO_INFRA")
-        self.no_teardown = (
-            no_teardown if no_teardown is not None else get_bool("BENCH_NO_TEARDOWN")
-        )
+        self.no_teardown = no_teardown if no_teardown is not None else get_bool("BENCH_NO_TEARDOWN")
         # Resolved once so capabilities and scoring observe the same value.
         self.use_mcp: bool = get_bool("BENCH_USE_MCP", True)
         # When running concurrently with other benchmark processes, allocate a
@@ -189,9 +187,7 @@ class DefaultEvalHarness(Harness):
             get_env("TARGET_DEPLOYMENT_NAME", self.default_target_deployment)
             or self.default_target_deployment
         )
-        self.namespace = (
-            get_env("NAMESPACE", self.default_namespace) or self.default_namespace
-        )
+        self.namespace = get_env("NAMESPACE", self.default_namespace) or self.default_namespace
         self.reporter = reporter or ResultReporter(results_root)
 
     @property
@@ -275,9 +271,7 @@ class DefaultEvalHarness(Harness):
         )
 
     @staticmethod
-    def _gate_capabilities(
-        env_caps: AllCapabilities, use_mcp: bool
-    ) -> AllCapabilities:
+    def _gate_capabilities(env_caps: AllCapabilities, use_mcp: bool) -> AllCapabilities:
         """Apply the harness's ``use_mcp`` gate to an env-derived capability set.
 
         Skills and rules are independent of MCP and pass through unchanged;
@@ -536,9 +530,7 @@ class DefaultEvalHarness(Harness):
             ``results.json`` schema.
         """
         run_dir = self.reporter.new_run_dir()
-        detailed_results: list[dict[str, Any]] = [
-            self._run_one(task, run_dir) for task in tasks
-        ]
+        detailed_results: list[dict[str, Any]] = [self._run_one(task, run_dir) for task in tasks]
 
         # Persist raw execution outputs before the (slower) scoring pass.
         self.reporter.write(run_dir, detailed_results)
@@ -555,9 +547,7 @@ class DefaultEvalHarness(Harness):
                 run_dir,
             )
         except Exception:  # noqa: BLE001 - execution results must survive scoring errors
-            _log.exception(
-                "scoring failed; returning unscored execution results from %s", run_dir
-            )
+            _log.exception("scoring failed; returning unscored execution results from %s", run_dir)
 
         # Emit the flattened, ingest-ready rows + run manifest. Best-effort: the
         # detailed results.json is already on disk, so a failure here must not
@@ -568,9 +558,7 @@ class DefaultEvalHarness(Harness):
             _log.exception("failed to write rows.json/manifest.json for %s", run_dir)
         return detailed_results
 
-    def _write_run_artifacts(
-        self, run_dir: Path, detailed_results: list[dict[str, Any]]
-    ) -> None:
+    def _write_run_artifacts(self, run_dir: Path, detailed_results: list[dict[str, Any]]) -> None:
         """Flatten ``detailed_results`` into ``rows.json`` + ``manifest.json``.
 
         Assembles the run-level :class:`~devops_bench.results.Manifest` from the
@@ -646,17 +634,13 @@ class DefaultEvalHarness(Harness):
             deployer.up()
             cluster_info = deployer.get_cluster_info()
             active_cluster_name = cluster_info.name or self.cluster_name
-            context = self.make_context(
-                task, cluster=cluster_info, workspace_path=workspace_path
-            )
+            context = self.make_context(task, cluster=cluster_info, workspace_path=workspace_path)
 
             prompt = self.replace_placeholders(task.prompt, active_cluster_name)
 
             chaos_specs = self._parse_chaos_specs(task.chaos_spec, active_cluster_name)
-            verification_mapping, verification_parse_errors = (
-                self._build_verification_mapping(
-                    task.verification_spec, active_cluster_name
-                )
+            verification_mapping, verification_parse_errors = self._build_verification_mapping(
+                task.verification_spec, active_cluster_name
             )
 
             # Hand the background scenario its own context with an isolated
@@ -678,13 +662,9 @@ class DefaultEvalHarness(Harness):
             agent_res = self.execute_agent(prompt, context)
             collect_generated_files(before_files, run_dir, source_dir=workspace_path)
 
-            expected_output = self.replace_placeholders(
-                task.expected_output, active_cluster_name
-            )
+            expected_output = self.replace_placeholders(task.expected_output, active_cluster_name)
 
-            chaos_report, perf_report = self._drain_scenario(
-                scenario_manager, scenario_thread
-            )
+            chaos_report, perf_report = self._drain_scenario(scenario_manager, scenario_thread)
 
             result = self._build_success_record(
                 task=task,
@@ -782,9 +762,7 @@ class DefaultEvalHarness(Harness):
                 # for consumers that only sample tool names; the trajectory is
                 # the source of truth.
                 "tools": [
-                    entry.get("name")
-                    for entry in dumped.get("trajectory", [])
-                    if entry.get("name")
+                    entry.get("name") for entry in dumped.get("trajectory", []) if entry.get("name")
                 ],
                 "trajectory": dumped.get("trajectory", []),
                 "status": "success",
@@ -796,9 +774,7 @@ class DefaultEvalHarness(Harness):
                 # flag alone would let an empty/errored run pass as a genuine low
                 # score. Require no agent error *and* a non-empty trajectory.
                 "validated": (
-                    task.validated
-                    and not agent_errors
-                    and bool(dumped.get("trajectory"))
+                    task.validated and not agent_errors and bool(dumped.get("trajectory"))
                 ),
                 "errors": agent_errors,
                 # First-error scalar so a parser reading ``error`` finds the
@@ -845,9 +821,7 @@ class DefaultEvalHarness(Harness):
             {
                 "input": prompt if prompt is not None else task.prompt,
                 "expected_output": (
-                    expected_output
-                    if expected_output is not None
-                    else task.expected_output
+                    expected_output if expected_output is not None else task.expected_output
                 ),
                 "status": "failed",
                 "error": error_text,
@@ -949,9 +923,7 @@ class DefaultEvalHarness(Harness):
             chaos_report["status"] = "timed_out"
         return chaos_report, perf_report
 
-    def _teardown(
-        self, deployer: Any, infra_config: dict[str, Any], name: str
-    ) -> None:
+    def _teardown(self, deployer: Any, infra_config: dict[str, Any], name: str) -> None:
         """Tear down infrastructure unless disabled by config or env.
 
         Args:

--- a/devops_bench/evalharness/reporter.py
+++ b/devops_bench/evalharness/reporter.py
@@ -128,9 +128,7 @@ class ResultReporter:
         _log.info("wrote rows.json with %d rows to %s", len(rows), path)
         return path
 
-    def write_manifest(
-        self, run_dir: str | os.PathLike[str], manifest: dict[str, Any]
-    ) -> Path:
+    def write_manifest(self, run_dir: str | os.PathLike[str], manifest: dict[str, Any]) -> Path:
         """Write the run-level manifest to ``<run_dir>/manifest.json``.
 
         Args:

--- a/devops_bench/evalharness/scenario.py
+++ b/devops_bench/evalharness/scenario.py
@@ -161,9 +161,7 @@ class ScenarioManager:
 
         try:
             chaos_result = self._inject_chaos(spec, ctx)
-            self.result_holder["chaos_report"] = self._chaos_report_from_result(
-                spec, chaos_result
-            )
+            self.result_holder["chaos_report"] = self._chaos_report_from_result(spec, chaos_result)
         except Exception as exc:  # noqa: BLE001 - surface failure into the report
             _log.error("error running scenario: %s", exc)
             self.result_holder["chaos_report"]["status"] = "failed"
@@ -196,12 +194,8 @@ class ScenarioManager:
                 "verification completed: %s",
                 verification_result.model_dump_json(indent=2),
             )
-            self.result_holder["chaos_report"]["verification"] = (
-                verification_result.model_dump()
-            )
-            self.result_holder["perf_report"] = self._perf_from_verification(
-                verification_result
-            )
+            self.result_holder["chaos_report"]["verification"] = verification_result.model_dump()
+            self.result_holder["perf_report"] = self._perf_from_verification(verification_result)
         except Exception as exc:  # noqa: BLE001 - surface failure into the report
             _log.error("verification failed with exception: %s", exc)
             self.result_holder["chaos_report"]["verification"] = {
@@ -297,10 +291,7 @@ class ScenarioManager:
             except Exception as exc:  # noqa: BLE001 - poll keeps retrying
                 _log.debug("waiting for LB IP on %s/%s: %s", namespace, service, exc)
                 return False
-            ingress = (
-                (doc.get("status") or {}).get("loadBalancer", {}).get("ingress")
-                or []
-            )
+            ingress = (doc.get("status") or {}).get("loadBalancer", {}).get("ingress") or []
             if not ingress:
                 return False
             entry = ingress[0] or {}

--- a/devops_bench/k8s/kubectl.py
+++ b/devops_bench/k8s/kubectl.py
@@ -287,9 +287,7 @@ def port_forward(
             process.wait(timeout=settle_sec)
         except Exception as exc:  # noqa: BLE001 - never mask the raise reason
             _log.warning("error reaping early-exited port-forward: %s", exc)
-        raise RuntimeError(
-            f"kubectl port-forward exited early (code {returncode}) for {target}"
-        )
+        raise RuntimeError(f"kubectl port-forward exited early (code {returncode}) for {target}")
 
     try:
         yield

--- a/devops_bench/metrics/_skills.py
+++ b/devops_bench/metrics/_skills.py
@@ -39,7 +39,5 @@ def load_skill_text(filename: str) -> str:
     """
     resource = resources.files(SKILLS_PACKAGE) / filename
     if not resource.is_file():
-        raise FileNotFoundError(
-            f"Judge skill {filename!r} not found in package {SKILLS_PACKAGE!r}"
-        )
+        raise FileNotFoundError(f"Judge skill {filename!r} not found in package {SKILLS_PACKAGE!r}")
     return resource.read_text(encoding="utf-8")

--- a/devops_bench/metrics/chaos_metrics.py
+++ b/devops_bench/metrics/chaos_metrics.py
@@ -66,8 +66,7 @@ def evaluate_chaos_metrics(
     diag_metric = GEval(
         name="DiagnosisAccuracy",
         criteria=(
-            "Did the agent accurately identify that the fault injected was"
-            f" '{actual_fault}'?"
+            f"Did the agent accurately identify that the fault injected was '{actual_fault}'?"
         ),
         evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
         model=judge_model,
@@ -89,13 +88,9 @@ def evaluate_chaos_metrics(
     except Exception as e:  # noqa: BLE001 - scoring must survive a judge failure
         _log.error("Error evaluating chaos metrics: %s", e)
 
-    scores["Workload_Deployment_Time_Seconds"] = perf_report.get(
-        "deployment_time_seconds"
-    )
+    scores["Workload_Deployment_Time_Seconds"] = perf_report.get("deployment_time_seconds")
     scores["Workload_Uptime_Percentage"] = perf_report.get("uptime_percentage")
-    scores["Resource_Utilization_Efficiency"] = perf_report.get(
-        "resource_utilization_efficiency"
-    )
+    scores["Resource_Utilization_Efficiency"] = perf_report.get("resource_utilization_efficiency")
 
 
 @METRICS.register("chaos")

--- a/devops_bench/metrics/checklist.py
+++ b/devops_bench/metrics/checklist.py
@@ -70,9 +70,7 @@ def extract_checklist_items(expected_output: str, use_mcp: bool) -> list[str]:
             reqs_section = parts[1]
 
     if "expected manifest generated:" in reqs_section.lower():
-        parts = re.split(
-            r"(?i)expected manifest generated\s*:", reqs_section, maxsplit=1
-        )
+        parts = re.split(r"(?i)expected manifest generated\s*:", reqs_section, maxsplit=1)
         reqs_section = parts[0]
 
     # Strip only the leading "- " bullet; ``str.strip("- ")`` would also eat
@@ -108,21 +106,16 @@ class ChecklistMetric:
 
     def applies(self, ctx: MetricContext) -> bool:
         """Run only when the result's ``expected_output`` carries bullets."""
-        return bool(
-            extract_checklist_items(ctx.result.get("expected_output", ""), ctx.use_mcp)
-        )
+        return bool(extract_checklist_items(ctx.result.get("expected_output", ""), ctx.use_mcp))
 
     def evaluate(self, ctx: MetricContext) -> Iterable[MetricScore]:
         """Score each requirement and emit the aggregate ChecklistScore."""
-        items = extract_checklist_items(
-            ctx.result.get("expected_output", ""), ctx.use_mcp
-        )
+        items = extract_checklist_items(ctx.result.get("expected_output", ""), ctx.use_mcp)
         dynamic_metrics = [
             GEval(
                 name=f"Check: {item}",
                 criteria=(
-                    "Verify that the actual output fulfills this specific"
-                    f" requirement: {item}"
+                    f"Verify that the actual output fulfills this specific requirement: {item}"
                 ),
                 threshold=GEVAL_PASS_THRESHOLD,
                 evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],

--- a/devops_bench/metrics/geval.py
+++ b/devops_bench/metrics/geval.py
@@ -112,9 +112,7 @@ class ModelLayerJudge(DeepEvalBaseLLM):
         return self._model_name
 
 
-def get_judge_model(
-    provider: str | None = None, model_name: str | None = None
-) -> ModelLayerJudge:
+def get_judge_model(provider: str | None = None, model_name: str | None = None) -> ModelLayerJudge:
     """Build the default judge model from configuration.
 
     Args:

--- a/devops_bench/metrics/grounding.py
+++ b/devops_bench/metrics/grounding.py
@@ -208,9 +208,7 @@ class GroundingMetric:
         """Score grounding constraints and derive the doc-retrieval rate."""
         documentation = ctx.result.get("documentation", [])
         scores: dict[str, Any] = {}
-        evaluate_documentation_grounding(
-            documentation, ctx.all_case, ctx.judge, scores
-        )
+        evaluate_documentation_grounding(documentation, ctx.all_case, ctx.judge, scores)
         retrieval_rate = calculate_doc_retrieval_rate(
             documentation, ctx.result.get("trajectory", [])
         )

--- a/devops_bench/metrics/pipeline.py
+++ b/devops_bench/metrics/pipeline.py
@@ -78,9 +78,7 @@ def _canonical_tool_name(name: str) -> str:
     return name.split("__", 1)[1] if "__" in name else name
 
 
-def _build_context(
-    res: dict[str, Any], judge_model: Any, use_mcp: bool
-) -> MetricContext:
+def _build_context(res: dict[str, Any], judge_model: Any, use_mcp: bool) -> MetricContext:
     """Build the per-result :class:`MetricContext`, sharing test cases.
 
     Args:

--- a/devops_bench/tasks/schema.py
+++ b/devops_bench/tasks/schema.py
@@ -145,9 +145,7 @@ class Task(BaseModel):
     validated: bool = False
 
     @classmethod
-    def from_dict(
-        cls, raw: dict[str, Any], *, name_default: str = "", folder: str = ""
-    ) -> "Task":
+    def from_dict(cls, raw: dict[str, Any], *, name_default: str = "", folder: str = "") -> "Task":
         """Build a task from a parsed spec mapping, validating types strictly.
 
         Adapts the source naming before validation: ``task_id`` is accepted as an

--- a/devops_bench/verification/runner.py
+++ b/devops_bench/verification/runner.py
@@ -183,10 +183,7 @@ class VerifierAgent:
         # ``verify(remaining)`` call, so they cannot linger long.
         ex = ThreadPoolExecutor(max_workers=workers)
         try:
-            futs = {
-                ex.submit(self._run, child, deadline): i
-                for i, child in enumerate(node.checks)
-            }
+            futs = {ex.submit(self._run, child, deadline): i for i, child in enumerate(node.checks)}
             done, _ = futures_wait(futs, timeout=max(0.0, deadline - time.monotonic()))
             for f, i in futs.items():
                 if f not in done:
@@ -203,9 +200,7 @@ class VerifierAgent:
         finally:
             ex.shutdown(wait=False, cancel_futures=True)
         ok = all(r.success for r in results)
-        reasons = [
-            f"[{i}] {'ok' if r.success else 'fail'}" for i, r in enumerate(results)
-        ]
+        reasons = [f"[{i}] {'ok' if r.success else 'fail'}" for i, r in enumerate(results)]
         return VerificationResult(
             success=ok,
             elapsed_time=time.monotonic() - start,

--- a/devops_bench/verification/spec.py
+++ b/devops_bench/verification/spec.py
@@ -144,10 +144,7 @@ def parse_node(data: Any) -> BaseModel:
             return data
         raise _validation_error(
             "verification_spec_unregistered_model",
-            (
-                f"verification spec node {type(data).__name__!r} is not a "
-                "registered verifier"
-            ),
+            (f"verification spec node {type(data).__name__!r} is not a registered verifier"),
             input_value=data,
         )
     if not isinstance(data, dict):
@@ -171,19 +168,14 @@ def parse_node(data: Any) -> BaseModel:
     except NotRegisteredError as exc:
         raise _validation_error(
             "verification_spec_unknown_type",
-            (
-                f"unknown verifier type {type_key!r}; "
-                f"registered: {sorted(VERIFIERS.keys())}"
-            ),
+            (f"unknown verifier type {type_key!r}; registered: {sorted(VERIFIERS.keys())}"),
             input_value=data,
         ) from exc
 
     return model_cls.model_validate(data)
 
 
-def _validation_error(
-    code: str, message: str, *, input_value: Any
-) -> ValidationError:
+def _validation_error(code: str, message: str, *, input_value: Any) -> ValidationError:
     """Build a ``ValidationError`` around a single ``PydanticCustomError``."""
     custom = PydanticCustomError(code, message)
     return ValidationError.from_exception_data(

--- a/devops_bench/verification/verifiers/pod_healthy.py
+++ b/devops_bench/verification/verifiers/pod_healthy.py
@@ -111,9 +111,7 @@ class PodHealthyVerifier(BaseVerifier):
                 kubeconfig=self.kubeconfig,
             )
         except Exception as exc:  # noqa: BLE001 - diagnostics path, never raises
-            _log.warning(
-                "Failed to fetch pod details for selector %s: %s", self.selector, exc
-            )
+            _log.warning("Failed to fetch pod details for selector %s: %s", self.selector, exc)
             return {"error": str(exc)}
 
     def _check_pods_status(self, raw: dict[str, Any]) -> bool:

--- a/devops_bench/verification/verifiers/scaling_complete.py
+++ b/devops_bench/verification/verifiers/scaling_complete.py
@@ -91,19 +91,13 @@ class ScalingCompleteVerifier(BaseVerifier):
         ready_replicas = (dep_data.get("status") or {}).get("readyReplicas", 0)
         raw = {"deployment": dep_data}
         if ready_replicas < self.min_replicas:
-            reason = (
-                f"Ready replicas ({ready_replicas}) < min replicas ({self.min_replicas})"
-            )
+            reason = f"Ready replicas ({ready_replicas}) < min replicas ({self.min_replicas})"
             return False, reason, raw
         if self.max_replicas is not None and ready_replicas > self.max_replicas:
-            reason = (
-                f"Ready replicas ({ready_replicas}) > max replicas ({self.max_replicas})"
-            )
+            reason = f"Ready replicas ({ready_replicas}) > max replicas ({self.max_replicas})"
             return False, reason, raw
         if self.max_replicas is None:
-            reason = (
-                f"Ready replicas ({ready_replicas}) >= min replicas ({self.min_replicas})"
-            )
+            reason = f"Ready replicas ({ready_replicas}) >= min replicas ({self.min_replicas})"
         else:
             reason = (
                 f"Ready replicas ({ready_replicas}) within bounds "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ packages = ["devops_bench"]
 dev = [
     "pytest>=8.0.0",
     "pytest-mock>=3.15.1",
-    "ruff>=0.8.2",
+    "ruff==0.15.17",
     "pre-commit>=3.5.0",
     "devops-bench[all]",
 ]

--- a/tests/unit/agents/api/test_agents_api_agent.py
+++ b/tests/unit/agents/api/test_agents_api_agent.py
@@ -47,6 +47,7 @@ def _mcp_caps(command: str = "server", *, tools: tuple[str, ...] = ()) -> AllCap
         mcp_servers=(McpBinding(name="test", command=tuple(command.split()), tools=tools),),
     )
 
+
 # ---------------------------------------------------------------------------
 # Test doubles
 # ---------------------------------------------------------------------------
@@ -354,9 +355,7 @@ def test_extract_tokens_reads_openai_ollama_shape():
 
 def test_extract_tokens_google_total_passes_through_when_present():
     """When the provider supplies its own total it wins over the computed sum."""
-    usage = SimpleNamespace(
-        prompt_token_count=5, candidates_token_count=7, total_token_count=99
-    )
+    usage = SimpleNamespace(prompt_token_count=5, candidates_token_count=7, total_token_count=99)
     response = SimpleNamespace(usage_metadata=usage)
     # The helper does not second-guess a provider-supplied total even when it
     # disagrees with prompt+candidates (some providers include reasoning/cached
@@ -460,9 +459,7 @@ def test_execute_records_openai_tokens_through_to_agentresult(monkeypatch):
         [
             _Turn(
                 text="done",
-                usage=SimpleNamespace(
-                    prompt_tokens=10, completion_tokens=20, total_tokens=30
-                ),
+                usage=SimpleNamespace(prompt_tokens=10, completion_tokens=20, total_tokens=30),
                 usage_attr="usage",
             )
         ]
@@ -579,8 +576,7 @@ def test_execute_records_missing_mcp_when_tool_requested_without_server(monkeypa
             "name": "ghost",
             "args": {},
             "result": (
-                "Error: tool 'ghost' requested but no MCP server is configured for "
-                "this agent."
+                "Error: tool 'ghost' requested but no MCP server is configured for this agent."
             ),
             "status": "error",
         },
@@ -662,8 +658,7 @@ def test_execute_returns_errored_on_mcpclient_value_error(monkeypatch):
 
         async def __aenter__(self) -> _BoomMCP:
             raise ValueError(
-                "MCP server_path is empty; set AGENT_MCP_SERVER to the MCP "
-                "server command."
+                "MCP server_path is empty; set AGENT_MCP_SERVER to the MCP server command."
             )
 
         async def __aexit__(self, *_a: Any) -> None: ...
@@ -784,12 +779,9 @@ def test_agent_source_has_no_bench_use_mcp_or_environ_reads():
                 # Allow doc references — only reject when the same line names an
                 # env accessor (``environ`` / ``getenv`` / ``get_env``).
                 line_text = src.read_text().splitlines()[node.lineno - 1]
-                accessor_hit = any(
-                    a in line_text for a in ("environ", "getenv", "get_env")
-                )
+                accessor_hit = any(a in line_text for a in ("environ", "getenv", "get_env"))
                 assert not accessor_hit, (
-                    f"{src.name} reads {node.value!r} via an env accessor "
-                    f"at line {node.lineno}"
+                    f"{src.name} reads {node.value!r} via an env accessor at line {node.lineno}"
                 )
 
 
@@ -878,13 +870,13 @@ def test_execute_runs_with_both_mcp_and_skills(monkeypatch, tmp_path):
     """Both bindings populated → MCP session is opened *and* skills are discovered."""
     skill_dir = tmp_path / "skills"
     (skill_dir / "demo").mkdir(parents=True)
-    (skill_dir / "demo" / "SKILL.md").write_text(
-        '---\nname: "demo"\ndescription: x\n---\nbody\n'
-    )
+    (skill_dir / "demo" / "SKILL.md").write_text('---\nname: "demo"\ndescription: x\n---\nbody\n')
 
     fc = [{"name": "do_thing", "args": {}, "id": "c1"}]
     fake = _FakeLLMClient([_Turn(text="working", calls=fc), _Turn(text="done")])
-    mcp = _FakeMCPClient(tools=[SimpleNamespace(name="do_thing", description="d", inputSchema=None)])
+    mcp = _FakeMCPClient(
+        tools=[SimpleNamespace(name="do_thing", description="d", inputSchema=None)]
+    )
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
     monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
 

--- a/tests/unit/agents/test_legacy_openclaw_tokens.py
+++ b/tests/unit/agents/test_legacy_openclaw_tokens.py
@@ -38,9 +38,33 @@ def test_parse_session_sums_usage_across_assistant_turns():
     session = "\n".join(
         json.dumps(line)
         for line in (
-            _assistant({"input": 2000, "output": 300, "cacheRead": 28000, "cacheWrite": 0, "totalTokens": 30300}),
-            _assistant({"input": 1500, "output": 250, "cacheRead": 41000, "cacheWrite": 0, "totalTokens": 42750}),
-            _assistant({"input": 900, "output": 120, "cacheRead": 60000, "cacheWrite": 0, "totalTokens": 61020}),
+            _assistant(
+                {
+                    "input": 2000,
+                    "output": 300,
+                    "cacheRead": 28000,
+                    "cacheWrite": 0,
+                    "totalTokens": 30300,
+                }
+            ),
+            _assistant(
+                {
+                    "input": 1500,
+                    "output": 250,
+                    "cacheRead": 41000,
+                    "cacheWrite": 0,
+                    "totalTokens": 42750,
+                }
+            ),
+            _assistant(
+                {
+                    "input": 900,
+                    "output": 120,
+                    "cacheRead": 60000,
+                    "cacheWrite": 0,
+                    "totalTokens": 61020,
+                }
+            ),
         )
     )
 

--- a/tests/unit/chaos/test_agent.py
+++ b/tests/unit/chaos/test_agent.py
@@ -97,7 +97,13 @@ def test_agent_dispatches_tool_calls_and_returns_final_text():
         [
             (
                 "running fortio now",
-                [{"name": "run_command", "args": {"command": "fortio load -qps 50 http://x"}, "id": "c1"}],
+                [
+                    {
+                        "name": "run_command",
+                        "args": {"command": "fortio load -qps 50 http://x"},
+                        "id": "c1",
+                    }
+                ],
             ),
             ("done; saturated at 50 qps", []),
         ]

--- a/tests/unit/chaos/test_extension_axis.py
+++ b/tests/unit/chaos/test_extension_axis.py
@@ -71,9 +71,7 @@ def test_dummy_fault_resolves_via_registry_with_no_central_edit(_isolated_regist
             ctx: RunContext,
             chaos_active_event: threading.Event | None = None,
         ) -> ChaosResult:
-            return ChaosResult(
-                success=True, injected_fault=self.type, output=self.payload
-            )
+            return ChaosResult(success=True, injected_fault=self.type, output=self.payload)
 
     # Harness-resolution path: registry.get(key) — no edit to chaos/spec.py
     # required for the harness to find a brand-new fault.

--- a/tests/unit/chaos/test_generate_load.py
+++ b/tests/unit/chaos/test_generate_load.py
@@ -105,9 +105,7 @@ def test_run_chaos_command_surfaces_executor_exception_as_error_string():
 
 
 def test_inject_returns_chaos_result_on_success():
-    fault = GenerateLoadFault(
-        target=LoadTarget(service_url="http://localhost:8080", qps=50)
-    )
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://localhost:8080", qps=50))
 
     # Patch the ChaosAgent the fault constructs so no model / SDK / network runs.
     class _StubAgent:
@@ -263,9 +261,7 @@ def test_inject_opens_port_forward_and_points_url_at_local_tunnel():
             _drive_load(self.kwargs)
             return "spike complete"
 
-    ctx = _make_ctx(
-        {_ENV_TARGET_DEPLOYMENT: "web-app", _ENV_TARGET_NAMESPACE: "prod"}
-    )
+    ctx = _make_ctx({_ENV_TARGET_DEPLOYMENT: "web-app", _ENV_TARGET_NAMESPACE: "prod"})
     with (
         patch.object(k8s_kubectl.subprocess, "Popen", return_value=proc) as popen_mock,
         patch.object(k8s_kubectl.time, "sleep"),  # don't actually sleep the settle window
@@ -320,9 +316,7 @@ def test_inject_uses_custom_local_port_for_parallel_runs():
             captured["url_during_run"] = fault.target.service_url
             return "spike complete"
 
-    ctx = _make_ctx(
-        {_ENV_TARGET_DEPLOYMENT: "web-app", _ENV_LOCAL_PORT: "34567"}
-    )
+    ctx = _make_ctx({_ENV_TARGET_DEPLOYMENT: "web-app", _ENV_LOCAL_PORT: "34567"})
     with (
         patch.object(k8s_kubectl.subprocess, "Popen", return_value=proc) as popen_mock,
         patch.object(k8s_kubectl.time, "sleep"),
@@ -337,9 +331,7 @@ def test_inject_uses_custom_local_port_for_parallel_runs():
 
 def test_inject_early_port_forward_exit_becomes_failed_result():
     """A port-forward that dies in the settle window yields a failed ChaosResult."""
-    fault = GenerateLoadFault(
-        target=LoadTarget(service_url="http://x.svc.cluster.local", qps=1)
-    )
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://x.svc.cluster.local", qps=1))
     dead = MagicMock()
     dead.poll.return_value = 1  # exited during the settle window
     dead.returncode = 1
@@ -363,9 +355,7 @@ def test_inject_early_port_forward_exit_becomes_failed_result():
 
 def test_inject_skips_port_forward_when_flagged():
     """``CHAOS_SKIP_PORT_FORWARD`` runs the loop against the existing URL, no Popen."""
-    fault = GenerateLoadFault(
-        target=LoadTarget(service_url="http://existing", qps=1)
-    )
+    fault = GenerateLoadFault(target=LoadTarget(service_url="http://existing", qps=1))
     captured: dict = {}
 
     class _StubAgent:

--- a/tests/unit/chaos/test_package_import.py
+++ b/tests/unit/chaos/test_package_import.py
@@ -39,9 +39,7 @@ def test_import_pulls_no_provider_sdk():
         "    assert forbidden not in loaded, forbidden\n"
         "print('ok')\n"
     )
-    proc = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
-    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, proc.stderr
     assert "ok" in proc.stdout
 
@@ -71,9 +69,7 @@ def test_import_does_not_pull_chaos_agent_or_models_chain():
         "    assert expected in loaded, expected\n"
         "print('ok')\n"
     )
-    proc = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
-    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, proc.stderr
     assert "ok" in proc.stdout
 
@@ -102,9 +98,7 @@ def test_parsing_a_spec_does_not_pull_the_agent_or_models_chain():
         "    assert forbidden not in loaded, forbidden\n"
         "print('ok')\n"
     )
-    proc = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
-    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, proc.stderr
     assert "ok" in proc.stdout
 

--- a/tests/unit/comparison/test_compare_results.py
+++ b/tests/unit/comparison/test_compare_results.py
@@ -181,7 +181,5 @@ def test_non_list_input_raises():
 def test_has_regression_and_exit_semantics():
     clean = cr.compare([_record({})], [_record({})])
     assert not cr.has_regression(clean)
-    flipped = cr.compare(
-        [_record({}, status="success")], [_record({}, status="failed")]
-    )
+    flipped = cr.compare([_record({}, status="success")], [_record({}, status="failed")])
     assert cr.has_regression(flipped)

--- a/tests/unit/evalharness/test_default_harness.py
+++ b/tests/unit/evalharness/test_default_harness.py
@@ -256,6 +256,7 @@ def test_ensure_builtin_agents_swallows_only_import_errors(
     top, etc.) must bubble out so the operator sees the real failure
     instead of a silent ``debug`` log.
     """
+
     # Case 1: ImportError is swallowed — function returns normally.
     def fake_import_missing_sdk(name: str) -> Any:
         raise ImportError("anthropic SDK not installed")

--- a/tests/unit/evalharness/test_e2e_smoke.py
+++ b/tests/unit/evalharness/test_e2e_smoke.py
@@ -205,9 +205,7 @@ def test_optimize_scale_smoke_end_to_end(
     real_start_scenario = harness.start_scenario
 
     def patched_start_scenario(chaos_specs, mapping, ctx):
-        return real_start_scenario(
-            chaos_specs, mapping, ctx, skip_port_forward=True
-        )
+        return real_start_scenario(chaos_specs, mapping, ctx, skip_port_forward=True)
 
     monkeypatch.setattr(harness, "start_scenario", patched_start_scenario)
 
@@ -217,9 +215,7 @@ def test_optimize_scale_smoke_end_to_end(
         # Inject without driving a real LLM / fortio binary.
         patch.object(GenerateLoadFault, "inject", _fake_inject),
         # Verification: typed result returned without touching k8s.
-        patch.object(
-            VerifierAgent, "wait_for_condition", _fake_verification_result
-        ),
+        patch.object(VerifierAgent, "wait_for_condition", _fake_verification_result),
         # Metrics: registry-driven loop replaced with the fake scorer so the
         # smoke does not pull deepeval / a real judge.
         patch(
@@ -227,9 +223,7 @@ def test_optimize_scale_smoke_end_to_end(
             _fake_evaluate_metrics,
             create=True,
         ),
-        patch(
-            "devops_bench.metrics.get_judge_model", lambda: object(), create=True
-        ),
+        patch("devops_bench.metrics.get_judge_model", lambda: object(), create=True),
     ):
         results = harness.run(tasks)
 
@@ -281,9 +275,7 @@ def test_optimize_scale_smoke_end_to_end(
     assert record["chaos_report"]["status"] == "success"
     assert record["chaos_report"]["injected_fault"] == "generate_load"
     assert record["chaos_report"]["verification"]["success"] is True
-    assert record["chaos_report"]["verification"]["name"] == (
-        "Planned Load Spike Verification"
-    )
+    assert record["chaos_report"]["verification"]["name"] == ("Planned Load Spike Verification")
     assert record["perf_report"]["uptime_percentage"] == 100.0
 
     # ----- scores wrote in place via the (stubbed) metrics registry ------
@@ -329,26 +321,20 @@ def test_smoke_uses_workspace_path_for_artifact_diff(
         # context, so the artifact diff cannot regress to ``"."`` hardcoded.
         assert ctx.workspace_path is not None
         assert os.fspath(ctx.workspace_path) == str(sandbox.resolve())
-        return real_start_scenario(
-            chaos_specs, mapping, ctx, skip_port_forward=True
-        )
+        return real_start_scenario(chaos_specs, mapping, ctx, skip_port_forward=True)
 
     monkeypatch.setattr(harness, "start_scenario", patched_start_scenario)
 
     with (
         patch.object(TimeTrigger, "wait", lambda self, ctx: None),
         patch.object(GenerateLoadFault, "inject", _fake_inject),
-        patch.object(
-            VerifierAgent, "wait_for_condition", _fake_verification_result
-        ),
+        patch.object(VerifierAgent, "wait_for_condition", _fake_verification_result),
         patch(
             "devops_bench.metrics.evaluate_metrics_batch",
             _fake_evaluate_metrics,
             create=True,
         ),
-        patch(
-            "devops_bench.metrics.get_judge_model", lambda: object(), create=True
-        ),
+        patch("devops_bench.metrics.get_judge_model", lambda: object(), create=True),
     ):
         results = harness.run(tasks)
 

--- a/tests/unit/evalharness/test_reporter.py
+++ b/tests/unit/evalharness/test_reporter.py
@@ -371,9 +371,7 @@ def test_verification_parse_errors_flow_into_success_record(
         agent_res=_stub_agent_result(),
         chaos_report={},
         perf_report={},
-        verification_parse_errors=[
-            {"name": "broken", "reason": "missing type discriminator"}
-        ],
+        verification_parse_errors=[{"name": "broken", "reason": "missing type discriminator"}],
     )
     assert record["verification_parse_errors"] == [
         {"name": "broken", "reason": "missing type discriminator"}
@@ -394,9 +392,7 @@ def test_verification_parse_errors_flow_into_failed_record(
         RuntimeError("boom"),
         verification_parse_errors=[{"name": "broken", "reason": "bad type"}],
     )
-    assert record["verification_parse_errors"] == [
-        {"name": "broken", "reason": "bad type"}
-    ]
+    assert record["verification_parse_errors"] == [{"name": "broken", "reason": "bad type"}]
 
 
 def test_record_carries_generation_only_and_validated(isolated_env: None) -> None:

--- a/tests/unit/evalharness/test_scenario.py
+++ b/tests/unit/evalharness/test_scenario.py
@@ -212,9 +212,7 @@ def test_scenario_resolves_verify_against_mapping() -> None:
     spec = _build_spec(verify_key="planned-verify")
     verification_node = object()  # opaque stand-in; VerifierAgent is mocked
 
-    fake_result = VerificationResult(
-        success=True, elapsed_time=2.5, reason="all good"
-    )
+    fake_result = VerificationResult(success=True, elapsed_time=2.5, reason="all good")
 
     with (
         patch.object(TimeTrigger, "wait", lambda self, ctx: None),
@@ -225,9 +223,7 @@ def test_scenario_resolves_verify_against_mapping() -> None:
                 success=True, injected_fault=self.type, elapsed_time=0.0
             ),
         ),
-        patch.object(
-            VerifierAgent, "wait_for_condition", return_value=fake_result
-        ) as mock_wait,
+        patch.object(VerifierAgent, "wait_for_condition", return_value=fake_result) as mock_wait,
     ):
         manager = ScenarioManager(
             target_deployment="dep",
@@ -384,9 +380,7 @@ def test_scenario_resolves_lb_ip_and_points_action_url_at_it() -> None:
         captured["service_url"] = self.target.service_url
         return ChaosResult(success=True, injected_fault=self.type, elapsed_time=0.0)
 
-    fake_svc = {
-        "status": {"loadBalancer": {"ingress": [{"ip": "34.10.20.30"}]}}
-    }
+    fake_svc = {"status": {"loadBalancer": {"ingress": [{"ip": "34.10.20.30"}]}}}
 
     with (
         patch.object(TimeTrigger, "wait", lambda self, ctx: None),

--- a/tests/unit/evalharness/test_single_env_read.py
+++ b/tests/unit/evalharness/test_single_env_read.py
@@ -60,9 +60,10 @@ def test_harness_reads_use_mcp_once_at_construction(
     """``BENCH_USE_MCP`` is read once during ``__init__``, not on every method."""
     monkeypatch.setenv("BENCH_USE_MCP", "true")
 
-    with patch("devops_bench.evalharness.default.get_bool", wraps=__import__(
-        "devops_bench.core", fromlist=["get_bool"]
-    ).get_bool) as wrapped:
+    with patch(
+        "devops_bench.evalharness.default.get_bool",
+        wraps=__import__("devops_bench.core", fromlist=["get_bool"]).get_bool,
+    ) as wrapped:
         harness = DefaultEvalHarness(project_id="p", cluster_name="c")
 
         bench_use_mcp_reads = [

--- a/tests/unit/metrics/test_metrics_base.py
+++ b/tests/unit/metrics/test_metrics_base.py
@@ -38,9 +38,7 @@ def test_metric_score_to_entry_bare_value_for_rate_metrics():
 
 def test_metric_score_to_entry_dict_for_judged_metrics():
     # Judged metrics: success + reason flip the entry to the legacy dict shape.
-    ms = MetricScore(
-        name="OutcomeValidity", score=0.9, success=True, reason="solid"
-    )
+    ms = MetricScore(name="OutcomeValidity", score=0.9, success=True, reason="solid")
     assert ms.to_entry() == {"score": 0.9, "success": True, "reason": "solid"}
 
 
@@ -64,14 +62,10 @@ def test_run_geval_strips_geval_suffix_exactly_once(mocker):
     # and emit the bare name.
     test_result = SimpleNamespace(
         metrics_data=[
-            SimpleNamespace(
-                name="OutcomeValidity [GEval]", score=0.7, success=True, reason="ok"
-            )
+            SimpleNamespace(name="OutcomeValidity [GEval]", score=0.7, success=True, reason="ok")
         ]
     )
-    mocker.patch(
-        "deepeval.evaluate", return_value=SimpleNamespace(test_results=[test_result])
-    )
+    mocker.patch("deepeval.evaluate", return_value=SimpleNamespace(test_results=[test_result]))
 
     out = run_geval(MagicMock(), [MagicMock()])
 
@@ -85,15 +79,9 @@ def test_run_geval_strips_geval_suffix_exactly_once(mocker):
 def test_run_geval_leaves_non_geval_names_alone(mocker):
     # Metric data that does not carry the suffix passes through unchanged.
     test_result = SimpleNamespace(
-        metrics_data=[
-            SimpleNamespace(
-                name="GracefulRecovery", score=4.0, success=True, reason="r"
-            )
-        ]
+        metrics_data=[SimpleNamespace(name="GracefulRecovery", score=4.0, success=True, reason="r")]
     )
-    mocker.patch(
-        "deepeval.evaluate", return_value=SimpleNamespace(test_results=[test_result])
-    )
+    mocker.patch("deepeval.evaluate", return_value=SimpleNamespace(test_results=[test_result]))
 
     out = run_geval(MagicMock(), [MagicMock()])
 

--- a/tests/unit/metrics/test_metrics_chaos.py
+++ b/tests/unit/metrics/test_metrics_chaos.py
@@ -24,12 +24,8 @@ from devops_bench.metrics.chaos_metrics import evaluate_chaos_metrics
 
 
 def _chaos_result():
-    diag = SimpleNamespace(
-        name="DiagnosisAccuracy [GEval]", score=5.0, success=True, reason="r"
-    )
-    rec = SimpleNamespace(
-        name="GracefulRecovery", score=4.0, success=True, reason="r"
-    )
+    diag = SimpleNamespace(name="DiagnosisAccuracy [GEval]", score=5.0, success=True, reason="r")
+    rec = SimpleNamespace(name="GracefulRecovery", score=4.0, success=True, reason="r")
     test_result = SimpleNamespace(metrics_data=[diag, rec])
     return SimpleNamespace(test_results=[test_result])
 
@@ -74,10 +70,9 @@ def test_chaos_defaults_fault_and_survives_eval_error(mocker):
     mocker.patch.object(
         chaos_metrics,
         "GEval",
-        side_effect=lambda **kw: captured.setdefault("criteria", []).append(
-            kw["criteria"]
-        )
-        or MagicMock(),
+        side_effect=lambda **kw: (
+            captured.setdefault("criteria", []).append(kw["criteria"]) or MagicMock()
+        ),
     )
     mocker.patch("deepeval.evaluate", side_effect=RuntimeError("judge down"))
     scores: dict = {}

--- a/tests/unit/metrics/test_metrics_grounding.py
+++ b/tests/unit/metrics/test_metrics_grounding.py
@@ -120,9 +120,7 @@ def test_grounding_no_constraints_returns_early(mocker):
     evaluate = mocker.patch("deepeval.evaluate")
     scores: dict = {}
 
-    evaluate_documentation_grounding(
-        [{"constraints": []}], MagicMock(), MagicMock(), scores
-    )
+    evaluate_documentation_grounding([{"constraints": []}], MagicMock(), MagicMock(), scores)
 
     evaluate.assert_not_called()
     assert scores == {}
@@ -204,9 +202,7 @@ def test_grounding_dedups_shared_constraint_text(mocker):
         {"constraints": [{"text": "use TLS", "critical": True}]},
     ]
     scores: dict = {}
-    evaluate = _evaluate_by_outcome(
-        mocker, {"Doc Constraint: use TLS": (5.0, True)}
-    )
+    evaluate = _evaluate_by_outcome(mocker, {"Doc Constraint: use TLS": (5.0, True)})
 
     evaluate_documentation_grounding(docs, MagicMock(), MagicMock(), scores)
 

--- a/tests/unit/metrics/test_metrics_pipeline.py
+++ b/tests/unit/metrics/test_metrics_pipeline.py
@@ -32,9 +32,7 @@ from devops_bench.metrics.pipeline import (
 
 def test_checklist_extracts_critical_requirements_bullets():
     expected = (
-        "Critical Requirements:\n"
-        "- Deployment must use 3 replicas\n"
-        "- Service exposes port 8080\n"
+        "Critical Requirements:\n- Deployment must use 3 replicas\n- Service exposes port 8080\n"
     )
     assert extract_checklist_items(expected, use_mcp=True) == [
         "Deployment must use 3 replicas",
@@ -53,11 +51,7 @@ def test_checklist_stops_at_expected_manifest_marker():
 
 
 def test_checklist_drops_tool_call_items_when_mcp_disabled():
-    expected = (
-        "Critical Requirements:\n"
-        "- Expected Tool Call: apply_manifest\n"
-        "- App is reachable\n"
-    )
+    expected = "Critical Requirements:\n- Expected Tool Call: apply_manifest\n- App is reachable\n"
     assert extract_checklist_items(expected, use_mcp=False) == ["App is reachable"]
     assert extract_checklist_items(expected, use_mcp=True) == [
         "Expected Tool Call: apply_manifest",
@@ -72,9 +66,7 @@ def test_checklist_empty_when_no_bullets():
 def test_checklist_preserves_trailing_hyphen():
     # ``lstrip("- ")`` must not eat a trailing hyphen the way ``strip("- ")`` would.
     expected = "Critical Requirements:\n- Deploy to namespace staging-\n"
-    assert extract_checklist_items(expected, use_mcp=True) == [
-        "Deploy to namespace staging-"
-    ]
+    assert extract_checklist_items(expected, use_mcp=True) == ["Deploy to namespace staging-"]
 
 
 def test_checklist_threshold_is_value_independent_of_tool_invocation():
@@ -87,9 +79,7 @@ def test_checklist_threshold_is_value_independent_of_tool_invocation():
 
 
 def _metric_result(name, score=1.0, success=True, reason="ok"):
-    metric_data = SimpleNamespace(
-        name=name, score=score, success=success, reason=reason
-    )
+    metric_data = SimpleNamespace(name=name, score=score, success=success, reason=reason)
     test_result = SimpleNamespace(metrics_data=[metric_data])
     return SimpleNamespace(test_results=[test_result])
 
@@ -236,9 +226,7 @@ def test_batch_invokes_grounding_and_chaos(mocker):
     from devops_bench.metrics import chaos_metrics, grounding
 
     grounding_call = mocker.patch.object(grounding, "evaluate_documentation_grounding")
-    retrieval = mocker.patch.object(
-        grounding, "calculate_doc_retrieval_rate", return_value=0.5
-    )
+    retrieval = mocker.patch.object(grounding, "calculate_doc_retrieval_rate", return_value=0.5)
     chaos = mocker.patch.object(chaos_metrics, "evaluate_chaos_metrics")
     judge = MagicMock()
     results = [
@@ -282,9 +270,7 @@ def test_batch_score_insertion_order_matches_legacy_results_json(mocker):
             }
         ),
     )
-    mocker.patch.object(
-        grounding, "calculate_doc_retrieval_rate", return_value=0.5
-    )
+    mocker.patch.object(grounding, "calculate_doc_retrieval_rate", return_value=0.5)
     mocker.patch.object(
         chaos_metrics,
         "evaluate_chaos_metrics",
@@ -311,6 +297,7 @@ def test_batch_score_insertion_order_matches_legacy_results_json(mocker):
     evaluate_metrics_batch(results, MagicMock(), use_mcp=True)
 
     keys = list(results[0]["scores"].keys())
+
     # Locate the section anchors and assert outcome -> tool -> checklist ->
     # grounding -> chaos. We pin the first-occurrence index of one canonical
     # key from each family so the assertion is robust to the per-family
@@ -337,9 +324,7 @@ def test_canonical_tool_name_strips_mcp_prefix():
 
 
 def test_build_context_threads_generation_only(mocker):
-    mocker.patch.object(
-        pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw)
-    )
+    mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
     ctx = pipeline._build_context(_base_result(generation_only=True), MagicMock(), True)
     assert ctx.generation_only is True
     # Absent key defaults to False.
@@ -347,9 +332,7 @@ def test_build_context_threads_generation_only(mocker):
 
 
 def test_build_context_normalizes_tool_names_for_judge(mocker):
-    mocker.patch.object(
-        pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw)
-    )
+    mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
     res = _base_result(
         tools=["default__generate_manifest"],
         trajectory=[{"name": "default__generate_manifest", "status": "completed"}],

--- a/tests/unit/metrics/test_metrics_skills.py
+++ b/tests/unit/metrics/test_metrics_skills.py
@@ -50,19 +50,12 @@ def _patch_resources(mocker, files_by_name):
 
 
 def test_load_skill_text_reads_packaged_resource(mocker):
-    _patch_resources(
-        mocker, {"outcome-validity-checklist.md": "## Evaluation Criteria"}
-    )
-    assert (
-        _skills.load_skill_text("outcome-validity-checklist.md")
-        == "## Evaluation Criteria"
-    )
+    _patch_resources(mocker, {"outcome-validity-checklist.md": "## Evaluation Criteria"})
+    assert _skills.load_skill_text("outcome-validity-checklist.md") == "## Evaluation Criteria"
 
 
 def test_load_outcome_criteria_uses_loader(mocker):
-    _patch_resources(
-        mocker, {outcome_validity.OUTCOME_SKILL_FILENAME: "OUTCOME-MD"}
-    )
+    _patch_resources(mocker, {outcome_validity.OUTCOME_SKILL_FILENAME: "OUTCOME-MD"})
     assert outcome_validity.load_outcome_criteria() == "OUTCOME-MD"
 
 

--- a/tests/unit/metrics/test_package_import.py
+++ b/tests/unit/metrics/test_package_import.py
@@ -40,9 +40,7 @@ def _fresh_import(module: str) -> set[str]:
         f"import {module}  # noqa: F401\n"
         f"print([s for s in {_SDKS!r} if s in sys.modules])\n"
     )
-    proc = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
-    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, proc.stderr
     return set(eval(proc.stdout.strip()))  # noqa: S307 - trusted child output
 
@@ -54,9 +52,7 @@ def test_metrics_exposes_public_symbols():
         "assert hasattr(m, 'MetricScore')\n"
         "print('ok')\n"
     )
-    proc = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
-    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, proc.stderr
     assert "ok" in proc.stdout
 

--- a/tests/unit/models/test_loop.py
+++ b/tests/unit/models/test_loop.py
@@ -109,8 +109,7 @@ def _dispatcher_recording(results: dict[str, str]):
 async def test_turn_cap_warns_and_stops_at_max_turns(caplog):
     # Every turn issues a tool call, so only the cap stops the loop.
     turns = [
-        _Turn(text=f"turn{i}", calls=[{"name": "t", "args": {}, "id": str(i)}])
-        for i in range(5)
+        _Turn(text=f"turn{i}", calls=[{"name": "t", "args": {}, "id": str(i)}]) for i in range(5)
     ]
     client = FakeLLMClient(turns)
     dispatch, _ = _dispatcher_recording({"t": "ok"})

--- a/tests/unit/verification/test_optimize_scale_regression.py
+++ b/tests/unit/verification/test_optimize_scale_regression.py
@@ -88,12 +88,8 @@ def test_optimize_scale_spec_dispatches_end_to_end_with_stubbed_leaves():
             success=True, elapsed_time=0.0, reason="pods ready", name=self.name
         )
 
-    def fake_scale(
-        self: ScalingCompleteVerifier, timeout_sec: float
-    ) -> VerificationResult:
-        return VerificationResult(
-            success=True, elapsed_time=0.0, reason="scaled", name=self.name
-        )
+    def fake_scale(self: ScalingCompleteVerifier, timeout_sec: float) -> VerificationResult:
+        return VerificationResult(success=True, elapsed_time=0.0, reason="scaled", name=self.name)
 
     with (
         patch.object(PodHealthyVerifier, "verify", fake_pod),

--- a/tests/unit/verification/test_package_import.py
+++ b/tests/unit/verification/test_package_import.py
@@ -34,8 +34,6 @@ def test_import_pulls_no_heavy_sdks():
         "    assert forbidden not in loaded, forbidden\n"
         "print('ok')\n"
     )
-    proc = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
-    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, proc.stderr
     assert "ok" in proc.stdout

--- a/tests/unit/verification/test_pod_healthy.py
+++ b/tests/unit/verification/test_pod_healthy.py
@@ -114,8 +114,6 @@ def test_name_is_echoed_onto_result():
         "devops_bench.verification.verifiers.pod_healthy.wait",
         return_value=completed,
     ):
-        result = PodHealthyVerifier(name="web-pods", selector="app=web").verify(
-            timeout_sec=10
-        )
+        result = PodHealthyVerifier(name="web-pods", selector="app=web").verify(timeout_sec=10)
 
     assert result.name == "web-pods"

--- a/tests/unit/verification/test_runner.py
+++ b/tests/unit/verification/test_runner.py
@@ -428,9 +428,7 @@ def test_parallel_leaf_unhandled_exception_becomes_failed_child_not_group_abort(
     def bad_pod(self: PodHealthyVerifier, timeout_sec: float) -> VerificationResult:
         raise RuntimeError("boom")
 
-    def ok_scale(
-        self: ScalingCompleteVerifier, timeout_sec: float
-    ) -> VerificationResult:
+    def ok_scale(self: ScalingCompleteVerifier, timeout_sec: float) -> VerificationResult:
         return _stub_result(success=True, reason="scaled")
 
     spec = VerificationSpec(

--- a/tests/unit/verification/test_scaling_complete.py
+++ b/tests/unit/verification/test_scaling_complete.py
@@ -31,9 +31,7 @@ def test_success_when_ready_replicas_meet_minimum():
         "devops_bench.verification.verifiers.scaling_complete.get_resource",
         return_value=deployment,
     ):
-        result = ScalingCompleteVerifier(
-            deployment="web", min_replicas=2
-        ).verify(timeout_sec=5)
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=2).verify(timeout_sec=5)
 
     assert result.success is True
     assert "Ready replicas (3) >= min replicas (2)" in result.reason
@@ -48,9 +46,7 @@ def test_failure_when_ready_replicas_below_minimum():
         "devops_bench.verification.verifiers.scaling_complete.get_resource",
         return_value=deployment,
     ):
-        result = ScalingCompleteVerifier(
-            deployment="web", min_replicas=3
-        ).verify(timeout_sec=0)
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=3).verify(timeout_sec=0)
 
     assert result.success is False
     assert "Ready replicas (1) < min replicas (3)" in result.reason
@@ -64,9 +60,7 @@ def test_null_status_does_not_crash_check():
         "devops_bench.verification.verifiers.scaling_complete.get_resource",
         return_value=deployment,
     ):
-        result = ScalingCompleteVerifier(
-            deployment="web", min_replicas=1
-        ).verify(timeout_sec=0)
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=1).verify(timeout_sec=0)
 
     assert result.success is False
     assert "Ready replicas (0) < min replicas (1)" in result.reason
@@ -77,9 +71,7 @@ def test_subprocess_error_is_reported_in_reason():
         "devops_bench.verification.verifiers.scaling_complete.get_resource",
         side_effect=SubprocessError(["kubectl"], returncode=1, stderr="not found"),
     ):
-        result = ScalingCompleteVerifier(
-            deployment="web", min_replicas=1
-        ).verify(timeout_sec=0)
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=1).verify(timeout_sec=0)
 
     assert result.success is False
     assert "Failed to get deployment" in result.reason
@@ -93,9 +85,9 @@ def test_success_when_ready_replicas_within_bounds():
         "devops_bench.verification.verifiers.scaling_complete.get_resource",
         return_value=deployment,
     ):
-        result = ScalingCompleteVerifier(
-            deployment="web", min_replicas=1, max_replicas=3
-        ).verify(timeout_sec=5)
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=1, max_replicas=3).verify(
+            timeout_sec=5
+        )
 
     assert result.success is True
     assert "within bounds [1, 3]" in result.reason
@@ -107,9 +99,9 @@ def test_failure_when_ready_replicas_above_maximum():
         "devops_bench.verification.verifiers.scaling_complete.get_resource",
         return_value=deployment,
     ):
-        result = ScalingCompleteVerifier(
-            deployment="web", min_replicas=1, max_replicas=3
-        ).verify(timeout_sec=0)
+        result = ScalingCompleteVerifier(deployment="web", min_replicas=1, max_replicas=3).verify(
+            timeout_sec=0
+        )
 
     assert result.success is False
     assert "Ready replicas (5) > max replicas (3)" in result.reason

--- a/uv.lock
+++ b/uv.lock
@@ -508,7 +508,7 @@ dev = [
     { name = "pre-commit", specifier = ">=3.5.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
-    { name = "ruff", specifier = ">=0.8.2" },
+    { name = "ruff", specifier = "==0.15.17" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bring devops_bench/ + tests/unit/ ruff-format clean (47 files) and add a Format step to guardrails.yml so the baseline holds. Scope the pre-commit ruff hooks to the same paths, and pin ruff exactly (==0.15.17) so a lock refresh cannot shift formatter style; a companion PR brings the same gate and pin upstream.

Open PRs will fail the new Format check until they rebase and run `uv run ruff format devops_bench tests/unit`.

Also included:

**chore(migration): drop the model_providers back-sync stopgap** — core/model_providers.py and its test now exist upstream, which is the stopgap's stated removal condition. The next back-sync reconciles both files with the rest of core/, adopting upstream's review edits (raw!r in the unknown-provider error, anthropic_bedrock test rows).

**docs(migration-prep): run ruff format in the export gate** — upstream CI now enforces `ruff format --check`, so exports must go out formatted, not just lint-clean.