### PR TITLE
chore(migration): content-parity flip detection, task+stack flip-groups, keep tf/ path

### DIFF
--- a/.github/workflows/suggest-flips.yml
+++ b/.github/workflows/suggest-flips.yml
@@ -25,15 +25,15 @@ jobs:
           # Use bot PAT so git operations attribute to the migration bot.
           token: ${{ secrets.SYNC_BOT_TOKEN }}
 
-      - name: List upstream files (public, anonymous)
+      - name: List upstream tree with blob hashes (public, anonymous)
         run: |
           set -euo pipefail
           git fetch --quiet --depth=1 https://github.com/kubernetes-sigs/devops-bench.git main
-          git ls-tree -r --name-only FETCH_HEAD > /tmp/upstream-files.txt
-          echo "upstream files: $(wc -l < /tmp/upstream-files.txt)"
+          git ls-tree -r FETCH_HEAD > /tmp/upstream-tree.txt
+          echo "upstream files: $(wc -l < /tmp/upstream-tree.txt)"
 
-      - name: Uncomment entries now present upstream
-        run: ./hack/migration-status.sh --suggest-flips --apply --upstream-files /tmp/upstream-files.txt
+      - name: Uncomment entries whose content has landed upstream
+        run: ./hack/migration-status.sh --suggest-flips --apply --upstream-tree /tmp/upstream-tree.txt
 
       - name: Open / update the flip PR
         env:
@@ -49,7 +49,7 @@ jobs:
           git config user.email "devops-bench-sync-bot@google.com"
           git checkout -B "$BRANCH"
           git add migrated.bara.sky
-          git commit -m "chore(migration): flip modules now present upstream"
+          git commit -m "chore(migration): flip modules whose content landed upstream"
           git push --force origin "$BRANCH"
           # Check if a PR already exists from this branch to prevent swallowing real token/policy failures
           PR_EXISTS=$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number')
@@ -57,8 +57,8 @@ jobs:
             # Keep the body self-contained: do NOT reference the forward/upstream PR
             # (owner/repo#NN or #NN) — GitHub would cross-link gke-labs <-> kubernetes-sigs.
             gh pr create --base main --head "$BRANCH" \
-              --title "Migration: flip modules now present upstream" \
-              --body $'Auto-suggested flips. These entries were uncommented in `migrated.bara.sky` because their paths now exist in kubernetes-sigs. Review and merge to complete the flip: ownership moves upstream, the back-sync turns on, and the path becomes read-only here.'
+              --title "Migration: flip modules whose content landed upstream" \
+              --body $'Auto-suggested flips. These entries were uncommented in `migrated.bara.sky` because every file they cover now exists in kubernetes-sigs with identical content (blob parity), and their flip-group (if any) is complete. Review and merge to complete the flip: ownership moves upstream, the back-sync turns on, and the path becomes read-only here.'
           else
             echo "PR #${PR_EXISTS} is already open; force-push has updated it."
           fi

--- a/copy.bara.sky
+++ b/copy.bara.sky
@@ -55,6 +55,12 @@ NEVER_SYNC = [
     ".python-version",
     "LICENSE",
     "LICENSES/**",
+    # TEMPORARY — remove once the wave-5 metric families land upstream. The wave-3 metrics base
+    # PR ships a trimmed metrics/__init__.py (base surface only); each family PR re-adds its
+    # imports upstream. Until the two files converge, a back-sync of the trimmed init would break
+    # gke-labs (run.py and evalharness/default.py import the full package-root surface). Content
+    # parity already keeps suggest-flips from proposing the entry early; this guards a manual flip.
+    "devops_bench/metrics/__init__.py",
 ]
 
 def frontier_glob():

--- a/docs/migration/pr-plan.md
+++ b/docs/migration/pr-plan.md
@@ -106,7 +106,7 @@ Every PR carries a **wave number**. **All PRs in a wave are mutually independent
 | **2** | foundation `core/` | `core/*` (registry, context, results, logging, subprocess, errors, config, run_env) | toolchain | **Pradeep** |
 | **3** | `tasks/` contracts | `tasks/schema.py`, `tasks/loader.py` | core | **Jessie** |
 | **3** | `skills/` guides | `skills/` (packaged `*.md` guides) | — | **Jessie** |
