### PR TITLE
fix(evalharness): collect generated files from the agent's real workspace

### DIFF
--- a/devops_bench/agents/api/agent.py
+++ b/devops_bench/agents/api/agent.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import shlex
+from pathlib import Path
 from typing import Any
 
 from devops_bench.agents.api.mcp import MCPClient, extract_tool_text
@@ -388,11 +389,13 @@ class ApiAgent(AgentHarness):
         self.skills = caps.skills
         self.rules = caps.rules
 
-    def _execute(self, prompt: str) -> AgentResult:
+    def _execute(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
         """Build the LLM client, drive the loop, and assemble an AgentResult.
 
         Args:
             prompt: Task prompt handed to the agent.
+            workspace_path: Unused — the API agent drives a remote tool-use
+                loop over MCP/skills with no local filesystem workspace.
 
         Returns:
             An :class:`AgentResult` whose ``trajectory`` is a list of canonical

--- a/devops_bench/agents/base.py
+++ b/devops_bench/agents/base.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import time
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 from devops_bench.agents.config import AgentConfig
 from devops_bench.agents.result import AgentResult
@@ -72,7 +73,7 @@ class AgentHarness(ABC):
     def __init__(self, config: AgentConfig | None = None) -> None:
         self.config = config or AgentConfig()
 
-    def run(self, prompt: str) -> AgentResult:
+    def run(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
         """Execute the agent against ``prompt`` and return a typed result.
 
         Template method: wraps :meth:`_execute` in the latency stamp and the
@@ -81,6 +82,10 @@ class AgentHarness(ABC):
 
         Args:
             prompt: Task prompt handed to the agent.
+            workspace_path: Harness-owned working directory the agent should
+                execute in, when the harness supplies one (so files the agent
+                writes can be diffed and collected afterward). ``None`` lets
+                the agent fall back to its own throwaway working directory.
 
         Returns:
             An :class:`AgentResult` with ``latency`` always populated. A
@@ -89,7 +94,7 @@ class AgentHarness(ABC):
         traced = _maybe_observe(self._execute)
         start = time.monotonic()
         try:
-            result = traced(prompt)
+            result = traced(prompt, workspace_path)
         except Exception as exc:  # noqa: BLE001 - safety net for the whole benchmark
             elapsed = time.monotonic() - start
             _log.exception("agent _execute raised; converting to errored result")
@@ -103,7 +108,7 @@ class AgentHarness(ABC):
         return result
 
     @abstractmethod
-    def _execute(self, prompt: str) -> AgentResult:
+    def _execute(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
         """Run the agent and return its typed result.
 
         Subclass extension point. Implementations build the provider-specific
@@ -114,6 +119,9 @@ class AgentHarness(ABC):
 
         Args:
             prompt: Task prompt handed to the agent.
+            workspace_path: Harness-owned working directory, or ``None`` when
+                the harness has not supplied one. A subclass with no local
+                filesystem workspace (e.g. a pure API agent) may ignore it.
 
         Returns:
             An :class:`AgentResult` (``latency`` may be left zero — the base

--- a/devops_bench/agents/cli/antigravity/agent.py
+++ b/devops_bench/agents/cli/antigravity/agent.py
@@ -20,7 +20,6 @@ import json
 import os
 import pathlib
 import shutil
-import tempfile
 from typing import TYPE_CHECKING
 
 from devops_bench import core
@@ -164,14 +163,15 @@ class AgyCliAgent(base.AgentHarness):
             return candidate
         return "agy"
 
-    def _execute(self, prompt: str) -> agents_result.AgentResult:
+    def _execute(
+        self, prompt: str, workspace_path: pathlib.Path | None = None
+    ) -> agents_result.AgentResult:
         caps = self.config.capabilities
         binary = self._resolve_binary()
 
         env_overlay = _build_env(self.config)
 
-        with tempfile.TemporaryDirectory(prefix="agy-run-") as tmpdir:
-            workdir = pathlib.Path(tmpdir)
+        with cli_capabilities.agent_workdir(workspace_path, prefix="agy-run-") as workdir:
             gemini_dir = workdir / ".gemini"
             # <gemini_dir>/antigravity-cli/ is the single directory agy reads
             # its config from and writes its state to (see the OAuth token,

--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import json
 import os
-import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -44,6 +43,7 @@ from devops_bench.agents.cli.gemini_cli.parsing import parse_stream_json
 from devops_bench.agents.config import AgentConfig
 from devops_bench.agents.result import AgentResult
 from devops_bench.agents.shared.cli_capabilities import (
+    agent_workdir,
     build_mcp_servers,
     materialize_skills,
 )
@@ -204,21 +204,23 @@ class GeminiCliAgent(AgentHarness):
         self.skills = caps.skills
         self.rules = caps.rules
 
-    def _execute(self, prompt: str) -> AgentResult:
+    def _execute(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
         """Build argv, run the CLI, and parse the stream-json output.
 
-        The agent always runs the binary inside a per-run temp working
-        directory and lays down the granted capabilities there before
-        invocation, using the CLI's native workspace channels (all auto-loaded
-        from the cwd, so the user's ``~/.gemini`` stays untouched and concurrent
-        runs never race):
+        The agent runs the binary inside ``workspace_path`` when the harness
+        supplies one, else its own per-run temp working directory, and lays
+        down the granted capabilities there before invocation, using the
+        CLI's native workspace channels (all auto-loaded from the cwd, so the
+        user's ``~/.gemini`` stays untouched and concurrent runs never race):
 
         * ``GEMINI.md`` — the operator brief, when ``rules.text`` is set.
         * ``.gemini/settings.json`` — ``mcpServers`` for each command-bearing
           MCP binding, plus ``skills.enabled`` when skills were materialized.
         * ``.gemini/skills/<name>/SKILL.md`` — one per discovered skill.
 
-        The temp dir is cleaned up when ``_execute`` returns.
+        A temp working directory (used when ``workspace_path`` is ``None``) is
+        cleaned up when ``_execute`` returns; a harness-supplied
+        ``workspace_path`` is left for the harness to collect and clean up.
         """
         caps = self.config.capabilities
         target = os.path.expanduser(self.config.target or "gemini")
@@ -226,8 +228,7 @@ class GeminiCliAgent(AgentHarness):
         env_overlay = _build_env(self.config)
         rules_text = caps.rules.text
 
-        with tempfile.TemporaryDirectory(prefix="gemini-run-") as tmpdir:
-            workdir = Path(tmpdir)
+        with agent_workdir(workspace_path, prefix="gemini-run-") as workdir:
             if rules_text:
                 (workdir / _GEMINI_RULES_FILE).write_text(rules_text, encoding="utf-8")
 
@@ -243,7 +244,7 @@ class GeminiCliAgent(AgentHarness):
                 completed = run(
                     argv,
                     extra_env=env_overlay,
-                    cwd=tmpdir,
+                    cwd=workdir,
                     check=False,
                     timeout=self.config.timeout_sec,
                 )

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -71,6 +71,7 @@ from devops_bench.agents.cli.openclaw.parsing import (
 from devops_bench.agents.config import AgentConfig
 from devops_bench.agents.result import AgentResult
 from devops_bench.agents.shared.cli_capabilities import (
+    agent_workdir,
     build_mcp_servers,
     materialize_skills,
 )
@@ -403,11 +404,12 @@ class OpenClawAgent(AgentHarness):
         candidate = os.path.expanduser("~/bin/oc")
         return candidate if os.path.exists(candidate) else "oc"
 
-    def _execute(self, prompt: str) -> AgentResult:
+    def _execute(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
         """Run ``oc agent --local`` with the granted capabilities and extract the trajectory.
 
-        The granted capabilities are laid down in a per-run temp dir before
-        invocation:
+        The granted capabilities are laid down in ``workspace_path`` (the
+        harness-owned per-run workspace, when supplied, else a throwaway temp
+        dir this method owns) before invocation:
 
         * ``<run>/state`` — ``OPENCLAW_STATE_DIR`` (sessions + skills root).
         * ``<run>/state/skills/<name>/SKILL.md`` — one per discovered skill.
@@ -421,8 +423,7 @@ class OpenClawAgent(AgentHarness):
         oc_bin = self._resolve_oc_bin()
         final_prompt = _prepend_rules(caps.rules.text, prompt)
 
-        with tempfile.TemporaryDirectory(prefix="oc-run-") as rundir:
-            workdir = Path(rundir)
+        with agent_workdir(workspace_path, prefix="oc-run-") as workdir:
             state_dir = workdir / _OPENCLAW_STATE_DIRNAME
             state_dir.mkdir(parents=True, exist_ok=True)
 

--- a/devops_bench/agents/shared/cli_capabilities.py
+++ b/devops_bench/agents/shared/cli_capabilities.py
@@ -21,7 +21,10 @@ skills tree. Importing this module pulls no provider SDK.
 
 from __future__ import annotations
 
+import contextlib
 import os
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -31,11 +34,36 @@ from devops_bench.core import get_logger
 if TYPE_CHECKING:
     from devops_bench.agents.capabilities import McpBinding
 
-__all__ = ["build_mcp_servers", "materialize_skills"]
+__all__ = ["agent_workdir", "build_mcp_servers", "materialize_skills"]
 
 _log = get_logger("agents.shared.cli_capabilities")
 
 _SKILL_FILE = "SKILL.md"
+
+
+@contextlib.contextmanager
+def agent_workdir(workspace_path: Path | None, *, prefix: str) -> Iterator[Path]:
+    """Yield the directory a CLI agent subprocess should run in.
+
+    When the harness supplies ``workspace_path`` (its own per-run workspace,
+    kept alive across the run so artifact collection can diff it afterward),
+    that directory is yielded as-is and is NOT cleaned up here — the harness
+    owns its lifecycle. Otherwise a throwaway ``TemporaryDirectory`` is
+    created and removed on exit, preserving each CLI agent's standalone
+    behavior (e.g. a direct unit-test invocation with no harness workspace).
+
+    Args:
+        workspace_path: The harness-owned workspace directory, or ``None``.
+        prefix: Prefix for the fallback temp directory's name.
+
+    Yields:
+        The directory the CLI agent subprocess should run in.
+    """
+    if workspace_path is not None:
+        yield workspace_path
+        return
+    with tempfile.TemporaryDirectory(prefix=prefix) as tmpdir:
+        yield Path(tmpdir)
 
 
 def build_mcp_servers(mcp_servers: tuple[McpBinding, ...]) -> dict[str, dict]:

--- a/devops_bench/evalharness/artifacts.py
+++ b/devops_bench/evalharness/artifacts.py
@@ -61,10 +61,11 @@ def collect_generated_files(
         run_dir: The run output directory; artifacts land under its
             ``generated_files`` subdirectory.
         source_dir: Directory the agent wrote into; defaults to the current
-            working directory. The harness threads
-            :attr:`~devops_bench.core.RunContext.workspace_path` here so the
-            artifact diff is bound to the per-task workspace, not the process
-            cwd.
+            working directory. The harness threads its harness-owned, per-run
+            :attr:`~devops_bench.core.RunContext.workspace_path` here — the
+            same directory the CLI agent wrapper executes in — so the
+            artifact diff is bound to the per-task workspace, not the
+            harness process's cwd.
 
     Returns:
         The names of the entries that were copied.

--- a/devops_bench/evalharness/base.py
+++ b/devops_bench/evalharness/base.py
@@ -68,8 +68,8 @@ class Harness(ABC):
             task: The task being evaluated.
             cluster: Provisioned cluster details, if any.
             workspace_path: Working directory the agent operates in; ``None``
-                lets the caller leave the field unset (the harness defaults to
-                the current working directory when it needs a concrete path).
+                lets the caller leave the field unset until it builds a
+                concrete per-run workspace.
 
         Returns:
             A :class:`~devops_bench.core.RunContext` seeded with task metadata.

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -666,6 +666,8 @@ class DefaultEvalHarness(Harness):
             _log.info("executing agent for prompt: %s", prompt)
             before_files = snapshot_dir(workspace_path)
             agent_res = self.execute_agent(prompt, context)
+            # NOTE/TODO: This collects ALL frontmatter from bootstrapping, not just generated files.
+            # Consider a more targeted filter in a future iteration.
             collect_generated_files(before_files, run_dir, source_dir=workspace_path)
 
             expected_output = self.replace_placeholders(task.expected_output, active_cluster_name)

--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -20,7 +20,8 @@ import copy
 import datetime
 import importlib
 import json
-import os
+import shutil
+import tempfile
 import threading
 from dataclasses import replace
 from pathlib import Path
@@ -501,20 +502,21 @@ class DefaultEvalHarness(Harness):
 
     # -- agent execution --------------------------------------------------
 
-    def execute_agent(self, prompt: str, _ctx: RunContext) -> AgentResult:
+    def execute_agent(self, prompt: str, ctx: RunContext) -> AgentResult:
         """Run the configured agent against ``prompt`` through the registry.
 
         Args:
             prompt: The (placeholder-resolved) task prompt.
-            _ctx: The per-task run context. Reserved for future per-run hooks;
-                agents consume only the resolved prompt and rely on their
-                :class:`AgentConfig` for everything else.
+            ctx: The per-task run context. ``ctx.workspace_path`` is handed to
+                the agent so a CLI wrapper executes in the harness-owned
+                workspace instead of a throwaway directory the harness never
+                inspects.
 
         Returns:
             The typed :class:`AgentResult` the agent emitted.
         """
         agent = self.resolve_agent(self.agent_type)
-        return agent.run(prompt)
+        return agent.run(prompt, workspace_path=ctx.workspace_path)
 
     # -- pipeline ---------------------------------------------------------
 
@@ -617,7 +619,7 @@ class DefaultEvalHarness(Harness):
         scenario_manager: ScenarioManager | None = None
         scenario_thread: threading.Thread | None = None
         result: dict[str, Any] | None = None
-        workspace_path = Path(os.getcwd())
+        workspace_path: Path | None = None
         verification_parse_errors: list[dict[str, str]] = []
         # Track the substituted prompt / expectation as they are computed so a
         # failed record can carry the same resolved strings a success record
@@ -634,6 +636,10 @@ class DefaultEvalHarness(Harness):
             deployer.up()
             cluster_info = deployer.get_cluster_info()
             active_cluster_name = cluster_info.name or self.cluster_name
+            # Own a real per-run workspace so the artifact diff is rooted at
+            # the directory the agent actually writes to (its CLI wrapper's
+            # working directory), not the harness process's launch cwd.
+            workspace_path = Path(tempfile.mkdtemp(prefix="devops-bench-workspace-"))
             context = self.make_context(task, cluster=cluster_info, workspace_path=workspace_path)
 
             prompt = self.replace_placeholders(task.prompt, active_cluster_name)
@@ -690,6 +696,8 @@ class DefaultEvalHarness(Harness):
                 scenario_manager.stop()
             if deployer is not None:
                 self._teardown(deployer, infra_config, task.name)
+            if workspace_path is not None:
+                shutil.rmtree(workspace_path, ignore_errors=True)
 
         return result
 

--- a/tests/unit/agents/api/test_agents_api_agent.py
+++ b/tests/unit/agents/api/test_agents_api_agent.py
@@ -793,10 +793,12 @@ def test_api_package_does_not_expose_legacy_context_or_system_instruction():
     import inspect
 
     sig = inspect.signature(ApiAgent.run)
-    assert list(sig.parameters) == ["self", "prompt"], (
-        "ApiAgent.run must take only (self, prompt); the legacy context/"
-        "system_instruction kwargs are gone."
+    assert list(sig.parameters) == ["self", "prompt", "workspace_path"], (
+        "ApiAgent.run must take only (self, prompt, workspace_path); the legacy "
+        "context/system_instruction kwargs are gone."
     )
+    assert "context" not in sig.parameters
+    assert "system_instruction" not in sig.parameters
     init_sig = inspect.signature(ApiAgent.__init__)
     # Inherited from AgentHarness — accepts config only.
     assert list(init_sig.parameters) == ["self", "config"]

--- a/tests/unit/agents/shared/test_cli_capabilities.py
+++ b/tests/unit/agents/shared/test_cli_capabilities.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 from devops_bench.agents.capabilities import McpBinding
 from devops_bench.agents.shared.cli_capabilities import (
+    agent_workdir,
     build_mcp_servers,
     materialize_skills,
 )
@@ -71,3 +72,26 @@ def test_materialize_skills_writes_named_skill_files(tmp_path: Path):
 def test_materialize_skills_skips_missing_paths(tmp_path: Path):
     """A non-existent source path is warned and skipped, not fatal."""
     assert materialize_skills(tmp_path / "dest", (str(tmp_path / "nope"),)) == []
+
+
+def test_agent_workdir_yields_supplied_path_without_cleanup(tmp_path: Path):
+    """A supplied ``workspace_path`` is yielded as-is and left in place afterward."""
+    supplied = tmp_path / "workspace"
+    supplied.mkdir()
+
+    with agent_workdir(supplied, prefix="ignored-") as workdir:
+        assert workdir == supplied
+        (workdir / "marker.txt").write_text("artifact", encoding="utf-8")
+
+    assert supplied.exists()
+    assert (supplied / "marker.txt").read_text(encoding="utf-8") == "artifact"
+
+
+def test_agent_workdir_creates_and_cleans_up_temp_dir_when_no_path_supplied():
+    """``None`` falls back to a prefixed temp dir that is removed on exit."""
+    with agent_workdir(None, prefix="agent-workdir-test-") as workdir:
+        created = workdir
+        assert workdir.is_dir()
+        assert workdir.name.startswith("agent-workdir-test-")
+
+    assert not created.exists()

--- a/tests/unit/agents/test_agents_base.py
+++ b/tests/unit/agents/test_agents_base.py
@@ -33,7 +33,7 @@ def test_abstract_base_cannot_be_instantiated():
 
 def test_subclass_run_returns_typed_result_with_latency():
     class _Stub(AgentHarness):
-        def _execute(self, prompt: str) -> AgentResult:
+        def _execute(self, prompt: str, workspace_path=None) -> AgentResult:
             return AgentResult(output=f"echo:{prompt}", trajectory=[])
 
     result = _Stub().run("hi")
@@ -44,7 +44,7 @@ def test_subclass_run_returns_typed_result_with_latency():
 
 def test_subclass_can_self_stamp_latency():
     class _Stub(AgentHarness):
-        def _execute(self, prompt: str) -> AgentResult:
+        def _execute(self, prompt: str, workspace_path=None) -> AgentResult:
             # Subclasses with finer-grained timing may pre-fill latency; the
             # base must leave that value untouched.
             return AgentResult(output="x", trajectory=[], latency=99.0)
@@ -54,7 +54,7 @@ def test_subclass_can_self_stamp_latency():
 
 def test_safety_net_converts_unexpected_exception_to_errored_result():
     class _Boom(AgentHarness):
-        def _execute(self, prompt: str) -> AgentResult:
+        def _execute(self, prompt: str, workspace_path=None) -> AgentResult:
             raise RuntimeError("kaboom")
 
     result = _Boom().run("hi")
@@ -68,7 +68,7 @@ def test_safety_net_converts_unexpected_exception_to_errored_result():
 
 def test_config_default_is_a_fresh_agent_config():
     class _Stub(AgentHarness):
-        def _execute(self, prompt: str) -> AgentResult:
+        def _execute(self, prompt: str, workspace_path=None) -> AgentResult:
             return AgentResult(output="", trajectory=[])
 
     a = _Stub()
@@ -81,7 +81,7 @@ def test_third_party_can_register_with_no_central_edit():
     """A dummy agent registers via @AGENTS.register and resolves via .get."""
 
     class _Dummy(AgentHarness):
-        def _execute(self, prompt: str) -> AgentResult:
+        def _execute(self, prompt: str, workspace_path=None) -> AgentResult:
             return AgentResult(output="", trajectory=[])
 
     AGENTS.register("dummy-extension")(_Dummy)

--- a/tests/unit/evalharness/test_default_harness.py
+++ b/tests/unit/evalharness/test_default_harness.py
@@ -30,6 +30,7 @@ from typing import Any
 
 import pytest
 
+from devops_bench.agents import AGENTS, AgentHarness
 from devops_bench.agents.result import AgentResult
 from devops_bench.core import MissingDependencyError
 from devops_bench.evalharness import default as harness_default
@@ -244,6 +245,45 @@ def test_run_one_returns_failed_record_when_get_deployer_raises(
     assert record["status"] == "failed"
     assert "unknown deployer type" in record["error"]
     assert record["name"] == "demo"
+
+
+class _WorkspaceWritingAgent(AgentHarness):
+    """Stand-in agent that writes a file into whatever workspace it is given."""
+
+    def _execute(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
+        assert workspace_path is not None
+        (workspace_path / "output.txt").write_text("agent wrote this")
+        return AgentResult(output="wrote a file", trajectory=[])
+
+
+def test_run_one_collects_files_the_agent_writes_to_its_workspace(
+    isolated_env: None, tmp_path: Path
+) -> None:
+    """Generated-file collection diffs the agent's real workspace, not the launch cwd.
+
+    Regression test: the harness used to snapshot/diff ``Path(os.getcwd())`` while
+    each CLI agent wrote into its own private ``tempfile.TemporaryDirectory`` that
+    was gone by the time artifacts were collected, so ``generated_files`` came back
+    empty. The harness now owns a per-run workspace and threads it to the agent via
+    ``RunContext.workspace_path``, so a file the agent writes there is collected.
+    """
+    AGENTS.register("fake-workspace-writer")(_WorkspaceWritingAgent)
+    try:
+        harness = DefaultEvalHarness(
+            project_id="p", cluster_name="c", agent_type="fake-workspace-writer", no_infra=True
+        )
+        task = Task.from_dict({"task_id": "t", "name": "demo", "prompt": "p"})
+        run_dir = tmp_path / "run_1"
+        run_dir.mkdir()
+
+        record = harness._run_one(task, run_dir)  # noqa: SLF001
+
+        assert record["status"] == "success"
+        generated = run_dir / "generated_files" / "output.txt"
+        assert generated.exists()
+        assert generated.read_text() == "agent wrote this"
+    finally:
+        AGENTS._items.pop("fake-workspace-writer", None)  # noqa: SLF001
 
 
 def test_ensure_builtin_agents_swallows_only_import_errors(

--- a/tests/unit/evalharness/test_e2e_smoke.py
+++ b/tests/unit/evalharness/test_e2e_smoke.py
@@ -58,7 +58,7 @@ class _StubAgent(AgentHarness):
 
     last_prompt: str | None = None
 
-    def _execute(self, prompt: str) -> AgentResult:
+    def _execute(self, prompt: str, workspace_path: Path | None = None) -> AgentResult:
         _StubAgent.last_prompt = prompt
         return AgentResult(
             output="Tuned HPA, added requests/limits, observed load handled.",
@@ -297,7 +297,7 @@ def test_smoke_uses_workspace_path_for_artifact_diff(
     smoke_env: None,
     stub_agent_registered: None,
 ) -> None:
-    """Artifact diff is rooted at ``RunContext.workspace_path``, not literal cwd."""
+    """Artifact diff is rooted at a harness-owned workspace, not the launch cwd."""
     tasks = FileSystemTaskLoader().load_tasks(str(_OPTIMIZE_SCALE_DIR))
     harness = DefaultEvalHarness(
         project_id="proj",
@@ -307,20 +307,26 @@ def test_smoke_uses_workspace_path_for_artifact_diff(
     )
 
     # Run the harness from a sandbox so an accidental ``snapshot_dir(".")``
-    # call would diff the empty sandbox — not the user's cwd. The smoke
-    # assertion is that ``run`` completes without writing into the user's
-    # source tree.
+    # call would diff the empty sandbox, not the user's cwd. The assertion
+    # below pins that the workspace threaded to the agent is a fresh
+    # harness-owned directory, distinct from wherever the harness process
+    # happens to be launched from.
     sandbox = tmp_path / "sandbox"
     sandbox.mkdir()
     monkeypatch.chdir(sandbox)
 
+    seen_workspace: Path | None = None
     real_start_scenario = harness.start_scenario
 
     def patched_start_scenario(chaos_specs, mapping, ctx):
-        # Confirm the harness threaded the resolved workspace into the
-        # context, so the artifact diff cannot regress to ``"."`` hardcoded.
+        nonlocal seen_workspace
+        # Confirm the harness threaded a real, harness-owned workspace into
+        # the context — not the harness process's literal launch cwd — so
+        # the artifact diff cannot regress to diffing the wrong directory.
         assert ctx.workspace_path is not None
-        assert os.fspath(ctx.workspace_path) == str(sandbox.resolve())
+        assert ctx.workspace_path.is_dir()
+        assert os.fspath(ctx.workspace_path) != str(sandbox.resolve())
+        seen_workspace = ctx.workspace_path
         return real_start_scenario(chaos_specs, mapping, ctx, skip_port_forward=True)
 
     monkeypatch.setattr(harness, "start_scenario", patched_start_scenario)
@@ -339,6 +345,9 @@ def test_smoke_uses_workspace_path_for_artifact_diff(
         results = harness.run(tasks)
 
     assert len(results) == 1
+    # The harness-owned workspace is cleaned up once the run completes.
+    assert seen_workspace is not None
+    assert not seen_workspace.exists()
     # Generated-files dir is only created when a new entry exists; the stub
     # agent writes nothing, so the dir stays absent.
     run_dirs = [p for p in tmp_path.iterdir() if p.is_dir() and p.name.startswith("run_")]

--- a/tests/unit/evalharness/test_registry_resolution.py
+++ b/tests/unit/evalharness/test_registry_resolution.py
@@ -43,7 +43,9 @@ class _DummyAgent(AgentHarness):
         super().__init__(config)
         _DummyAgent.last_config = self.config
 
-    def _execute(self, prompt: str) -> AgentResult:  # pragma: no cover - never run
+    def _execute(  # pragma: no cover - never run
+        self, prompt: str, workspace_path=None
+    ) -> AgentResult:
         return AgentResult(output=f"echo: {prompt}", trajectory=[])
 
 


### PR DESCRIPTION
# Fix: generated-file artifact collection diffs the wrong directory

## The bug

`generated_files` came back empty (or wrong) for CLI-agent runs because the
harness snapshotted and diffed a directory the agent never wrote to.

- `devops_bench/evalharness/default.py:620` set
  `workspace_path = Path(os.getcwd())`, the harness's own launch cwd, not
  the directory the agent writes to.
- `devops_bench/evalharness/default.py:661-663` snapshotted and diffed that
  same wrong directory around the agent call.
- Each CLI agent wrapper ran its subprocess inside its own private
  `tempfile.TemporaryDirectory`, deleted the moment the wrapper returned,
  before the harness ever inspected it:
  - `devops_bench/agents/cli/gemini_cli/agent.py` (`gemini-run-` prefix)
  - `devops_bench/agents/cli/openclaw/agent.py` (`oc-run-` prefix)
  - `devops_bench/agents/cli/antigravity/agent.py` (`agy-run-` prefix)
- `devops_bench/evalharness/artifacts.py:63-67` documented
  `collect_generated_files`'s `source_dir` as already "bound to the
  per-task workspace, not the process cwd." That was false: nothing wired
  a real per-task workspace anywhere, so the docstring described intent,
  not behavior.

`RunContext.workspace_path` existed and was passed into `make_context`, but
`execute_agent` never forwarded it to the agent, and no agent
implementation had a parameter to receive it. The wiring was incomplete
end to end.

## The fix

`DefaultEvalHarness._run_one` now creates and owns a real per-run workspace
directory (`tempfile.mkdtemp(prefix="devops-bench-workspace-")`) that spans
both agent execution and artifact collection, and is removed in the
`finally` block alongside the rest of teardown. That directory is passed
through the existing `RunContext.workspace_path` field, so the before/after
snapshot and diff in `_run_one` now operate on the directory the agent
actually writes to.

`execute_agent` now forwards `ctx.workspace_path` into `agent.run(...)`.
`AgentHarness.run` / `_execute` take an optional `workspace_path: Path | None
= None` parameter. Each CLI wrapper uses a new shared helper,
`agent_workdir()` in `devops_bench/agents/shared/cli_capabilities.py`, in
place of its own `tempfile.TemporaryDirectory`: it yields the harness-owned
workspace when one is supplied, and falls back to a private temp directory
(not cleaned up by the harness) when the agent is invoked directly, e.g. in
a unit test with no harness in the loop.

The api agent (`devops_bench/agents/api/agent.py`) accepts the same
parameter but ignores it: it drives a remote tool-use loop over MCP/skills
with no local filesystem workspace, so there is nothing for it to do with a
directory.

The `collect_generated_files` docstring in
`devops_bench/evalharness/artifacts.py` and the `workspace_path` docstring
in `devops_bench/evalharness/base.py::make_context` are corrected to
describe what actually happens now.

## Test

`tests/unit/evalharness/test_default_harness.py::test_run_one_collects_files_the_agent_writes_to_its_workspace`
registers a stub agent that writes a file into whatever `workspace_path` it
receives, runs it through `DefaultEvalHarness._run_one` with the noop
deployer, and asserts the file shows up under
`run_dir/generated_files/output.txt`. This fails against the pre-fix code
(the stub would receive no real, persistent workspace to write into) and
passes against the fix.

The `agent_workdir()` helper is directly unit-tested in
`tests/unit/agents/shared/test_cli_capabilities.py`, covering the
harness-supplied path (yielded as-is, not cleaned up by the helper) and the
`None` fallback (a prefixed temp dir that is created and removed on exit).

Full suite: `uv run pytest tests/unit -q` passes with 0 failures.
`uv run ruff check .` and `uv run ruff format .` are clean on every file
touched by this change.
