### PR TITLE
fix(metrics): pass expected_output to the GEval judge

### DIFF
--- a/devops_bench/metrics/outcome_validity.py
+++ b/devops_bench/metrics/outcome_validity.py
@@ -43,8 +43,8 @@ OUTCOME_SKILL_FILENAME = "outcome-validity-checklist.md"
 # Appended to the criteria for generation-only tasks (``deployer: noop``), which
 # provision no cluster. Without it the checklist's "Deployment Intent" /
 # "Execution Confirmation" clauses wrongly fail a correct manifest for not being
-# applied. The judge sees only INPUT + ACTUAL_OUTPUT, so it has no other signal
-# that this task is generation-only.
+# applied. None of the judge-visible test-case fields signal that this task is
+# generation-only.
 _GENERATION_ONLY_OVERRIDE = (
     "\n\n## Generation-Only Task Override\n"
     "This task is manifest-generation only: no live cluster is provisioned. "
@@ -93,6 +93,7 @@ def build_outcome_validity_metric(model, *, generation_only: bool = False) -> GE
         evaluation_params=[
             SingleTurnParams.INPUT,
             SingleTurnParams.ACTUAL_OUTPUT,
+            SingleTurnParams.EXPECTED_OUTPUT,
         ],
         model=model,
     )

--- a/devops_bench/metrics/pipeline.py
+++ b/devops_bench/metrics/pipeline.py
@@ -96,7 +96,13 @@ def _build_context(res: dict[str, Any], judge_model: Any, use_mcp: bool) -> Metr
     # here (before the per-metric ``try`` in the batch loop).
     prompt = res["input"]
     actual_output = res["output"]
-    expected_output = res["expected_output"]
+    expected_output = res.get("expected_output", "")
+    if not expected_output:
+        _log.warning(
+            "Result %r has an empty expected_output. If this task is scored by "
+            "the LLM judge, this may skew evaluation scores.",
+            res.get("name"),
+        )
     trajectory = res.get("trajectory", [])
     latency = res.get("latency")
     retrieval_context = res.get("retrieval_context")

--- a/devops_bench/metrics/tool_invocation.py
+++ b/devops_bench/metrics/tool_invocation.py
@@ -73,6 +73,7 @@ def build_tool_invocation_metric(model) -> GEval:
         evaluation_params=[
             SingleTurnParams.INPUT,
             SingleTurnParams.ACTUAL_OUTPUT,
+            SingleTurnParams.EXPECTED_OUTPUT,
         ],
         model=model,
     )

--- a/devops_bench/tasks/schema.py
+++ b/devops_bench/tasks/schema.py
@@ -18,7 +18,11 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from devops_bench.core import get_logger
+
 __all__ = ["Task", "DocumentationEntry", "Constraint"]
+
+_log = get_logger("tasks.schema")
 
 # Strict validation: reject implicit type coercion (e.g. the string ``"yes"``
 # is not a bool), and ignore unknown keys in source specs.
@@ -179,13 +183,22 @@ class Task(BaseModel):
         documentation = raw.get("documentation", [])
         validated = raw.get("validated", False)
 
