### PR TITLE
docs(migration): batch waves 4-5 into one PR per owner per wave

### DIFF
--- a/docs/migration/pr-plan.md
+++ b/docs/migration/pr-plan.md
@@ -16,7 +16,7 @@ To ensure a smooth, error-free upstream review process, every PR must adhere to 
 3. **Keep the Frontier Documented**: Immediately after an upstream PR merges, uncomment its paths in `migrated.bara.sky` in a small, reviewed `gke-labs` PR (refer to [README.md](./README.md) §4 Step 2.2 for details). This locks the paths and activates the back-sync bot.
 4. **All PRs are Disposable**: If a forward PR becomes stale, close it and re-assemble a clean one using `prep-export.sh`.
 5. **No Cross-Border Imports**: Banish imports of un-migrated paths in migrated code to maintain a clean boundary.
-6. **Smallest reviewable unit**: Prefer the finest PR that still builds and tests green. Once a shared base/registry has landed, migrate **one concrete per PR** — one CLI agent, one verifier, one fault, one deployer engine, one model provider, one task — rather than a whole family at once. This keeps upstream reviews fast and isolates any back-sync issue to a single concrete. The stage groupings in §2 are logical buckets; each typically expands into several granular PRs (enumerated in §3.2).
+6. **Smallest reviewable unit**: Prefer the finest PR that still builds and tests green. Once a shared base/registry has landed, migrate **one concrete per PR** — one CLI agent, one verifier, one fault, one deployer engine, one model provider, one task — rather than a whole family at once. This keeps upstream reviews fast and isolates any back-sync issue to a single concrete. The stage groupings in §2 are logical buckets; each typically expands into several granular PRs (enumerated in §3.2). *Exception:* waves **4–5** batch related concretes into **one PR per owner per wave** (10 PRs total) to cap review overhead; a back-sync issue there bisects to a batch rather than a concrete — an accepted trade-off.
 7. **Dependencies travel with their code**: `pyproject.toml`/`uv.lock` are `NEVER_SYNC` (managed per-repo), so a package can't be staged upstream ahead of its code. A PR that introduces a new third-party import must add that package to `pyproject.toml` and refresh `uv.lock` **in the same PR** (the `migration-prep` skill does this). `core/` is pure-stdlib and adds none.
 
 ---
@@ -98,7 +98,7 @@ Every owner completes the [README.md](./README.md) §2 prerequisites independent
 
 ### 3.2 PRs by wave
 
-Every PR carries a **wave number**. **All PRs in a wave are mutually independent and ship in parallel**; a wave opens only once *every* PR in the prior wave is merged upstream **and flipped** in `migrated.bara.sky` (so later PRs can import them via the back-sync). The waves are **derived from the real import edges in `devops_bench/`** (verified against the tree), so nothing in a wave imports anything else in the same wave. Load is balanced at **8–9 PRs per owner**. Waves **1–2** are the unavoidable serial bootstrap (toolchain, then `core/`, imported everywhere); **3–5** are the parallel bulk; **6–8** are the serial orchestrator tail + entrypoints; **9** is the benchmark data — each task coupled with the `tf/prebuilt/` stack it provisions (one PR + one `flip-group` per pair) — gated on the full pipeline so tasks are validated upstream before flipping.
+Every PR carries a **wave number**. **All PRs in a wave are mutually independent and ship in parallel**; a wave opens only once *every* PR in the prior wave is merged upstream **and flipped** in `migrated.bara.sky` (so later PRs can import them via the back-sync). The waves are **derived from the real import edges in `devops_bench/`** (verified against the tree), so nothing in a wave imports anything else in the same wave. **Waves 4–5 are batched into one PR per owner per wave** (5 + 5 = 10 PRs); each batch is authored by someone who did **not** build that area originally (per the pre-refactor `pkg/` history), with the area's main past contributors as reviewers — fresh eyes write, the experts review. Waves **1–2** are the unavoidable serial bootstrap (toolchain, then `core/`, imported everywhere); **3–5** are the parallel bulk; **6–8** are the serial orchestrator tail + entrypoints; **9** is the benchmark data — each task coupled with the `tf/prebuilt/` stack it provisions (one PR + one `flip-group` per pair) — gated on the full pipeline so tasks are validated upstream before flipping.
 
 | Wave | PR | Paths | Imports (basis) | Owner |
 |:--:|---|---|---|---|