-| **3** | metrics base | `metrics/base.py` (METRICS registry) | core | **Jessie** |
+| **3** | metrics base | `metrics/base.py` (METRICS registry), plus `__init__.py` trimmed to the base surface — each family PR re-adds its imports, so the init reaches parity (and flips) only after wave 5 | core | **Jessie** |
 | **3** | models base | `models/base.py`, `models/utils/loop.py` (`run_tool_loop`) | core | **Richard** |
 | **3** | agents base | `agents/base.py`, `config.py`, `result.py`, `capabilities/*` | core | **Simran** |
 | **3** | `k8s/` wrappers | `k8s/kubectl.py`, `k8s/conditions.py` | core | **Eugene** |

--- a/docs/migration/pr-plan.md
+++ b/docs/migration/pr-plan.md
@@ -36,7 +36,7 @@ graph TD
     S1["Stage 1: Leaf Modules (Parallel)<br/>(tasks/, providers/, deployers/, k8s/, models/, skills/, results/)"]:::stage
     S2["Stage 2: Main Components (Parallel)<br/>(agents/ base+CLI+API, verification/, chaos/, metrics/)"]:::stage
     S3["Stage 3: Orchestrator Engine<br/>(evalharness/ pipeline + reporter)"]:::stage
-    S4["Stage 4: Data & Integration<br/>(infra/ stacks, tasks/ data, cli/ + integration tests)"]:::stage
+    S4["Stage 4: Data & Integration<br/>(cli/ + integration tests, then tasks/ data coupled with tf/ stacks)"]:::stage
     S5["Stage 5: Developer Experience<br/>(docs, .agents/ skills, references — each after its module)"]:::stage
 
     S0 --> S1