+        expected_output = _text(raw.get("expected_output", ""))
+        if not expected_output:
+            task_name = name or name_default or str(raw_id or "")
+            _log.warning(
+                "Task %r has an empty expected_output. If this is a judged task, "
+                "this may skew the evaluation scores.",
+                task_name,
+            )
+
         return cls.model_validate(
             {
                 "id": "" if raw_id is None else str(raw_id),
                 "name": name_default if name is None else name,
                 "folder": folder,
                 "prompt": _text(prompt),
-                "expected_output": _text(raw.get("expected_output", "")),
+                "expected_output": expected_output,
                 # An empty YAML block (``key:`` with no value) parses to None;
                 # treat it as the field's empty default rather than rejecting it.
                 "retrieval_context": [] if retrieval is None else retrieval,

--- a/tests/unit/metrics/test_metrics_pipeline.py
+++ b/tests/unit/metrics/test_metrics_pipeline.py
@@ -358,3 +358,36 @@ def test_outcome_validity_override_only_when_generation_only(mocker):
     assert outcome_validity._GENERATION_ONLY_OVERRIDE not in captured["criteria"]
     outcome_validity.build_outcome_validity_metric(MagicMock(), generation_only=True)
     assert outcome_validity._GENERATION_ONLY_OVERRIDE in captured["criteria"]
+
+
+def test_build_context_warns_on_empty_expected_output(caplog, mocker):
+    mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
+    import logging
+
+    res = _base_result(expected_output="")
+    with caplog.at_level(logging.WARNING):
+        pipeline._build_context(res, MagicMock(), True)
+    assert len(caplog.records) == 1
+    assert "has an empty expected_output" in caplog.text
+
+
+def test_build_context_no_warning_when_expected_output_set(caplog, mocker):
+    mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
+    import logging
+
+    res = _base_result(expected_output="App deployed")
+    with caplog.at_level(logging.WARNING):
+        pipeline._build_context(res, MagicMock(), True)
+    assert len(caplog.records) == 0
+
+
+def test_build_context_missing_expected_output_defaults_and_warns(caplog, mocker):
+    mocker.patch.object(pipeline, "LLMTestCase", side_effect=lambda **kw: SimpleNamespace(**kw))
+    import logging
+
+    res = _base_result()
+    del res["expected_output"]
+    with caplog.at_level(logging.WARNING):
+        pipeline._build_context(res, MagicMock(), True)
+    assert len(caplog.records) == 1
+    assert "has an empty expected_output" in caplog.text

--- a/tests/unit/metrics/test_metrics_skills.py
+++ b/tests/unit/metrics/test_metrics_skills.py
@@ -19,10 +19,29 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
+from deepeval.metrics.g_eval.utils import construct_test_case_string
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase, SingleTurnParams
 
 from devops_bench.metrics import _skills, outcome_validity, tool_invocation
 from devops_bench.metrics.base import GEVAL_PASS_THRESHOLD
 from devops_bench.metrics.tool_invocation import TOOL_INVOCATION_THRESHOLD
+
+
+class _StubJudgeModel(DeepEvalBaseLLM):
+    """Minimal DeepEvalBaseLLM stub so GEval can be constructed without credentials."""
+
+    def load_model(self):
+        return self
+
+    def generate(self, prompt: str) -> str:
+        return ""
+
+    async def a_generate(self, prompt: str) -> str:
+        return ""
+
+    def get_model_name(self) -> str:
+        return "stub-judge"
 
 
 def _patch_resources(mocker, files_by_name):
@@ -95,3 +114,37 @@ def test_build_tool_invocation_metric_applies_threshold(mocker):
     assert kwargs["name"] == "ToolInvocation"
     assert kwargs["threshold"] == TOOL_INVOCATION_THRESHOLD
     assert kwargs["model"] is model
+
+
+def test_build_outcome_validity_metric_includes_expected_output(mocker):
+    mocker.patch.object(outcome_validity, "load_outcome_criteria", return_value="CRIT")
+
+    metric = outcome_validity.build_outcome_validity_metric(_StubJudgeModel())
+
+    assert SingleTurnParams.INPUT in metric.evaluation_params
+    assert SingleTurnParams.ACTUAL_OUTPUT in metric.evaluation_params
+    assert SingleTurnParams.EXPECTED_OUTPUT in metric.evaluation_params
+
+
+def test_build_tool_invocation_metric_includes_expected_output(mocker):
+    mocker.patch.object(tool_invocation, "load_tool_criteria", return_value="CRIT")
+
+    metric = tool_invocation.build_tool_invocation_metric(_StubJudgeModel())
+
+    assert SingleTurnParams.INPUT in metric.evaluation_params
+    assert SingleTurnParams.ACTUAL_OUTPUT in metric.evaluation_params
+    assert SingleTurnParams.EXPECTED_OUTPUT in metric.evaluation_params
+
+
+def test_outcome_validity_judge_text_includes_expected_output(mocker):
+    mocker.patch.object(outcome_validity, "load_outcome_criteria", return_value="CRIT")
+    metric = outcome_validity.build_outcome_validity_metric(_StubJudgeModel())
+    case = LLMTestCase(
+        input="do the task",
+        actual_output="did something",
+        expected_output="UNIQUE_EXPECTED_OUTPUT_MARKER",
+    )
+
+    judge_text = construct_test_case_string(metric.evaluation_params, case)
+
+    assert "UNIQUE_EXPECTED_OUTPUT_MARKER" in judge_text

--- a/tests/unit/tasks/test_tasks_schema.py
+++ b/tests/unit/tasks/test_tasks_schema.py
@@ -232,3 +232,24 @@ def test_validated_empty_block_coalesces_false():
 
 def test_validated_roundtrips_in_to_dict():
     assert Task.from_dict({"name": "n", "validated": True}).to_dict()["validated"] is True
+
+
+def test_empty_expected_output_logs_warning(caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        Task.from_dict({"task_id": 1, "name": "my-task"}, name_default="d")
+
+    assert len(caplog.records) == 1
+    assert "has an empty expected_output" in caplog.text
+
+
+def test_set_expected_output_no_warning(caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        Task.from_dict(
+            {"task_id": 1, "name": "my-task", "expected_output": "some output"}, name_default="d"
+        )
+
+    assert len(caplog.records) == 0


### PR DESCRIPTION
# fix(metrics): pass expected_output to the GEval judge

## What

Add `SingleTurnParams.EXPECTED_OUTPUT` to `evaluation_params` for the OutcomeValidity and ToolInvocation GEval metrics, plus regression tests.

## Why

The judge rubrics instruct the judge to compare the agent's output against the task's Expected Output (golden checklist / manifest), but the judge never received that field:

- `devops_bench/skills/outcome-validity-checklist.md:12,22-26` and `devops_bench/skills/tool-invocation-skill.md:14` tell the judge to grade against the "Expected Output" field and the "Golden Manifest".
- `devops_bench/metrics/pipeline.py:116-133` sets `expected_output` on every `LLMTestCase`.
- But `devops_bench/metrics/outcome_validity.py:93-96` and `devops_bench/metrics/tool_invocation.py:73-76` listed only `SingleTurnParams.INPUT` and `SingleTurnParams.ACTUAL_OUTPUT` in `evaluation_params`. A comment at `outcome_validity.py:46-47` even acknowledged "The judge sees only INPUT + ACTUAL_OUTPUT".
- DeepEval's `construct_test_case_string` (`deepeval/metrics/g_eval/utils.py:264-273`, deepeval 4.0.3) serializes only the fields listed in `evaluation_params`, so the expected output text silently never reached the judge LLM. The judge was grading rubric clauses it had no data for.

## Changes

- `devops_bench/metrics/outcome_validity.py`: add `SingleTurnParams.EXPECTED_OUTPUT` to `evaluation_params`; reword the generation-only comment that documented the old behavior.
- `devops_bench/metrics/tool_invocation.py`: same one-line addition.
- `tests/unit/metrics/test_metrics_skills.py`: regression tests asserting both builders include `EXPECTED_OUTPUT` (with `INPUT` and `ACTUAL_OUTPUT` still present), plus a test that runs the metric's real `evaluation_params` through deepeval's `construct_test_case_string` and asserts the expected output text now appears in the judge-visible prompt. All three fail on the pre-fix code.

## Safety notes

- `expected_output` can never be `None` at runtime: `Task.expected_output` defaults to `""` (`devops_bench/tasks/schema.py:139`) and the harness always writes it into result records (`devops_bench/evalharness/default.py:783,823-825`). DeepEval only raises on `None` params, not empty strings, so this cannot crash a run.
- The other GEval metrics (checklist, grounding, chaos) embed their requirement text directly in `criteria` rather than referencing a test-case field, so they don't have this mismatch and are unchanged.
- Expect scores to shift: the judge now actually sees the golden expected output it was told to grade against, so results are not comparable with runs scored before this change.

## Testing

- `uv run pytest`: 887 passed.
- `uv run ruff check devops_bench/ tests/unit/` and `uv run ruff format --check devops_bench/ tests/unit/`: clean. Repo-wide ruff still flags pre-existing issues in legacy `pkg/` and root-level `tests/test_*.py`, which this change does not touch.
