### PR TITLE
fix(migration): make the upstream-tree check work under GNU grep

### DIFF
--- a/hack/migration-status.sh
+++ b/hack/migration-status.sh
@@ -48,7 +48,7 @@ done
 if [[ "$MODE" == "suggest" ]]; then
   [[ -n "$UPSTREAM_TREE" && -f "$UPSTREAM_TREE" ]] \
     || { echo "error: --suggest-flips needs --upstream-tree <file> (git ls-tree -r <upstream-ref>)" >&2; exit 2; }
-  grep -qE '^[0-9]+ blob [0-9a-f]{40,64}\t' "$UPSTREAM_TREE" \
+  grep -qE $'^[0-9]+ blob [0-9a-f]{40,64}\t' "$UPSTREAM_TREE" \
     || { echo "error: $UPSTREAM_TREE has no blob hashes; generate it with 'git ls-tree -r <ref>' (not --name-only)" >&2; exit 2; }
 
   LOCAL_TREE="$(mktemp)"


### PR DESCRIPTION
The suggest-flips workflow failed on its first run since the content-parity rewrite: the upstream-tree validation in `hack/migration-status.sh` never matches under GNU grep, which reads `\t` in an ERE as a literal `t` (BSD grep on macOS interprets it as a tab, so it passed locally). Pass a real tab via ANSI-C quoting so the check works on both.

Verified: `--suggest-flips` dry-run against the current upstream tree reports the same 2 parity-ready entries as before the change.