@@ -75,7 +75,7 @@ Built on the leaves: `agents/` (base + CLI + API), `verification/` (needs `k8s/`
 ---
 
 ### Stage 4: Data and entrypoints
-`tf/` → `infra/` (modules + stacks), the benchmark `tasks/` data, and the entrypoints (`cli.py`, `__main__.py`, `run.py`) plus integration tests.
+The entrypoints (`cli.py`, `__main__.py`, `run.py`) plus integration tests, then the benchmark `tasks/` data. `tf/` keeps its path upstream (no `infra/` rename — a rename would churn every stack reference for no benefit). Each task ships **coupled with the `tf/prebuilt/` stack it provisions** — one PR, one `flip-group` in `migrated.bara.sky` — and only after the full pipeline runs upstream, so every task can be validated there before ownership moves. A shared stack (`minimum`, `hypercomputer-d1`) travels with all the tasks that use it.
 
 ---
 
@@ -98,7 +98,7 @@ Every owner completes the [README.md](./README.md) §2 prerequisites independent
 
 ### 3.2 PRs by wave
 
-Every PR carries a **wave number**. **All PRs in a wave are mutually independent and ship in parallel**; a wave opens only once *every* PR in the prior wave is merged upstream **and flipped** in `migrated.bara.sky` (so later PRs can import them via the back-sync). The waves are **derived from the real import edges in `devops_bench/`** (verified against the tree), so nothing in a wave imports anything else in the same wave. Load is balanced at **8–9 PRs per owner**. Waves **1–2** are the unavoidable serial bootstrap (toolchain, then `core/`, imported everywhere); **3–5** are the parallel bulk; **6–8** are the serial orchestrator tail + entrypoints.
+Every PR carries a **wave number**. **All PRs in a wave are mutually independent and ship in parallel**; a wave opens only once *every* PR in the prior wave is merged upstream **and flipped** in `migrated.bara.sky` (so later PRs can import them via the back-sync). The waves are **derived from the real import edges in `devops_bench/`** (verified against the tree), so nothing in a wave imports anything else in the same wave. Load is balanced at **8–9 PRs per owner**. Waves **1–2** are the unavoidable serial bootstrap (toolchain, then `core/`, imported everywhere); **3–5** are the parallel bulk; **6–8** are the serial orchestrator tail + entrypoints; **9** is the benchmark data — each task coupled with the `tf/prebuilt/` stack it provisions (one PR + one `flip-group` per pair) — gated on the full pipeline so tasks are validated upstream before flipping.
 
 | Wave | PR | Paths | Imports (basis) | Owner |
 |:--:|---|---|---|---|
@@ -124,7 +124,7 @@ Every PR carries a **wave number**. **All PRs in a wave are mutually independent
 | **4** | verification base | `verification/base.py`, `spec.py`, `runner.py` | core, k8s | **Jessie** |
 | **4** | metrics judge | `metrics/geval.py`, `pipeline.py`, `_skills.py` | core, models base, skills, metrics base | **Jessie** |
 | **4** | deployers base | `deployers/base.py`, `factory.py` | core, providers | **Eugene** |
-| **4** | Terraform stacks | `tf/prebuilt/` → `infra/stacks/` (split per stack if large) | tf modules | **Eugene** |
+| **4** | default kind stack | `tf/prebuilt/kind/` (the harness's default stack; task-specific stacks ship with their task in wave 9) | tf modules | **Eugene** |
 | **4** | `evalharness/reporter` | `evalharness/reporter.py` | core, results | **Simran** |
 | **5** | deployers: tofu engine | `deployers/tofu.py` | deployers base | **Eugene** |
 | **5** | deployers: noop engine | `deployers/noop.py` | deployers base | **Eugene** |
@@ -138,13 +138,13 @@ Every PR carries a **wave number**. **All PRs in a wave are mutually independent
 | **5** | metric: checklist | `metrics/checklist.py` | metrics judge | **Pradeep** |
 | **5** | metric: outcome-validity | `metrics/outcome_validity.py` | metrics judge | **Jessie** |
 | **5** | metric: chaos-metrics | `metrics/chaos_metrics.py` | metrics judge | **Jessie** |
-| **5** | task data (batch 1) | a slice of `tasks/<group>/<task>/` (YAML + co-located infra) | tasks contracts, stacks | **Eugene** |
-| **5** | task data (batch 2) | a slice of `tasks/…` | tasks contracts, stacks | **Richard** |
-| **5** | task data (batch 3) | a slice of `tasks/…` | tasks contracts, stacks | **Pradeep** |
 | **6** | harness base + scenario | `evalharness/base.py`, `artifacts.py`, `scenario.py` | agents, chaos, verification, deployers | **Simran** |
 | **7** | default eval harness | `evalharness/default.py` | harness base, metrics, results, tasks | **Simran** |
 | **8** | CLI entrypoint | `cli.py`, `__main__.py`, `run.py` | evalharness, metrics, tasks | **Pradeep** |
 | **8** | integration tests | `tests/integration/` | everything | **Pradeep** |
+| **9** | task + stack pairs (common) | each `tasks/common/<task>/` in one PR with the `tf/prebuilt/` stack it provisions; the pair shares a `flip-group` and flips together | tasks contracts + full pipeline (wave 8) | **Eugene** |
+| **9** | task + stack pairs (gcp) | each `tasks/gcp/<task>/` with its stack; shared stacks (`minimum`, `hypercomputer-d1`) carry all their tasks in one flip-group | tasks contracts + full pipeline (wave 8) | **Richard** |
+| **9** | kind + noop tasks | `tasks/kind/cp-recovery/` + its stack; `tasks/noop/` (no stacks) | tasks contracts + full pipeline (wave 8) | **Pradeep** |
 
 > [!NOTE]
 > The **Imports (basis)** column is the verified dependency that fixes each PR's wave: a PR sits in the earliest wave after *all* its imports.
@@ -164,16 +164,16 @@ Docs, `.agents/` skills, and shared references sit *on top of* the code, so each
 
 | Wave | Unit | Paths | Gated on (module fully landed) | Owner |
 |:--:|---|---|---|---|
-| **6** | infra docs | `docs/components/infra.md` | providers + deployers + infra stacks | **Eugene** |
+| **6** | infra docs | `docs/components/infra.md` | providers + deployers + tf modules + default kind stack | **Eugene** |
 | **6** | models docs | `docs/components/model_providers.md`, `docs/how-to/add-a-model-provider.md` | models | **Richard** |
 | **6** | agents docs | `docs/components/agents.md`, `docs/how-to/add-an-agent-harness.md`, `.agents/references/harness-capabilities.md` | agents (base + CLI + API + shared) | **Simran** |
 | **6** | metrics docs | `docs/components/metrics.md` | metrics (base + judge + families) | **Jessie** |
-| **6** | tasks docs | `docs/how-to/add-a-task.md`, `tasks/AGENTS.md` | tasks contracts + task data | **Eugene** |
+| **10** | tasks docs | `docs/how-to/add-a-task.md`, `tasks/AGENTS.md` | tasks contracts + task data (wave 9) | **Eugene** |
 | **6** | review skills | `.agents/skills/task-review/`, `.agents/skills/devops-bench-review/`, `.agents/references/permission-configs/review-readonly.*` | tasks + review targets (tasks, docs conventions) | **Jessie** |
 | **6** | cleanup skill | `.agents/skills/cleanup-orphaned-resources/` | providers + deployers + infra | **Eugene** |
-| **9** | eval-run skills + refs | `.agents/skills/{run-eval,run-parallel-evals,validate-eval,diagnose-eval-failure}/`, `.agents/references/{running-evals,monitoring-and-recovery,unlimited-mode}.md`, `.agents/references/permission-configs/{eval-infra.*,README.md}` | `cli/` + default eval harness | **Pradeep** |
-| **9** | run + onboarding docs | `docs/how-to/run-evals.md`, `docs/components/bastion.md`, `docs/getting-started.md` | `cli/` + evalharness + infra | **Pradeep** |
-| **9** | repo overview + routers + docs-sync skill | `docs/README.md`, `docs/components/architecture.md`, `docs/components/glossary.md`, `docs/contributing.md`, `docs/appendix/known_issues.md`, `AGENTS.md`, `CLAUDE.md`, `devops_bench/AGENTS.md`, `.agents/skills/docs-sync/` | everything (ships last) | **Pradeep** |
+| **10** | eval-run skills + refs | `.agents/skills/{run-eval,run-parallel-evals,validate-eval,diagnose-eval-failure}/`, `.agents/references/{running-evals,monitoring-and-recovery,unlimited-mode}.md`, `.agents/references/permission-configs/{eval-infra.*,README.md}` | `cli/` + default eval harness + task data (wave 9) | **Pradeep** |
+| **10** | run + onboarding docs | `docs/how-to/run-evals.md`, `docs/components/bastion.md`, `tf/prebuilt/bastion/`, `docs/getting-started.md` | `cli/` + evalharness + infra | **Pradeep** |
+| **10** | repo overview + routers + docs-sync skill | `docs/README.md`, `docs/components/architecture.md`, `docs/components/glossary.md`, `docs/contributing.md`, `docs/appendix/known_issues.md`, `AGENTS.md`, `CLAUDE.md`, `devops_bench/AGENTS.md`, `.agents/skills/docs-sync/` | everything (ships last) | **Pradeep** |
 
 > [!NOTE]
 > **Never migrated (retires with `gke-labs`):** the `migration-prep` skill and `docs/migration/**` (they exist only to run this migration), plus the leaderboard assets — `site/**`, `site_new/**` (incl. `site_new/AGENTS.md`) and `docs/how-to/leaderboard.md`. These are kept out of the frontier and marked `NEVER_SYNC`.

--- a/hack/migration-status.sh
+++ b/hack/migration-status.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 #
 # migration-status.sh: reports migration progress by comparing migrated.bara.sky and upstream main.
-# --suggest-flips lists/uncomments entries whose paths now exist upstream.
+# --suggest-flips lists/uncomments entries whose upstream CONTENT matches gke-labs (blob parity).
 #
 # Usage:
 #   ./hack/migration-status.sh
-#   ./hack/migration-status.sh --suggest-flips --upstream-files <file>          # report ready-to-flip
-#   ./hack/migration-status.sh --suggest-flips --apply --upstream-files <file>  # uncomment them
+#   ./hack/migration-status.sh --suggest-flips --upstream-tree <file>          # report ready-to-flip
+#   ./hack/migration-status.sh --suggest-flips --apply --upstream-tree <file>  # uncomment them
+#
+# <file> is the FULL upstream tree listing WITH blob hashes:
+#   git ls-tree -r upstream/main   (mode type sha<TAB>path — NOT --name-only)
+#
+# An entry flips only when every local file it covers exists upstream with an identical blob
+# hash. Mere path existence is not enough: upstream placeholders (an empty tasks/README.md) and
+# same-named-but-different files (a sigs-native AGENTS.md) must never flip ownership. Entries
+# tagged with a trailing `# flip-group: <name>` comment flip atomically: none of the group
+# flips until every member is content-ready (used to couple a task with its tf stack).
 #
 set -euo pipefail
 
@@ -15,7 +24,7 @@ SRC="${SRC:-devops_bench}"
 UPSTREAM="${UPSTREAM:-kubernetes-sigs/devops-bench}"
 MODE="status"
 APPLY="false"
-UPSTREAM_FILES=""
+UPSTREAM_TREE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -24,48 +33,129 @@ while [[ $# -gt 0 ]]; do
     --upstream)       UPSTREAM="$2"; shift 2 ;;
     --suggest-flips)  MODE="suggest"; shift ;;
     --apply)          APPLY="true"; shift ;;
-    --upstream-files) UPSTREAM_FILES="$2"; shift 2 ;;
-    -h|--help)        sed -n '2,18p' "$0"; exit 0 ;;
+    --upstream-tree)  UPSTREAM_TREE="$2"; shift 2 ;;
+    --upstream-files) echo "error: --upstream-files (name-only) was replaced by --upstream-tree" >&2
+                      echo "       (existence is not migration; pass 'git ls-tree -r <ref>' output)" >&2
+                      exit 2 ;;
+    -h|--help)        sed -n '2,20p' "$0"; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 
 [[ -f "$MANIFEST" ]] || { echo "error: manifest '$MANIFEST' not found (run from repo root)" >&2; exit 1; }
 
