### PR TITLE
chore(migration): flip models base + tool loop into the frontier

### DIFF
--- a/migrated.bara.sky
+++ b/migrated.bara.sky
@@ -39,11 +39,11 @@ MIGRATED = [
     # "tests/unit/metrics/test_metrics_extension_axis.py",
     # "tests/unit/metrics/test_package_import.py",
     # models base + tool loop (run_tool_loop)
-    # "devops_bench/models/base.py",
-    # "devops_bench/models/utils/**",
-    # "devops_bench/models/__init__.py",
-    # "tests/unit/models/test_models_base.py",
-    # "tests/unit/models/test_loop.py",
+    "devops_bench/models/base.py",
+    "devops_bench/models/utils/**",
+    "devops_bench/models/__init__.py",
+    "tests/unit/models/test_models_base.py",
+    "tests/unit/models/test_loop.py",
     # agents base + capabilities
     # "devops_bench/agents/base.py",
     # "devops_bench/agents/config.py",


### PR DESCRIPTION
The models base (LLM client ABC + registry, `run_tool_loop`, package init) has landed in the canonical repo. This uncomments its five frontier entries in `migrated.bara.sky` so the paths lock read-only here and the back-sync starts mirroring them.

Note: three of the five files carry small review edits made upstream during the forward review (`base.py` type annotation, `__init__.py` docstring, `test_models_base.py` rewritten against the stub adapter). The first back-sync run after this merges will open the PR that reconciles them — merge it promptly.

Unblocks the wave-4 PRs that import the models base (provider clients, chaos base, metrics judge).