### PR TITLE
fix(site): migrate manualChunks to rolldown codeSplitting for vite 8

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -183,7 +183,7 @@ replaces `generateRaw()` with an eval-results adapter and **reuses the same
 ```
 site/
 ├── index.html              # Vite entry: <div id="root"> + /src/main.jsx
-├── vite.config.js          # @vitejs/plugin-react, manualChunks, Vitest config
+├── vite.config.js          # @vitejs/plugin-react, codeSplitting, Vitest config
 ├── tailwind.config.js      # Tailwind (build-time, not CDN)
 ├── firebase.json           # Hosting (dist + SPA rewrite) + rules for BOTH named DBs
 ├── firestore.rules         # security rules (see §1)
@@ -239,7 +239,7 @@ Firebase Hosting.
 ### Tooling
 
 - **Vite** (`@vitejs/plugin-react`) — dev server; production build to `dist/`, split
-  into `react` / `firebase` / `charts` vendor chunks via `manualChunks`.
+  into `react` / `firebase` / `charts` vendor chunks via rolldown `codeSplitting` groups.
 - **Tailwind** via PostCSS (purged at build; no CDN).
 - **Firebase** modular SDK (tree-shaken) on the client; **firebase-admin** in `seed/`.
 - **Chart.js** via `react-chartjs-2`.

--- a/site/vite.config.js
+++ b/site/vite.config.js
@@ -9,15 +9,28 @@ export default defineConfig({
     base: process.env.VITE_BASE_PATH || "/",
     plugins: [react()],
     build: {
-        rollupOptions: {
+        rolldownOptions: {
             output: {
                 // Split the heavy third-party deps into their own chunks so a code
                 // change doesn't bust the vendor cache and the app loads them in
                 // parallel. (Avoids the single >500 kB bundle warning.)
-                manualChunks: {
-                    react: ["react", "react-dom", "react-router-dom"],
-                    firebase: ["firebase/app", "firebase/firestore"],
-                    charts: ["chart.js", "react-chartjs-2"]
+                // Vite 8's rolldown bundler dropped the manualChunks object form;
+                // codeSplitting groups are its replacement.
+                codeSplitting: {
+                    groups: [
+                        {
+                            name: "react",
+                            test: /[\\/]node_modules[\\/](react|react-dom|react-router|react-router-dom|scheduler|@remix-run)[\\/]/
+                        },
+                        {
+                            name: "firebase",
+                            test: /[\\/]node_modules[\\/](firebase|@firebase|idb)[\\/]/
+                        },
+                        {
+                            name: "charts",
+                            test: /[\\/]node_modules[\\/](chart\.js|react-chartjs-2|@kurkle)[\\/]/
+                        }
+                    ]
                 }
             }
         }


### PR DESCRIPTION
## Problem

The Pages deploy broke after the dependabot vite 5 → 8 bump (685ee97): [failed run](https://github.com/gke-labs/devops-bench/actions/runs/29297772527/job/86974900417).

Vite 8's rolldown bundler no longer supports the object form of `build.rollupOptions.output.manualChunks` — the build warns `Expected Function but received Object` and then fails with `TypeError: manualChunks is not a function`.

## Fix

Replace it with rolldown's replacement, `build.rolldownOptions.output.codeSplitting` groups, producing the same `react` / `firebase` / `charts` vendor chunks as before. Updated the two `site/README.md` mentions.

## Verification

- `VITE_BASE_PATH=/devops-bench/ npm run build:staging` passes on vite 8.1.4 with no warnings; output chunks: `react` 161.9 kB, `charts` 168.0 kB, `firebase` 461.4 kB, and `index.html` assets are prefixed with `/devops-bench/`.
- `npm test` (vitest 4.1.10): 11 files, 95 tests, all pass.