-# --- suggest-flips: auto-uncomment entries present upstream -----------------
-# A commented path is ready to flip once it exists in upstream main.
+# --- suggest-flips: auto-uncomment entries whose content has landed upstream -----------------
 if [[ "$MODE" == "suggest" ]]; then
-  [[ -n "$UPSTREAM_FILES" && -f "$UPSTREAM_FILES" ]] \
-    || { echo "error: --suggest-flips needs --upstream-files <file> (e.g. git ls-tree -r --name-only upstream/main)" >&2; exit 2; }
+  [[ -n "$UPSTREAM_TREE" && -f "$UPSTREAM_TREE" ]] \
+    || { echo "error: --suggest-flips needs --upstream-tree <file> (git ls-tree -r <upstream-ref>)" >&2; exit 2; }
+  grep -qE '^[0-9]+ blob [0-9a-f]{40,64}\t' "$UPSTREAM_TREE" \
+    || { echo "error: $UPSTREAM_TREE has no blob hashes; generate it with 'git ls-tree -r <ref>' (not --name-only)" >&2; exit 2; }
 
-  to_flip=()
-  while IFS= read -r path; do
-    [[ -n "$path" ]] || continue
-    case "$path" in
-      *'/**') prefix="${path%/**}/"; awk -v p="$prefix" 'index($0,p)==1{f=1} END{exit f?0:1}' "$UPSTREAM_FILES" && to_flip+=("$path") ;;
-      *'/*')  prefix="${path%/*}/";  awk -v p="$prefix" 'index($0,p)==1{f=1} END{exit f?0:1}' "$UPSTREAM_FILES" && to_flip+=("$path") ;;
-      *)      grep -qxF -- "$path" "$UPSTREAM_FILES" && to_flip+=("$path") ;;
-    esac
-  done < <(grep -oE '^[[:space:]]*#[[:space:]]*"[^"]+"' "$MANIFEST" | grep -oE '"[^"]+"' | tr -d '"')
+  LOCAL_TREE="$(mktemp)"
+  trap 'rm -f "$LOCAL_TREE"' EXIT
+  git ls-tree -r HEAD > "$LOCAL_TREE"
 
