### PR TITLE
feat(verification): type verification_spec with roles (schema foundation)

### DIFF
--- a/devops_bench/evalharness/default.py
+++ b/devops_bench/evalharness/default.py
@@ -54,6 +54,7 @@ from devops_bench.evalharness.scenario import (
 )
 from devops_bench.tasks import Task
 from devops_bench.verification import VerificationSpec
+from devops_bench.verification.entry import VerificationEntry
 
 __all__ = ["DefaultEvalHarness"]
 
@@ -470,6 +471,32 @@ class DefaultEvalHarness(Harness):
             return {}, []
 
         errors: list[dict[str, str]] = []
+        mapping: dict[str, Any] = {}
+
+        # Typed path: task.verification_spec has been parsed into VerificationEntry
+        # objects at load time. Placeholders live inside entry.spec (still raw dicts).
+        if isinstance(raw, list) and raw and isinstance(raw[0], VerificationEntry):
+            for entry in raw:
+                try:
+                    spec_resolved = self._resolve_spec_placeholders(
+                        entry.spec, cluster_name, target_deployment, namespace
+                    )
+                    if entry.name in mapping:
+                        _log.warning(
+                            "duplicate verification entry name %r; overwriting", entry.name
+                        )
+                    mapping[entry.name] = VerificationSpec(spec_resolved)
+                except Exception as exc:  # noqa: BLE001 - surface every failure
+                    _log.warning(
+                        "verification entry %r failed to validate; skipping: %s",
+                        entry.name,
+                        exc,
+                    )
+                    errors.append({"name": entry.name, "reason": str(exc)})
+            return mapping, errors
+
+        # Legacy path: raw dict / list / JSON-string (pre-migration or direct calls
+        # that bypass the typed schema).
         resolved = self._resolve_spec_placeholders(raw, cluster_name, target_deployment, namespace)
         if isinstance(resolved, str):
             try:
@@ -480,7 +507,6 @@ class DefaultEvalHarness(Harness):
                 return {}, errors
         entries = resolved if isinstance(resolved, list) else [resolved]
 