@@ -113,31 +113,16 @@ Every PR carries a **wave number**. **All PRs in a wave are mutually independent
 | **3** | `providers/` | `providers/base.py`, `providers/gcp.py`, `providers/kind.py` | core | **Eugene** |
 | **3** | Terraform modules | `tf/modules/` *(no code deps — only needs to precede stacks in wave 4)* | — | **Eugene** |
 | **3** | `results/` model | `results/row.py`, `aggregate.py`, `normalize.py` | core | **Pradeep** |
-| **4** | models: gemini client | `models/gemini.py` | models base | **Richard** |
-| **4** | models: claude client | `models/claude.py` | models base | **Richard** |
-| **4** | models: ollama client | `models/ollama.py` | models base | **Richard** |
-| **4** | **gemini CLI agent** | `agents/cli/gemini_cli/` (agent, parsing) | agents base | **Richard** |
-| **4** | MCP client | `agents/api/mcp.py` | core | **Richard** |
-| **4** | **openclaw CLI agent** | `agents/cli/openclaw/` (agent, parsing) | agents base | **Simran** |
-| **4** | agents shared | `agents/shared/cli_capabilities.py`, `shared/skills.py` | agents base | **Simran** |
-| **4** | chaos base **(replaces upstream `agents/chaos/`)** | adds `chaos/base.py`, `agent.py`, `schema.py`, `spec.py`; **`git rm` the 3 superseded `agents/chaos/` files** | core, models base | **Simran** |
-| **4** | verification base | `verification/base.py`, `spec.py`, `runner.py` | core, k8s | **Jessie** |
-| **4** | metrics judge | `metrics/geval.py`, `pipeline.py`, `_skills.py` | core, models base, skills, metrics base | **Jessie** |
-| **4** | deployers base | `deployers/base.py`, `factory.py` | core, providers | **Eugene** |
-| **4** | default kind stack | `tf/prebuilt/kind/` (the harness's default stack; task-specific stacks ship with their task in wave 9) | tf modules | **Eugene** |
-| **4** | `evalharness/reporter` | `evalharness/reporter.py` | core, results | **Simran** |
-| **5** | deployers: tofu engine | `deployers/tofu.py` | deployers base | **Eugene** |
-| **5** | deployers: noop engine | `deployers/noop.py` | deployers base | **Eugene** |
-| **5** | API agent | `agents/api/agent.py`, `api/skills.py` | agents base, models, mcp | **Richard** |
-| **5** | chaos: generate-load fault | `chaos/faults/generate_load.py` | chaos base, k8s | **Simran** |
-| **5** | chaos: time-delay trigger | `chaos/triggers/time_delay.py` | chaos base | **Simran** |
-| **5** | verification: pod-healthy | `verification/verifiers/pod_healthy.py` | verification base | **Jessie** |
-| **5** | verification: scaling-complete | `verification/verifiers/scaling_complete.py` | verification base | **Jessie** |
-| **5** | metric: grounding | `metrics/grounding.py` | metrics judge | **Pradeep** |
-| **5** | metric: tool-invocation | `metrics/tool_invocation.py` | metrics judge | **Pradeep** |
-| **5** | metric: checklist | `metrics/checklist.py` | metrics judge | **Pradeep** |
-| **5** | metric: outcome-validity | `metrics/outcome_validity.py` | metrics judge | **Jessie** |
-| **5** | metric: chaos-metrics | `metrics/chaos_metrics.py` | metrics judge | **Jessie** |
+| **4** | models provider clients + **gemini CLI agent** | `models/gemini.py`, `claude.py`, `ollama.py`; `agents/cli/gemini_cli/` (agent, parsing) | models base, agents base | **Richard** *(review: Jessie, Simran)* |
+| **4** | **openclaw CLI agent** + agents shared + chaos base **(replaces upstream `agents/chaos/`)** | `agents/cli/openclaw/` (agent, parsing); `agents/shared/cli_capabilities.py`, `shared/skills.py`; adds `chaos/base.py`, `agent.py`, `schema.py`, `spec.py`; **`git rm` the 3 superseded `agents/chaos/` files** | core, agents base, models base | **Pradeep** *(review: Simran, Jessie)* |
+| **4** | verification base + metrics judge | `verification/base.py`, `spec.py`, `runner.py`; `metrics/geval.py`, `pipeline.py`, `_skills.py` | core, k8s, models base, skills, metrics base | **Eugene** *(review: Jessie)* |
+| **4** | deployers base + default kind stack | `deployers/base.py`, `factory.py`; `tf/prebuilt/kind/` (the harness's default stack; task-specific stacks ship with their task in wave 9) | core, providers, tf modules | **Simran** *(review: Eugene, Jessie)* |
+| **4** | `evalharness/reporter` | `evalharness/reporter.py` | core, results | **Jessie** *(review: Pradeep)* |
+| **5** | API agent + MCP client | `agents/api/agent.py`, `api/skills.py`, `api/mcp.py` *(`mcp.py` could ship in wave 4 on its basis, but its only importer is the API agent, so it travels here)* | agents base, models clients | **Richard** *(review: Simran)* |
+| **5** | chaos concretes | `chaos/faults/generate_load.py`, `chaos/triggers/time_delay.py` | chaos base, k8s | **Jessie** *(review: Simran)* |
+| **5** | verification verifiers | `verification/verifiers/pod_healthy.py`, `scaling_complete.py` | verification base | **Simran** *(review: Jessie, Pradeep)* |
+| **5** | deployer engines | `deployers/tofu.py`, `noop.py` | deployers base | **Pradeep** *(review: Richard, Eugene)* |
+| **5** | concrete metrics | `metrics/grounding.py`, `tool_invocation.py`, `checklist.py`, `outcome_validity.py`, `chaos_metrics.py` *(one PR restores the full `metrics/__init__.py` surface, so the init flips right after — see the wave-3 metrics base row)* | metrics judge, skills | **Eugene** *(review: Jessie, Richard)* |
 | **6** | harness base + scenario | `evalharness/base.py`, `artifacts.py`, `scenario.py` | agents, chaos, verification, deployers | **Simran** |
 | **7** | default eval harness | `evalharness/default.py` | harness base, metrics, results, tasks | **Simran** |
 | **8** | CLI entrypoint | `cli.py`, `__main__.py`, `run.py` | evalharness, metrics, tasks | **Pradeep** |

--- a/migrated.bara.sky
+++ b/migrated.bara.sky
@@ -3,11 +3,12 @@
 # hack/check-migrated-readonly.sh (flip guard) and hack/migration-status.sh (tracker), so there is
 # exactly one list. Add a path (uncomment a line) when its forward PR merges; remove it to un-migrate.
 #
-# Ordered by wave (pr-plan.md §3.2 code, §3.4 docs/skills). Entries are per-PR: one concrete plus
-# its co-located unit tests, matching the "smallest reviewable unit" rule (pr-plan.md §1.6). That
-# granularity is deliberate — suggest-flips uncomments a line only once every file it covers exists
-# upstream with IDENTICAL content (blob parity), so an upstream placeholder or a same-named-but-
-# different file never flips ownership; a per-PR entry flips exactly when its PR lands. Entries
+# Ordered by wave (pr-plan.md §3.2 code, §3.4 docs/skills). Entries are per-concrete: one concrete
+# plus its co-located unit tests (waves 4–5 batch several concretes into one PR — pr-plan.md §3.2 —
+# but the finer entry granularity stays). That granularity is deliberate — suggest-flips uncomments
+# a line only once every file it covers exists upstream with IDENTICAL content (blob parity), so an
+# upstream placeholder or a same-named-but-different file never flips ownership; an entry flips
+# exactly when its files land. Entries
 # tagged `# flip-group: <name>` flip atomically — none until all members are content-ready — which
 # couples each benchmark task with the tf stack it provisions. Wave 1 (toolchain: pyproject.toml,
 # uv.lock, .python-version, CI) is human-managed in both repos and is intentionally NOT listed here.
@@ -32,8 +33,8 @@ MIGRATED = [
     # metrics registry base
     # "devops_bench/metrics/base.py",
     # __init__.py lags its PR by design: it ships trimmed to the base surface and only reaches
-    # blob parity once the wave-5 family PRs re-add their imports upstream. Do not flip it by
-    # hand before then — gke-labs imports the full package root (also NEVER_SYNC'd until parity).
+    # blob parity once the wave-5 concrete-metrics PR re-adds the family imports upstream. Do not
+    # flip it by hand before then — gke-labs imports the full package root (NEVER_SYNC'd until parity).
     # "devops_bench/metrics/__init__.py",
     # "tests/unit/metrics/test_metrics_base.py",
     # "tests/unit/metrics/test_metrics_extension_axis.py",
@@ -69,31 +70,24 @@ MIGRATED = [
     # "devops_bench/results/**",
     # "tests/unit/results/**",
 
-    # --- Wave 4: components on the bases (parallel) ---
-    # models: provider clients
+    # --- Wave 4: components on the bases (parallel; one batched PR per owner — pr-plan.md §3.2) ---
+    # PR: models provider clients + gemini CLI agent
     # "devops_bench/models/gemini.py",
     # "tests/unit/models/test_models_gemini.py",
     # "devops_bench/models/claude.py",
     # "tests/unit/models/test_models_claude.py",
     # "devops_bench/models/ollama.py",
     # "tests/unit/models/test_models_ollama.py",
-    # gemini CLI agent
     # "devops_bench/agents/cli/gemini_cli/**",
     # "devops_bench/agents/cli/__init__.py",
     # "tests/unit/agents/test_agents_cli_gemini.py",
-    # openclaw CLI agent
+    # PR: openclaw CLI agent + agents shared + chaos base
+    # (chaos base replaces upstream agents/chaos/ — git rm the 3 superseded files in this PR)
     # "devops_bench/agents/cli/openclaw/**",
     # "tests/unit/agents/test_agents_cli_openclaw.py",
     # "tests/unit/agents/test_legacy_openclaw_tokens.py",
-    # agents shared (cli_capabilities, skills)
     # "devops_bench/agents/shared/**",
     # "tests/unit/agents/shared/**",
-    # MCP client
-    # "devops_bench/agents/api/mcp.py",
-    # "devops_bench/agents/api/__init__.py",
-    # "tests/unit/agents/api/test_agents_api_mcp.py",
-    # "tests/unit/agents/api/test_agents_api_import_hygiene.py",
-    # chaos base (replaces upstream agents/chaos/ — git rm the 3 superseded files in this PR)
     # "devops_bench/chaos/base.py",
     # "devops_bench/chaos/agent.py",
     # "devops_bench/chaos/schema.py",
@@ -104,7 +98,7 @@ MIGRATED = [
     # "tests/unit/chaos/test_spec.py",
     # "tests/unit/chaos/test_extension_axis.py",
     # "tests/unit/chaos/test_package_import.py",
-    # verification base (base, spec, runner)
+    # PR: verification base + metrics judge
     # "devops_bench/verification/base.py",
     # "devops_bench/verification/spec.py",
     # "devops_bench/verification/runner.py",
@@ -114,47 +108,49 @@ MIGRATED = [
     # "tests/unit/verification/test_runner.py",
     # "tests/unit/verification/test_verifier_registry.py",
     # "tests/unit/verification/test_package_import.py",
-    # metrics judge (geval, pipeline, _skills)
     # "devops_bench/metrics/geval.py",
     # "devops_bench/metrics/pipeline.py",
     # "devops_bench/metrics/_skills.py",
     # "tests/unit/metrics/test_metrics_geval.py",
     # "tests/unit/metrics/test_metrics_pipeline.py",
     # "tests/unit/metrics/test_metrics_skills.py",
-    # deployers base (base, factory)
+    # PR: deployers base + default kind stack (task-specific stacks travel with their task — wave 9)
     # "devops_bench/deployers/base.py",
     # "devops_bench/deployers/factory.py",
     # "devops_bench/deployers/__init__.py",
     # "tests/unit/deployers/test_deployers_factory.py",
-    # harness default kind stack (task-specific stacks travel with their task — wave 9)
     # "tf/prebuilt/kind/**",
-    # evalharness reporter (consumes results/)
+    # PR: evalharness reporter (consumes results/)
     # "devops_bench/evalharness/reporter.py",
     # "tests/unit/evalharness/test_reporter.py",
 
-    # --- Wave 5: concretes on the components (parallel) ---
-    # deployers engines
-    # "devops_bench/deployers/tofu.py",
-    # "tests/unit/deployers/test_deployers_tofu.py",
-    # "devops_bench/deployers/noop.py",
-    # "tests/unit/deployers/test_deployers_noop.py",
-    # API agent (agent, skills)
+    # --- Wave 5: concretes on the components (parallel; one batched PR per owner — pr-plan.md §3.2) ---
+    # PR: API agent + MCP client (mcp.py's only importer is the API agent, so it travels here)
     # "devops_bench/agents/api/agent.py",
     # "devops_bench/agents/api/skills.py",
+    # "devops_bench/agents/api/mcp.py",
+    # "devops_bench/agents/api/__init__.py",
     # "tests/unit/agents/api/test_agents_api_agent.py",
     # "tests/unit/agents/api/test_agents_api_skills.py",
-    # chaos: generate-load fault
+    # "tests/unit/agents/api/test_agents_api_mcp.py",
+    # "tests/unit/agents/api/test_agents_api_import_hygiene.py",
+    # PR: chaos concretes (generate-load fault + time-delay trigger)
     # "devops_bench/chaos/faults/**",
     # "tests/unit/chaos/test_generate_load.py",
-    # chaos: time-delay trigger
     # "devops_bench/chaos/triggers/**",
     # "tests/unit/chaos/test_time_trigger.py",
-    # verification: verifiers
+    # PR: verification verifiers (pod-healthy + scaling-complete)
     # "devops_bench/verification/verifiers/pod_healthy.py",
     # "tests/unit/verification/test_pod_healthy.py",
     # "devops_bench/verification/verifiers/scaling_complete.py",
     # "tests/unit/verification/test_scaling_complete.py",
-    # metric families (each travels with its skills/ guide; see wave 3 skills)
+    # PR: deployer engines (tofu + noop)
+    # "devops_bench/deployers/tofu.py",
+    # "tests/unit/deployers/test_deployers_tofu.py",
+    # "devops_bench/deployers/noop.py",
+    # "tests/unit/deployers/test_deployers_noop.py",
+    # PR: concrete metrics (all five; each travels with its skills/ guide — see wave 3 skills —
+    # and this PR restores the full metrics/__init__.py surface, so flip the init after it lands)
     # "devops_bench/metrics/grounding.py",
     # "tests/unit/metrics/test_metrics_grounding.py",
     # "devops_bench/metrics/tool_invocation.py",


### PR DESCRIPTION
Waves 4 and 5 collapse from 25 PRs to 10 — one batched PR per owner per wave.

- Authors are reshuffled so each batch is written by someone who did not build that area (going by the pre-refactor `pkg/` history), with the area's main past contributors listed as reviewers.
- The MCP client moves from wave 4 into the wave-5 API agent PR (its only importer).
- All five concrete metrics ship in one PR, so `metrics/__init__.py` reaches parity and flips right after it lands.
- `migrated.bara.sky` comments are regrouped to match the new PR boundaries; the path entries themselves are unchanged.