-  if [[ ${#to_flip[@]} -eq 0 ]]; then
-    echo "No commented frontier entries are present upstream yet; nothing to flip."
-    exit 0
-  fi
+  MANIFEST="$MANIFEST" UPSTREAM_TREE="$UPSTREAM_TREE" APPLY="$APPLY" \
+    LOCAL_TREE="$LOCAL_TREE" python3 - <<'PYEOF'
+import os, re, sys
 
-  echo "Ready to flip (present upstream, still commented): ${#to_flip[@]}"
-  for p in "${to_flip[@]}"; do echo "  + $p"; done
+manifest_path = os.environ["MANIFEST"]
+apply_mode = os.environ["APPLY"] == "true"
 
-  if [[ "$APPLY" == "true" ]]; then
-    for path in "${to_flip[@]}"; do
-      esc="$(printf '%s' "$path" | sed 's/[.*]/\\&/g')"   # escape regex metacharacters in paths
-      sed -i.bak -E "s|^([[:space:]]*)#[[:space:]]*(\"${esc}\",)|\1\2|" "$MANIFEST"
-    done
-    rm -f "$MANIFEST.bak"
-    echo "Uncommented ${#to_flip[@]} entries in $MANIFEST."
-  else
-    echo "(run with --apply to uncomment these in $MANIFEST)"
-  fi
+def read_tree(path):
+    """Parse `git ls-tree -r` output into {path: blob_sha}."""
+    tree = {}
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line or "\t" not in line:
+                continue
+            meta, fpath = line.split("\t", 1)
+            parts = meta.split()
+            if len(parts) == 3 and parts[1] == "blob":
+                tree[fpath] = parts[2]
+    return tree
+
+local = read_tree(os.environ["LOCAL_TREE"])
+upstream = read_tree(os.environ["UPSTREAM_TREE"])
+
+# Commented manifest entry, optionally tagged: # "path/**",  # flip-group: name
+entry_re = re.compile(r'^(\s*)#\s*("([^"]+)",)\s*(?:#\s*flip-group:\s*(\S+))?\s*$')
+
+entries = []  # (lineno, path, group)
+lines = open(manifest_path, encoding="utf-8").read().splitlines(keepends=True)
+for i, line in enumerate(lines):
+    m = entry_re.match(line)
+    if m:
+        entries.append((i, m.group(3), m.group(4)))
+
+def covered_files(path):
+    """Local files an entry covers. `p/**` is recursive, `p/*` single level, else exact."""
+    if path.endswith("/**"):
+        prefix = path[:-2]
+        return sorted(f for f in local if f.startswith(prefix))
+    if path.endswith("/*"):
+        prefix = path[:-1]
+        return sorted(f for f in local if f.startswith(prefix) and "/" not in f[len(prefix):])
+    return [path] if path in local else []
+
+def check(path):
+    """Returns (ready, reason)."""
+    files = covered_files(path)
+    if not files:
+        return False, "no local files match (stale manifest entry?)"
+    missing = [f for f in files if f not in upstream]
+    if missing:
+        return False, f"{len(missing)}/{len(files)} file(s) not upstream yet (e.g. {missing[0]})"
+    differ = [f for f in files if upstream[f] != local[f]]
+    if differ:
+        return False, f"{len(differ)}/{len(files)} file(s) differ from upstream (e.g. {differ[0]})"
+    return True, f"all {len(files)} file(s) match upstream"
+
+results = {path: check(path) for _, path, _ in entries}
+
+# A flip-group is ready only when every member is ready.
+groups = {}
+for _, path, group in entries:
+    if group:
+        groups.setdefault(group, []).append(path)
+
+to_flip, held, pending = [], [], []
+for lineno, path, group in entries:
+    ready, reason = results[path]
+    if not ready:
+        pending.append((path, reason))
+    elif group and not all(results[p][0] for p in groups[group]):
+        waiting = next(p for p in groups[group] if not results[p][0])
+        held.append((path, f"flip-group '{group}' not complete (waiting on {waiting})"))
+    else:
+        to_flip.append((lineno, path))
+
+if pending:
+    print(f"Not ready ({len(pending)}):")
+    for path, reason in pending:
+        print(f"  - {path}: {reason}")
+if held:
+    print(f"Held back by flip-group ({len(held)}):")
+    for path, reason in held:
+        print(f"  ~ {path}: {reason}")
+if not to_flip:
+    print("No commented frontier entries have full content parity upstream yet; nothing to flip.")
+    sys.exit(0)
+
+print(f"Ready to flip (content matches upstream, still commented): {len(to_flip)}")
+for _, path in to_flip:
+    print(f"  + {path}")
+
+if apply_mode:
+    for lineno, _ in to_flip:
+        lines[lineno] = re.sub(r'^(\s*)#\s*', r'\1', lines[lineno], count=1)
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        f.writelines(lines)
+    print(f"Uncommented {len(to_flip)} entries in {manifest_path}.")
+else:
+    print(f"(run with --apply to uncomment these in {manifest_path})")
+PYEOF
   exit 0
 fi
 

--- a/migrated.bara.sky
+++ b/migrated.bara.sky
@@ -31,6 +31,9 @@ MIGRATED = [
     # "devops_bench/skills/**",
     # metrics registry base
     # "devops_bench/metrics/base.py",
+    # __init__.py lags its PR by design: it ships trimmed to the base surface and only reaches
+    # blob parity once the wave-5 family PRs re-add their imports upstream. Do not flip it by
+    # hand before then — gke-labs imports the full package root (also NEVER_SYNC'd until parity).
     # "devops_bench/metrics/__init__.py",
     # "tests/unit/metrics/test_metrics_base.py",
     # "tests/unit/metrics/test_metrics_extension_axis.py",

--- a/migrated.bara.sky
+++ b/migrated.bara.sky
@@ -5,10 +5,12 @@
 #
 # Ordered by wave (pr-plan.md §3.2 code, §3.4 docs/skills). Entries are per-PR: one concrete plus
 # its co-located unit tests, matching the "smallest reviewable unit" rule (pr-plan.md §1.6). That
-# granularity is deliberate — suggest-flips uncomments a line as soon as its path exists upstream, so
-# a per-family glob would lock not-yet-migrated siblings early; a per-PR entry flips exactly when its
-# PR lands. Wave 1 (toolchain: pyproject.toml, uv.lock, .python-version, CI) is human-managed in both
-# repos and is intentionally NOT listed here.
+# granularity is deliberate — suggest-flips uncomments a line only once every file it covers exists
+# upstream with IDENTICAL content (blob parity), so an upstream placeholder or a same-named-but-
+# different file never flips ownership; a per-PR entry flips exactly when its PR lands. Entries
+# tagged `# flip-group: <name>` flip atomically — none until all members are content-ready — which
+# couples each benchmark task with the tf stack it provisions. Wave 1 (toolchain: pyproject.toml,
+# uv.lock, .python-version, CI) is human-managed in both repos and is intentionally NOT listed here.
 #
 # gke-labs-only tooling — the migration-prep skill, docs/migration/**, and the leaderboard assets
 # (site*/**, docs/how-to/leaderboard.md) — never migrates: it stays NEVER_SYNC and is not listed.
@@ -58,8 +60,8 @@ MIGRATED = [
     # cloud providers (base, gcp, kind)
     # "devops_bench/providers/**",
     # "tests/unit/providers/**",
-    # Terraform modules (tf/modules -> infra/modules)
-    # "infra/modules/**",
+    # Terraform modules (path kept as tf/modules — no infra/ rename)
+    # "tf/modules/**",
     # result model (row, aggregate, normalize)
     # "devops_bench/results/**",
     # "tests/unit/results/**",
@@ -121,8 +123,8 @@ MIGRATED = [
     # "devops_bench/deployers/factory.py",
     # "devops_bench/deployers/__init__.py",
     # "tests/unit/deployers/test_deployers_factory.py",
-    # Terraform stacks (tf/prebuilt -> infra/stacks)
-    # "infra/stacks/**",
+    # harness default kind stack (task-specific stacks travel with their task — wave 9)
+    # "tf/prebuilt/kind/**",
     # evalharness reporter (consumes results/)
     # "devops_bench/evalharness/reporter.py",
     # "tests/unit/evalharness/test_reporter.py",
@@ -157,8 +159,6 @@ MIGRATED = [
     # "devops_bench/metrics/outcome_validity.py",
     # "devops_bench/metrics/chaos_metrics.py",
     # "tests/unit/metrics/test_metrics_chaos.py",
-    # benchmark task data (batched across owners)
-    # "tasks/**",
 
     # --- Wave 6: harness base + scenario, and module docs/skills (each after its module lands) ---
     # "devops_bench/evalharness/base.py",
@@ -174,8 +174,6 @@ MIGRATED = [
     # "docs/how-to/add-an-agent-harness.md",
     # ".agents/references/harness-capabilities.md",
     # "docs/components/metrics.md",
-    # "docs/how-to/add-a-task.md",
-    # "tasks/AGENTS.md",
     # ".agents/skills/task-review/**",
     # ".claude/skills/task-review",
     # ".agents/skills/devops-bench-review/**",
@@ -204,7 +202,41 @@ MIGRATED = [
     # "tests/unit/verification/test_optimize_scale_regression.py",
     # "tests/integration/**",
 
-    # --- Wave 9: eval-lifecycle skills, onboarding + repo-overview docs (need cli/ + evalharness) ---
+    # --- Wave 9: benchmark tasks, each coupled with the tf stack it provisions (flip-group entries
+    # --- flip together). Ships after wave 8 so every task can be validated on the full upstream
+    # --- pipeline before ownership moves. A shared stack carries all the tasks that use it. ---
+    # noop tasks (no stack; need only the pipeline to validate)
+    # "tasks/noop/**",
+    # "tasks/common/cve-remediation/**",  # flip-group: cve-remediation
+    # "tf/prebuilt/cve-remediation-kind/**",  # flip-group: cve-remediation
+    # "tasks/common/migration-and-upgrade/**",  # flip-group: migration-and-upgrade
+    # "tf/prebuilt/migration-and-upgrade-kind/**",  # flip-group: migration-and-upgrade
+    # "tf/prebuilt/migration-and-upgrade/**",  # flip-group: migration-and-upgrade
+    # "tasks/common/opa-remediation/**",  # flip-group: opa-remediation
+    # "tf/prebuilt/opa-remediation-kind/**",  # flip-group: opa-remediation
+    # "tasks/common/optimize-scale/**",  # flip-group: optimize-scale
+    # "tf/prebuilt/optimize-scale/**",  # flip-group: optimize-scale
+    # "tasks/common/spot-rebalancing/**",  # flip-group: spot-rebalancing
+    # "tf/prebuilt/spot-rebalancing-kind/**",  # flip-group: spot-rebalancing
+    # "tasks/gcp/deploy-hello-app/**",  # flip-group: minimum
+    # "tf/prebuilt/minimum/**",  # flip-group: minimum
+    # "tasks/gcp/deploy-config/**",  # flip-group: hypercomputer-d1
+    # "tasks/gcp/fix-config/**",  # flip-group: hypercomputer-d1
+    # "tasks/gcp/get-app-architecture/**",  # flip-group: hypercomputer-d1
+    # "tf/prebuilt/hypercomputer-d1/**",  # flip-group: hypercomputer-d1
+    # "tasks/gcp/gpu-stress-test-diagnosis/**",  # flip-group: gpu-stress-test
+    # "tf/prebuilt/gpu-stress-test/**",  # flip-group: gpu-stress-test
+    # "tasks/gcp/lustre-csi-deployment/**",  # flip-group: lustre-csi
+    # "tf/prebuilt/lustre-csi/**",  # flip-group: lustre-csi
+    # "tasks/gcp/multi-region-failover/**",  # flip-group: multi-region-failover
+    # "tf/prebuilt/multi-region-failover/**",  # flip-group: multi-region-failover
+    # "tasks/gcp/secret-rotation/**",  # flip-group: secret-rotation
+    # "tf/prebuilt/secret-rotation/**",  # flip-group: secret-rotation
+    # "tasks/kind/cp-recovery/**",  # flip-group: cp-recovery
+    # "tf/prebuilt/cp-recovery-kind/**",  # flip-group: cp-recovery
+
+    # --- Wave 10: eval-lifecycle skills, onboarding + repo-overview docs (need cli/ + evalharness,
+    # --- and task data from wave 9 for the run/validate skills to exercise) ---
     # ".agents/skills/run-eval/**",
     # ".claude/skills/run-eval",
     # ".agents/skills/run-parallel-evals/**",
@@ -221,6 +253,10 @@ MIGRATED = [
     # ".agents/references/permission-configs/README.md",
     # "docs/how-to/run-evals.md",
     # "docs/components/bastion.md",
+    # "tf/prebuilt/bastion/**",
+    # tasks docs (need the wave-9 task data they document)
+    # "docs/how-to/add-a-task.md",
+    # "tasks/AGENTS.md",
     # "docs/getting-started.md",
     # "docs/README.md",
     # "docs/components/architecture.md",


### PR DESCRIPTION
Follow-up to the closed auto-flip PR (#186), which uncommented `tasks/**`, `AGENTS.md`, and `devops_bench/agents/__init__.py` because those paths merely *exist* upstream: `tasks/` is a placeholder README, upstream `AGENTS.md` is a different sigs-native document, and `agents/__init__.py` is scaffolding from a layout that differs from ours.

**1. Flip detection now requires content parity, not existence** (`hack/migration-status.sh`)
- `--suggest-flips` takes `--upstream-tree` (`git ls-tree -r <ref>`, with blob hashes; the old `--upstream-files` name-only flag is a hard error with guidance).
- An entry flips only when **every local file it covers exists upstream with an identical blob hash**. Placeholders and same-named-but-different files now report as `not upstream yet` / `differ from upstream` instead of flipping.
- Entries tagged `# flip-group: <name>` flip atomically: none flips until all members are content-ready.
- `suggest-flips.yml` passes the hash-bearing listing and the flip-PR wording reflects the new rule.

**2. Manifest: tf/ keeps its path; tasks couple with their stacks** (`migrated.bara.sky`)
- `infra/modules/**` / `infra/stacks/**` → `tf/modules/**` and per-stack entries (no `infra/` rename upstream, avoiding churn).
- The batch `tasks/**` entry is replaced by per-task entries, each in a flip-group with the `tf/prebuilt/` stack it provisions (shared stacks — `minimum`, `hypercomputer-d1` — carry all their tasks). These move to a new **wave 9**, after the full pipeline (wave 8), so every task can be validated upstream before ownership flips.
- The harness-default `tf/prebuilt/kind` stays in wave 4; `tf/prebuilt/bastion` travels with the bastion doc; docs waves renumber 9 → 10 and the tasks docs join them (they document wave-9 data).

**3. `docs/migration/pr-plan.md`** — stage 4, §3.2 and §3.4 tables updated to match.

**4. Hold for the trimmed `metrics/__init__.py`** (`copy.bara.sky`)
The wave-3 metrics base PR ships `__init__.py` trimmed to the base surface; each family PR re-adds its imports upstream, so the entry only reaches blob parity (and can flip) after wave 5 — content parity already keeps suggest-flips from proposing it early. A temporary `NEVER_SYNC` entry additionally keeps a *manual* flip from back-syncing the trimmed init over gke-labs' full one (`run.py` and `evalharness/default.py` import the full package root). Noted on the manifest entry and the §3.2 row; remove the entry once the families land.

Tested: rejected name-only listings and the old flag; a same-named-but-different upstream file reports as a diff and does not flip; a half-landed flip-group holds both members; full parity flips and `--apply` preserves indentation and group tags; `bash -n`, status mode, and manifest parse all green.
