### PR TITLE
chore(migration): flip providers + tf modules into the frontier

### DIFF
--- a/migrated.bara.sky
+++ b/migrated.bara.sky
@@ -62,10 +62,10 @@ MIGRATED = [
     # "devops_bench/k8s/**",
     # "tests/unit/k8s/**",
     # cloud providers (base, gcp, kind)
-    # "devops_bench/providers/**",
-    # "tests/unit/providers/**",
+    "devops_bench/providers/**",
+    "tests/unit/providers/**",
     # Terraform modules (path kept as tf/modules — no infra/ rename)
-    # "tf/modules/**",
+    "tf/modules/**",
     # result model (row, aggregate, normalize)
     # "devops_bench/results/**",
     # "tests/unit/results/**",


### PR DESCRIPTION
The cloud provider abstraction (base, GCP, KinD) and the reusable Terraform modules (cluster, bastion) have landed in the canonical repo. This uncomments their frontier entries in migrated.bara.sky so the paths lock read-only here and the back-sync starts mirroring them.

Note: kind.py and test_providers.py carry small review edits made upstream during forward review; tf/modules/** picked up the Apache license header. The first back-sync run after this merges will open the PR that reconciles them — merge it promptly.

Unblocks the wave-4 deployers-base PR that imports providers + tf modules.