-        mapping: dict[str, Any] = {}
         for index, entry in enumerate(entries):
             if not isinstance(entry, dict):
                 msg = (
@@ -500,6 +526,8 @@ class DefaultEvalHarness(Harness):
             # a ``spec`` key is itself treated as the typed node.
             node = entry.get("spec") if "spec" in entry else entry
             try:
+                if name in mapping:
+                    _log.warning("duplicate verification entry name %r; overwriting", name)
                 mapping[name] = VerificationSpec(node)
             except Exception as exc:  # noqa: BLE001 - surface every failure
                 _log.warning(
@@ -944,7 +972,11 @@ class DefaultEvalHarness(Harness):
             "expected_output_raw": task.expected_output,
             "retrieval_context": list(task.retrieval_context),
             "chaos_spec": task.chaos_spec,
-            "verification_spec": task.verification_spec,
+            "verification_spec": (
+                [e.model_dump() if hasattr(e, "model_dump") else e for e in task.verification_spec]
+                if task.verification_spec is not None
+                else None
+            ),
             "chaos_report": {},
             "perf_report": {},
             "documentation": [doc.model_dump() for doc in task.documentation],

--- a/devops_bench/tasks/schema.py
+++ b/devops_bench/tasks/schema.py
@@ -19,6 +19,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from devops_bench.core import get_logger
+from devops_bench.verification.entry import VerificationEntry
 
 __all__ = ["Task", "DocumentationEntry", "Constraint"]
 
@@ -143,7 +144,7 @@ class Task(BaseModel):
     expected_output: str = ""
     retrieval_context: list[str] = Field(default_factory=list)
     chaos_spec: Any = None
-    verification_spec: Any = None
+    verification_spec: list[VerificationEntry] | None = None
     infrastructure: dict[str, Any] = Field(default_factory=dict)
     documentation: list[DocumentationEntry] = Field(default_factory=list)
     validated: bool = False

--- a/devops_bench/verification/__init__.py
+++ b/devops_bench/verification/__init__.py
@@ -19,11 +19,15 @@ This package exposes the verification spec model
 typed outcome (:class:`VerificationResult`), the registry-driven extension
 surface (:data:`VERIFIERS`, :func:`parse_node`), and the deadline-based
 :class:`VerifierAgent` that evaluates them. Importing the package pulls no
-heavy SDKs — concrete leaf verifiers register via this package's submodules
+heavy SDKs -- concrete leaf verifiers register via this package's submodules
 only.
+
+The entry-level schema (:class:`VerificationEntry`, :data:`Role`) is available
+via direct submodule imports or from this package.
 """
 
-from devops_bench.verification.base import VERIFIERS, BaseVerifier, VerificationResult
+from devops_bench.verification.base import VERIFIERS, BaseVerifier, Mode, VerificationResult
+from devops_bench.verification.entry import Role, VerificationEntry
 from devops_bench.verification.runner import VerifierAgent
 from devops_bench.verification.spec import (
     ParallelSpec,
@@ -36,9 +40,12 @@ from devops_bench.verification.spec import (
 
 __all__ = [
     "BaseVerifier",
+    "Mode",
     "ParallelSpec",
+    "Role",
     "SequenceSpec",
     "VERIFIERS",
+    "VerificationEntry",
     "VerificationNode",
     "VerificationResult",
     "VerificationSpec",

--- a/devops_bench/verification/base.py
+++ b/devops_bench/verification/base.py
@@ -64,10 +64,12 @@ class VerificationResult(BaseModel):
         raw: Leaf-only kubectl diagnostics or supporting data.
         weight: Contribution weight used by the rollup; default 1.0. Echoed
             from the originating leaf's :attr:`BaseVerifier.weight` so the
-            result tree is self-describing for downstream scoring. A custom
-            verifier overriding :meth:`BaseVerifier.verify` and constructing
-            this result directly must pass ``weight=self.weight``; omitting it
-            silently loses the configured weight from the result tree.
+            result tree is self-describing for downstream scoring. The runner
+            (:meth:`~devops_bench.verification.runner.VerifierAgent._run_leaf`)
+            stamps the leaf's configured weight onto the result after
+            evaluation, so a custom verifier that builds this result directly
+            (bypassing :meth:`BaseVerifier._poll_to_result`) does not need to
+            forward ``weight`` itself — the runner is authoritative.
     """
 
     success: bool

--- a/devops_bench/verification/base.py
+++ b/devops_bench/verification/base.py
@@ -23,14 +23,23 @@ from __future__ import annotations
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
 from devops_bench.core import Registry
 from devops_bench.k8s import poll_until
 
-__all__ = ["VERIFIERS", "VerificationResult", "BaseVerifier"]
+__all__ = ["Mode", "VERIFIERS", "VerificationResult", "BaseVerifier"]
+
+# Execution mode for a leaf verifier.
+#
+# converge  -- verify(timeout_sec=N): keep polling until success or deadline.
+# assert    -- verify(timeout_sec=0): evaluate exactly once, never sleep.
+# hold      -- sample verify(0) repeatedly; every sample must pass.
+# unchanged -- NOT IMPLEMENTED: requires a pre-agent snapshot protocol.
+#              The first consumer (unchanged_outside) is not in this PR.
+Mode = Literal["converge", "assert", "unchanged", "hold"]
 
 # Registry keyed by the ``type`` discriminator literal. Entry-point discovery
 # lets external packages register a verifier without touching this tree.
@@ -53,6 +62,12 @@ class VerificationResult(BaseModel):
         name: Optional label echoed from the spec node, for result rendering.
         children: Per-member results from compound (sequence/parallel) nodes.
         raw: Leaf-only kubectl diagnostics or supporting data.
+        weight: Contribution weight used by the rollup; default 1.0. Echoed
+            from the originating leaf's :attr:`BaseVerifier.weight` so the
+            result tree is self-describing for downstream scoring. A custom
+            verifier overriding :meth:`BaseVerifier.verify` and constructing
+            this result directly must pass ``weight=self.weight``; omitting it
+            silently loses the configured weight from the result tree.
     """
 
     success: bool
@@ -61,6 +76,7 @@ class VerificationResult(BaseModel):
     name: str | None = None
     children: list[VerificationResult] = Field(default_factory=list)
     raw: dict | None = None
+    weight: float = 1.0
 
 
 VerificationResult.model_rebuild()
@@ -77,10 +93,26 @@ class BaseVerifier(BaseModel, ABC):
         kubeconfig: Optional path to a kubeconfig file, forwarded to the
             ``devops_bench.k8s`` wrappers so a check can target a specific
             cluster. When ``None`` the wrappers use the ambient kubeconfig.
+        weight: Contribution weight used by the rollup when summing pass/fail
+            fractions across leaves. Default 1.0 (all leaves equal). Echoed
+            onto the :class:`VerificationResult` so the tree is self-describing.
+        mode: Explicit execution mode. When ``None`` the runner derives the
+            mode from the parent :class:`~devops_bench.verification.entry.Role`:
+            ``"correctness"`` -> ``"converge"``;
+            ``"safety"`` / ``"catastrophic"`` -> ``"assert"``. An explicit
+            ``mode`` always wins over the role-derived default.
+        hold_window_sec: Duration of the hold-mode sampling window; meaningful
+            only when ``mode="hold"``. Defaults to 30 s.
+        hold_interval_sec: Pause between hold-mode samples; meaningful only
+            when ``mode="hold"``. Defaults to 5 s.
     """
 
     name: str | None = None
     kubeconfig: str | None = None
+    weight: float = 1.0
+    mode: Mode | None = None
+    hold_window_sec: float = 30.0
+    hold_interval_sec: float = 5.0
 
     @abstractmethod
     def verify(self, timeout_sec: float) -> VerificationResult:
@@ -133,4 +165,5 @@ class BaseVerifier(BaseModel, ABC):
             reason=last["reason"],
             name=self.name,
             raw=last["raw"],
+            weight=self.weight,
         )

--- a/devops_bench/verification/base.py
+++ b/devops_bench/verification/base.py
@@ -98,9 +98,9 @@ class BaseVerifier(BaseModel, ABC):
             onto the :class:`VerificationResult` so the tree is self-describing.
         mode: Explicit execution mode. When ``None`` the runner derives the
             mode from the parent :class:`~devops_bench.verification.entry.Role`:
-            ``"correctness"`` -> ``"converge"``;
-            ``"safety"`` / ``"catastrophic"`` -> ``"assert"``. An explicit
-            ``mode`` always wins over the role-derived default.
+            ``"objective"`` -> ``"converge"``;
+            ``"safeguard"`` -> ``"assert"``. An explicit ``mode`` always wins
+            over the role-derived default.
         hold_window_sec: Duration of the hold-mode sampling window; meaningful
             only when ``mode="hold"``. Defaults to 30 s.
         hold_interval_sec: Pause between hold-mode samples; meaningful only

--- a/devops_bench/verification/entry.py
+++ b/devops_bench/verification/entry.py
@@ -1,0 +1,71 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Typed outer wrapper for a verification spec entry.
+
+This module is intentionally kept dependency-light: it must not import from
+``devops_bench.tasks`` (that direction would create a cycle) and it must not
+import from ``devops_bench.verification.spec`` (that triggers registry
+population and verifier imports at task-load time, before placeholder
+substitution has run).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, model_validator
+
+__all__ = ["Role", "VerificationEntry"]
+
+Role = Literal["correctness", "safety", "catastrophic"]
+
+
+def _contains_unchanged_mode(value: Any) -> bool:
+    """Recursively walk a raw spec value looking for ``mode: unchanged``."""
+    if isinstance(value, dict):
+        if value.get("mode") == "unchanged":
+            return True
+        return any(_contains_unchanged_mode(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_contains_unchanged_mode(item) for item in value)
+    return False
+
+
+class VerificationEntry(BaseModel):
+    """One named verification suite with an associated scoring role.
+
+    Attributes:
+        name: Cross-reference key resolved by the chaos ``verify:`` field and
+            used as the key in the name-keyed verification mapping.
+        role: Scoring category. Defaults to ``"correctness"`` so every
+            existing spec authored without a ``role`` key is backward-compatible
+            without editing.
+        spec: Raw (unparsed) verification node dict. Placeholder substitution
+            (``{{NAMESPACE}}``, etc.) happens at eval time; the inner spec is
+            validated against the verifier registry only after substitution.
+    """
+
+    name: str
+    role: Role = "correctness"
+    spec: Any
+
+    @model_validator(mode="after")
+    def _reject_unchanged_mode(self) -> VerificationEntry:
+        if _contains_unchanged_mode(self.spec):
+            raise ValueError(
+                "mode 'unchanged' is designed but not implemented yet: "
+                "its first consumer (unchanged_outside) is not in this PR"
+            )
+        return self

--- a/devops_bench/verification/entry.py
+++ b/devops_bench/verification/entry.py
@@ -27,9 +27,21 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, model_validator
 
-__all__ = ["Role", "VerificationEntry"]
+__all__ = ["Role", "Severity", "VerificationEntry"]
 
-Role = Literal["correctness", "safety", "catastrophic"]
+# Scoring role of a verification entry.
+#
+# objective  -- something the agent must achieve; feeds the correctness score c.
+# safeguard  -- a protective invariant that must hold; a violation penalizes
+#               (recoverable) or hard-gates (catastrophic) the score.
+Role = Literal["objective", "safeguard"]
+
+# Severity of a safeguard violation. Required when role='safeguard', forbidden
+# when role='objective'.
+#
+# recoverable  -- a violation penalizes the score (feeds rec_v).
+# catastrophic -- a violation hard-gates the score to zero (feeds cat_v).
+Severity = Literal["recoverable", "catastrophic"]
 
 
 def _contains_unchanged_mode(value: Any) -> bool:
@@ -49,17 +61,36 @@ class VerificationEntry(BaseModel):
     Attributes:
         name: Cross-reference key resolved by the chaos ``verify:`` field and
             used as the key in the name-keyed verification mapping.
-        role: Scoring category. Defaults to ``"correctness"`` so every
+        role: Scoring category. Defaults to ``"objective"`` so every
             existing spec authored without a ``role`` key is backward-compatible
             without editing.
+        severity: Required when ``role == "safeguard"``; must be ``None`` when
+            ``role == "objective"``. ``"recoverable"`` violations penalize the
+            score (feed ``rec_v``); ``"catastrophic"`` violations hard-gate the
+            run (feed ``cat_v``).
         spec: Raw (unparsed) verification node dict. Placeholder substitution
             (``{{NAMESPACE}}``, etc.) happens at eval time; the inner spec is
             validated against the verifier registry only after substitution.
     """
 
     name: str
-    role: Role = "correctness"
+    role: Role = "objective"
+    severity: Severity | None = None
     spec: Any
+
+    @model_validator(mode="after")
+    def _validate_severity(self) -> VerificationEntry:
+        if self.role == "safeguard" and self.severity is None:
+            raise ValueError(
+                "severity is required when role='safeguard'; "
+                "set severity='recoverable' or severity='catastrophic'"
+            )
+        if self.role == "objective" and self.severity is not None:
+            raise ValueError(
+                "severity must be None when role='objective'; "
+                "severity is only meaningful on safeguard entries"
+            )
+        return self
 
     @model_validator(mode="after")
     def _reject_unchanged_mode(self) -> VerificationEntry:

--- a/devops_bench/verification/runner.py
+++ b/devops_bench/verification/runner.py
@@ -119,11 +119,23 @@ class VerifierAgent:
         Short-circuits when the remaining budget is below
         :data:`_MIN_LEAF_BUDGET_SECONDS` so we never issue a useless
         sub-second ``kubectl wait`` at the tail of the deadline.
+
+        The verifier's configured ``weight`` is stamped onto the returned result
+        here, authoritatively: the leaf is the single source of truth for its
+        weight, so a custom ``verify()`` that builds a
+        :class:`VerificationResult` directly (bypassing ``_poll_to_result``) can
+        never silently drop it. When the node carries no ``weight`` attribute
+        (e.g. a compound spec reached as a leaf), the result's own weight is
+        left untouched.
         """
         remaining = deadline - time.monotonic()
         if remaining < _MIN_LEAF_BUDGET_SECONDS:
             return _timed_out(node, "deadline exhausted before evaluation")
-        return node.verify(remaining)
+        result = node.verify(remaining)
+        weight = getattr(node, "weight", None)
+        if weight is not None:
+            result.weight = weight
+        return result
 
     def _run_sequence(self, node: SequenceSpec, deadline: float) -> VerificationResult:
         """Run children in order; stop and skip the rest on the first failure."""

--- a/tests/unit/evalharness/test_default_harness.py
+++ b/tests/unit/evalharness/test_default_harness.py
@@ -391,3 +391,35 @@ def test_resolve_deployment_and_namespace_precedence_and_types(
     dep, ns = harness._resolve_deployment_and_namespace(task_non_str_vars)  # noqa: SLF001
     assert dep == "123"
     assert ns == "456"
+
+
+def test_empty_record_does_not_crash_when_verification_spec_holds_raw_dicts(
+    isolated_env: None,
+) -> None:
+    """``_empty_record`` must not crash when ``verification_spec`` contains raw dicts.
+
+    A test fixture or mock that bypasses ``Task.from_dict`` can produce a
+    ``Task`` whose ``verification_spec`` holds plain dicts instead of
+    ``VerificationEntry`` objects. The defensive ``hasattr`` guard in
+    ``_empty_record`` must absorb this without raising ``AttributeError``.
+    """
+    harness = DefaultEvalHarness(project_id="p", cluster_name="c")
+
+    raw_spec = {"name": "check-a", "spec": {"type": "pod_healthy", "selector": "app=x"}}
+    task = Task.model_construct(
+        id="t",
+        name="demo",
+        folder="",
+        prompt="p",
+        expected_output="",
+        retrieval_context=[],
+        chaos_spec=None,
+        verification_spec=[raw_spec],
+        infrastructure={},
+        documentation=[],
+        validated=False,
+    )
+
+    record = harness._empty_record(task)  # noqa: SLF001
+
+    assert record["verification_spec"] == [raw_spec]

--- a/tests/unit/evalharness/test_reporter.py
+++ b/tests/unit/evalharness/test_reporter.py
@@ -107,7 +107,9 @@ def _stub_task() -> Task:
             "expected_output": "exp",
             "retrieval_context": ["doc-a"],
             "chaos_spec": {"chaos": "yes"},
-            "verification_spec": {"verify": "yes"},
+            "verification_spec": [
+                {"name": "check", "spec": {"type": "pod_healthy", "selector": "app=demo"}}
+            ],
         }
     )
 

--- a/tests/unit/evalharness/test_spec_parsing.py
+++ b/tests/unit/evalharness/test_spec_parsing.py
@@ -22,8 +22,12 @@ at its own boundary.
 
 from __future__ import annotations
 
+import json
+import logging
 from pathlib import Path
+from unittest.mock import patch
 
+import pytest
 import yaml
 
 from devops_bench.chaos import ChaosSpec
@@ -35,6 +39,7 @@ from devops_bench.verification import (
     ParallelSpec,
     VerificationSpec,
 )
+from devops_bench.verification.entry import VerificationEntry
 from devops_bench.verification.verifiers import (
     PodHealthyVerifier,
     ScalingCompleteVerifier,
@@ -184,3 +189,79 @@ def test_task_loader_reads_native_yaml_specs_as_python_values() -> None:
     # Opaque ``Any``: a list-of-mappings flows through verbatim, not as a string.
     assert isinstance(task.chaos_spec, list)
     assert isinstance(task.verification_spec, list)
+
+
+def test_verification_mapping_captures_placeholder_resolution_error_as_parse_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A placeholder-resolution failure is recorded as a parse error, not a crash.
+
+    The typed path (``VerificationEntry`` objects) moves ``_resolve_spec_placeholders``
+    inside the per-entry try/except, so any exception it raises is appended to the
+    errors list rather than propagating out of ``_build_verification_mapping``.
+    """
+    good_entry = VerificationEntry(
+        name="good",
+        spec={"type": "pod_healthy", "selector": "app=x", "namespace": "default"},
+    )
+    bad_entry = VerificationEntry(
+        name="bad",
+        spec={"type": "pod_healthy", "selector": "app=y", "namespace": "default"},
+    )
+
+    harness = _harness()
+
+    def _boom(spec, cluster_name, target_deployment=None, namespace=None):
+        if spec.get("selector") == "app=y":
+            raise ValueError("placeholder boom")
+        return spec
+
+    with (
+        caplog.at_level(logging.WARNING, logger="devops_bench.evalharness.default"),
+        patch.object(harness, "_resolve_spec_placeholders", side_effect=_boom),
+    ):
+        mapping, errors = harness._build_verification_mapping(  # noqa: SLF001
+            [good_entry, bad_entry], cluster_name="c"
+        )
+
+    assert "good" in mapping
+    assert "bad" not in mapping
+    assert len(errors) == 1
+    assert errors[0]["name"] == "bad"
+    assert "placeholder boom" in errors[0]["reason"]
+
+
+def test_verification_mapping_warns_on_duplicate_entry_names(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Two entries sharing a name emit a warning and the last one wins.
+
+    The typed path must not silently overwrite without any operator signal.
+    ``caplog`` pins that a WARNING-level log line naming the duplicate is
+    emitted, and the final mapping carries the second entry's spec.
+    """
+    entry_first = VerificationEntry(
+        name="same",
+        spec={"type": "pod_healthy", "selector": "app=first", "namespace": "default"},
+    )
+    entry_second = VerificationEntry(
+        name="same",
+        spec={"type": "pod_healthy", "selector": "app=second", "namespace": "default"},
+    )
+
+    harness = _harness()
+    with caplog.at_level(logging.WARNING, logger="devops_bench.evalharness.default"):
+        mapping, errors = harness._build_verification_mapping(  # noqa: SLF001
+            [entry_first, entry_second], cluster_name="c"
+        )
+
+    assert errors == []
+    assert "same" in mapping
+    # Warning was emitted
+    assert any(
+        "duplicate" in record.message and "same" in record.message for record in caplog.records
+    )
+    # Last entry wins: the resolved spec carries the second selector
+    spec = mapping["same"]
+    raw_repr = json.dumps(spec.model_dump())
+    assert "app=second" in raw_repr

--- a/tests/unit/tasks/test_tasks_schema.py
+++ b/tests/unit/tasks/test_tasks_schema.py
@@ -28,7 +28,9 @@ def test_from_dict_full():
         "expected_output": "  done  ",
         "retrieval_context": ["ctx"],
         "chaos_spec": {"kind": "kill"},
-        "verification_spec": {"check": "ok"},
+        "verification_spec": [
+            {"name": "check-pods", "spec": {"type": "pod_healthy", "selector": "app=web"}}
+        ],
         "infrastructure": {"deployer": "tofu"},
     }
     task = Task.from_dict(raw, name_default="dir-name")
@@ -39,7 +41,9 @@ def test_from_dict_full():
     assert task.expected_output == "done"
     assert task.retrieval_context == ["ctx"]
     assert task.chaos_spec == {"kind": "kill"}
-    assert task.verification_spec == {"check": "ok"}
+    assert task.verification_spec is not None
+    assert len(task.verification_spec) == 1
+    assert task.verification_spec[0].name == "check-pods"
     assert task.infrastructure == {"deployer": "tofu"}
 
 
@@ -183,13 +187,32 @@ def test_constraint_empty_text_coalesces():
     assert constraint.critical is False
 
 
-def test_chaos_and_verification_specs_are_opaque():
-    # These specs are parsed downstream, so the schema accepts any shape
-    # (e.g. a raw JSON string from a YAML literal block, a list, or a mapping).
-    raw = {"chaos_spec": '[{"name": "spike"}]', "verification_spec": [{"name": "v"}]}
+def test_chaos_spec_is_opaque():
+    # chaos_spec is still Any; accepts JSON strings, lists, mappings.
+    raw = {"chaos_spec": '[{"name": "spike"}]'}
     task = Task.from_dict(raw, name_default="d")
     assert task.chaos_spec == '[{"name": "spike"}]'
-    assert task.verification_spec == [{"name": "v"}]
+
+
+def test_verification_spec_parses_typed_entries():
+    # verification_spec is now list[VerificationEntry]; the spec field inside
+    # each entry is kept raw (unparsed) so placeholder substitution can run later.
+    from devops_bench.verification.entry import VerificationEntry
+
+    raw = {
+        "verification_spec": [
+            {
+                "name": "check",
+                "role": "safety",
+                "spec": {"type": "pod_healthy", "selector": "app=web"},
+            },
+        ]
+    }
+    task = Task.from_dict(raw, name_default="d")
+    assert task.verification_spec is not None
+    assert isinstance(task.verification_spec[0], VerificationEntry)
+    assert task.verification_spec[0].name == "check"
+    assert task.verification_spec[0].role == "safety"
 
 
 def test_to_dict_roundtrip_fields():

--- a/tests/unit/tasks/test_tasks_schema.py
+++ b/tests/unit/tasks/test_tasks_schema.py
@@ -203,7 +203,8 @@ def test_verification_spec_parses_typed_entries():
         "verification_spec": [
             {
                 "name": "check",
-                "role": "safety",
+                "role": "safeguard",
+                "severity": "recoverable",
                 "spec": {"type": "pod_healthy", "selector": "app=web"},
             },
         ]
@@ -212,7 +213,8 @@ def test_verification_spec_parses_typed_entries():
     assert task.verification_spec is not None
     assert isinstance(task.verification_spec[0], VerificationEntry)
     assert task.verification_spec[0].name == "check"
-    assert task.verification_spec[0].role == "safety"
+    assert task.verification_spec[0].role == "safeguard"
+    assert task.verification_spec[0].severity == "recoverable"
 
 
 def test_to_dict_roundtrip_fields():

--- a/tests/unit/verification/test_entry_schema.py
+++ b/tests/unit/verification/test_entry_schema.py
@@ -1,0 +1,192 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for VerificationEntry schema and the optimize-scale regression.
+
+Critical regression: the only real task with a verification_spec
+(tasks/common/optimize-scale/task.yaml) must parse under the new typed
+list[VerificationEntry] schema and its entries must default to role='correctness'.
+This test makes that claim explicit so the renovation cannot silently break it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from devops_bench.tasks.schema import Task
+from devops_bench.verification.entry import VerificationEntry
+
+# -- VerificationEntry model --------------------------------------------------
+
+
+def test_entry_defaults_role_to_correctness():
+    entry = VerificationEntry(name="check-pods", spec={"type": "pod_healthy", "selector": "app=x"})
+
+    assert entry.role == "correctness"
+
+
+def test_entry_accepts_all_roles():
+    for role in ("correctness", "safety", "catastrophic"):
+        entry = VerificationEntry(name="check", role=role, spec={})
+        assert entry.role == role
+
+
+def test_entry_rejects_unknown_role():
+    with pytest.raises(ValidationError):
+        VerificationEntry(name="check", role="unknown", spec={})
+
+
+def test_entry_rejects_unchanged_mode():
+    with pytest.raises(ValidationError, match="unchanged"):
+        VerificationEntry(
+            name="check",
+            role="correctness",
+            spec={"type": "scaling_complete", "deployment": "web", "mode": "unchanged"},
+        )
+
+
+def test_entry_rejects_unchanged_mode_nested_in_parallel():
+    with pytest.raises(ValidationError, match="unchanged"):
+        VerificationEntry(
+            name="check",
+            role="correctness",
+            spec={
+                "type": "parallel",
+                "checks": [
+                    {"type": "scaling_complete", "deployment": "web", "mode": "unchanged"},
+                ],
+            },
+        )
+
+
+def test_entry_spec_accepts_any_value():
+    entry = VerificationEntry(name="raw", spec={"type": "parallel", "checks": []})
+    assert entry.spec == {"type": "parallel", "checks": []}
+
+
+def test_entry_spec_can_be_none():
+    entry = VerificationEntry(name="raw", spec=None)
+    assert entry.spec is None
+
+
+def test_entry_name_is_required():
+    with pytest.raises(ValidationError):
+        VerificationEntry(role="correctness", spec={})
+
+
+# -- Role type ----------------------------------------------------------------
+
+
+def test_role_literal_values():
+    valid = ["correctness", "safety", "catastrophic"]
+    for v in valid:
+        entry = VerificationEntry(name="x", role=v, spec={})
+        assert entry.role == v
+
+
+# -- Critical regression: optimize-scale task parses under typed schema -------
+
+
+_TASK_YAML_PATH = Path(__file__).parents[3] / "tasks" / "common" / "optimize-scale" / "task.yaml"
+
+
+@pytest.mark.skipif(
+    not _TASK_YAML_PATH.exists(),
+    reason="optimize-scale task.yaml not present in this checkout",
+)
+def test_optimize_scale_verification_spec_parses_as_typed_entries():
+    """The optimize-scale task's verification_spec loads as list[VerificationEntry].
+
+    This is the load-time regression gate for the 'renovation not replacement'
+    claim. The spec must round-trip through Task.from_dict with the new typed
+    field without any authoring change to the task.yaml.
+    """
+    raw = yaml.safe_load(_TASK_YAML_PATH.read_text())
+    task = Task.from_dict(raw, name_default="optimize-scale", folder="optimize-scale")
+
+    assert task.verification_spec is not None
+    assert isinstance(task.verification_spec, list)
+    assert len(task.verification_spec) == 1
+
+    entry = task.verification_spec[0]
+    assert isinstance(entry, VerificationEntry)
+    assert entry.name == "Planned Load Spike Verification"
+    assert entry.role == "correctness"
+
+    # The inner spec is kept raw (unsubstituted, unparsed) at task-load time.
+    assert isinstance(entry.spec, dict)
+    assert entry.spec.get("type") == "parallel"
+
+
+@pytest.mark.skipif(
+    not _TASK_YAML_PATH.exists(),
+    reason="optimize-scale task.yaml not present in this checkout",
+)
+def test_optimize_scale_entry_spec_retains_unsubstituted_placeholders():
+    """Placeholder strings survive task load so the harness can substitute them."""
+    raw = yaml.safe_load(_TASK_YAML_PATH.read_text())
+    task = Task.from_dict(raw, name_default="optimize-scale", folder="optimize-scale")
+
+    entry = task.verification_spec[0]
+    spec_str = str(entry.spec)
+    assert "{{TARGET_DEPLOYMENT_NAME}}" in spec_str or "{{NAMESPACE}}" in spec_str
+
+
+# -- Task.from_dict with typed verification_spec ------------------------------
+
+
+def test_task_from_dict_with_no_verification_spec_is_none():
+    raw = {"id": "t1", "name": "t", "prompt": "p"}
+    task = Task.from_dict(raw)
+
+    assert task.verification_spec is None
+
+
+def test_task_from_dict_with_list_of_entries():
+    raw = {
+        "id": "t2",
+        "name": "t",
+        "prompt": "p",
+        "verification_spec": [
+            {
+                "name": "check-pods",
+                "role": "safety",
+                "spec": {"type": "pod_healthy", "selector": "app=x"},
+            },
+        ],
+    }
+    task = Task.from_dict(raw)
+
+    assert task.verification_spec is not None
+    assert len(task.verification_spec) == 1
+    assert task.verification_spec[0].name == "check-pods"
+    assert task.verification_spec[0].role == "safety"
+
+
+def test_task_from_dict_with_entries_defaults_role():
+    raw = {
+        "id": "t3",
+        "name": "t",
+        "prompt": "p",
+        "verification_spec": [
+            {"name": "check", "spec": {"type": "pod_healthy", "selector": "app=x"}},
+        ],
+    }
+    task = Task.from_dict(raw)
+
+    assert task.verification_spec[0].role == "correctness"

--- a/tests/unit/verification/test_entry_schema.py
+++ b/tests/unit/verification/test_entry_schema.py
@@ -16,7 +16,7 @@
 
 Critical regression: the only real task with a verification_spec
 (tasks/common/optimize-scale/task.yaml) must parse under the new typed
-list[VerificationEntry] schema and its entries must default to role='correctness'.
+list[VerificationEntry] schema and its entries must default to role='objective'.
 This test makes that claim explicit so the renovation cannot silently break it.
 """
 
@@ -34,16 +34,23 @@ from devops_bench.verification.entry import VerificationEntry
 # -- VerificationEntry model --------------------------------------------------
 
 
-def test_entry_defaults_role_to_correctness():
+def test_entry_defaults_role_to_objective():
     entry = VerificationEntry(name="check-pods", spec={"type": "pod_healthy", "selector": "app=x"})
 
-    assert entry.role == "correctness"
+    assert entry.role == "objective"
+    assert entry.severity is None
 
 
-def test_entry_accepts_all_roles():
-    for role in ("correctness", "safety", "catastrophic"):
-        entry = VerificationEntry(name="check", role=role, spec={})
-        assert entry.role == role
+def test_entry_accepts_objective_role():
+    entry = VerificationEntry(name="check", role="objective", spec={})
+    assert entry.role == "objective"
+
+
+def test_entry_accepts_safeguard_roles_with_severity():
+    for severity in ("recoverable", "catastrophic"):
+        entry = VerificationEntry(name="check", role="safeguard", severity=severity, spec={})
+        assert entry.role == "safeguard"
+        assert entry.severity == severity
 
 
 def test_entry_rejects_unknown_role():
@@ -51,11 +58,26 @@ def test_entry_rejects_unknown_role():
         VerificationEntry(name="check", role="unknown", spec={})
 
 
+def test_entry_rejects_safeguard_without_severity():
+    with pytest.raises(ValidationError, match="severity is required"):
+        VerificationEntry(name="check", role="safeguard", spec={})
+
+
+def test_entry_rejects_objective_with_severity():
+    with pytest.raises(ValidationError, match="severity must be None"):
+        VerificationEntry(name="check", role="objective", severity="recoverable", spec={})
+
+
+def test_entry_rejects_unknown_severity():
+    with pytest.raises(ValidationError):
+        VerificationEntry(name="check", role="safeguard", severity="mild", spec={})
+
+
 def test_entry_rejects_unchanged_mode():
     with pytest.raises(ValidationError, match="unchanged"):
         VerificationEntry(
             name="check",
-            role="correctness",
+            role="objective",
             spec={"type": "scaling_complete", "deployment": "web", "mode": "unchanged"},
         )
 
@@ -64,7 +86,7 @@ def test_entry_rejects_unchanged_mode_nested_in_parallel():
     with pytest.raises(ValidationError, match="unchanged"):
         VerificationEntry(
             name="check",
-            role="correctness",
+            role="objective",
             spec={
                 "type": "parallel",
                 "checks": [
@@ -86,17 +108,20 @@ def test_entry_spec_can_be_none():
 
 def test_entry_name_is_required():
     with pytest.raises(ValidationError):
-        VerificationEntry(role="correctness", spec={})
+        VerificationEntry(role="objective", spec={})
 
 
 # -- Role type ----------------------------------------------------------------
 
 
 def test_role_literal_values():
-    valid = ["correctness", "safety", "catastrophic"]
-    for v in valid:
-        entry = VerificationEntry(name="x", role=v, spec={})
-        assert entry.role == v
+    entry = VerificationEntry(name="x", role="objective", spec={})
+    assert entry.role == "objective"
+
+    for severity in ("recoverable", "catastrophic"):
+        entry = VerificationEntry(name="x", role="safeguard", severity=severity, spec={})
+        assert entry.role == "safeguard"
+        assert entry.severity == severity
 
 
 # -- Critical regression: optimize-scale task parses under typed schema -------
@@ -126,7 +151,7 @@ def test_optimize_scale_verification_spec_parses_as_typed_entries():
     entry = task.verification_spec[0]
     assert isinstance(entry, VerificationEntry)
     assert entry.name == "Planned Load Spike Verification"
-    assert entry.role == "correctness"
+    assert entry.role == "objective"
 
     # The inner spec is kept raw (unsubstituted, unparsed) at task-load time.
     assert isinstance(entry.spec, dict)
@@ -165,7 +190,8 @@ def test_task_from_dict_with_list_of_entries():
         "verification_spec": [
             {
                 "name": "check-pods",
-                "role": "safety",
+                "role": "safeguard",
+                "severity": "recoverable",
                 "spec": {"type": "pod_healthy", "selector": "app=x"},
             },
         ],
@@ -175,7 +201,8 @@ def test_task_from_dict_with_list_of_entries():
     assert task.verification_spec is not None
     assert len(task.verification_spec) == 1
     assert task.verification_spec[0].name == "check-pods"
-    assert task.verification_spec[0].role == "safety"
+    assert task.verification_spec[0].role == "safeguard"
+    assert task.verification_spec[0].severity == "recoverable"
 
 
 def test_task_from_dict_with_entries_defaults_role():
@@ -189,4 +216,4 @@ def test_task_from_dict_with_entries_defaults_role():
     }
     task = Task.from_dict(raw)
 
-    assert task.verification_spec[0].role == "correctness"
+    assert task.verification_spec[0].role == "objective"

--- a/tests/unit/verification/test_runner.py
+++ b/tests/unit/verification/test_runner.py
@@ -59,6 +59,40 @@ def test_leaf_spec_dispatches_to_verify():
     assert 25.0 < calls[0] <= 30.0
 
 
+def test_runner_stamps_configured_weight_onto_leaf_result():
+    """The runner is authoritative for weight, even if ``verify`` forgets it.
+
+    A custom verifier that builds its ``VerificationResult`` directly (bypassing
+    ``_poll_to_result``) and omits ``weight`` would otherwise leave the default
+    1.0 on the result. The runner re-stamps the leaf's configured weight so the
+    scoring rollup cannot silently lose it.
+    """
+
+    def forgetful_verify(self: Any, timeout_sec: float) -> VerificationResult:
+        # Deliberately omit ``weight`` — the default 1.0 would be wrong.
+        return VerificationResult(success=True, elapsed_time=0.0, reason="ok")
+
+    spec = VerificationSpec({"type": "pod_healthy", "selector": "app=web", "weight": 3.0})
+    with patch.object(PodHealthyVerifier, "verify", forgetful_verify):
+        result = VerifierAgent().wait_for_condition(spec, timeout_sec=30)
+
+    assert result.success is True
+    assert result.weight == 3.0
+
+
+def test_runner_preserves_default_weight_when_unset():
+    """A leaf with no configured weight keeps the default 1.0."""
+
+    def fake_verify(self: Any, timeout_sec: float) -> VerificationResult:
+        return VerificationResult(success=True, elapsed_time=0.0, reason="ok")
+
+    spec = VerificationSpec({"type": "pod_healthy", "selector": "app=web"})
+    with patch.object(PodHealthyVerifier, "verify", fake_verify):
+        result = VerifierAgent().wait_for_condition(spec, timeout_sec=30)
+
+    assert result.weight == 1.0
+
+
 def test_sequence_runs_children_in_order_and_aggregates():
     order: list[str] = []
     verify_calls: dict[str, float] = {}


### PR DESCRIPTION
## Type verification_spec with roles (schema foundation)

### Motivation
A foundational step toward the multi-dimensional scoring we've been discussing. Typing `verification_spec` with a `role` gives a task a way to express which checks feed which scoring dimension, and sets the stage for the next steps. It is intentionally split from the machinery that consumes it (a follow-up PR) so this part lands as a small, behavior-neutral change.

### What this does
- Adds `VerificationEntry` (`name`, `role`, `spec`) and types `Task.verification_spec` as `list[VerificationEntry] | None`. `role` is one of `correctness | safety | catastrophic`, defaulting to `correctness`, so every existing spec stays valid unchanged.
- Declares optional `mode` and `weight` fields on `BaseVerifier` (and `weight` on `VerificationResult`). Additive metadata; nothing consumes them in this PR.
- Adapts the harness parse path to accept typed entries, preserving the existing `verification_parse_errors` behavior.

### What this does NOT do
No new verifiers, no scoring logic, no runtime behavior change. `tasks/common/optimize-scale` parses and runs exactly as before (regression test included). The verifier vocabulary and the c/rec_v/cat_v rollup that consume role/mode/weight will land in a follow-up PR, framed as directional and open for discussion.
