### PR TITLE
feat: canonical token buckets across harnesses and the result row

### DIFF
--- a/devops_bench/agents/api/agent.py
+++ b/devops_bench/agents/api/agent.py
@@ -26,6 +26,7 @@ import shlex
 from pathlib import Path
 from typing import Any
 
+from devops_bench.agents import result as agents_result
 from devops_bench.agents.api.mcp import MCPClient, extract_tool_text
 from devops_bench.agents.api.skills import (
     SkillToolInfo,
@@ -142,33 +143,31 @@ def _fold_with_extraction_errors(
 
 
 def extract_tokens(response: Any) -> dict:
-    """Pull provider token usage off the final raw response.
+    """Pull provider token usage off the final raw response, canonicalized.
 
-    Detects which provider's usage shape is present and maps each onto a stable
-    key scheme (``prompt_tokens`` / ``candidates_tokens`` / ``total_tokens``) so
-    ``results.json`` stays consistent across providers.
+    Detects which provider's usage shape is present and maps it onto the
+    canonical token buckets (:func:`devops_bench.agents.result.empty_tokens`),
+    where ``input`` is the **non-cached** prompt and ``output`` excludes
+    ``reasoning``:
 
-    Supported shapes:
+    * **Google** — ``usage_metadata``: ``input = prompt_token_count −
+      cached_content_token_count (+ tool_use_prompt_token_count)``,
+      ``reasoning = thoughts_token_count``.
+    * **Anthropic** — ``usage``: ``input_tokens`` is already non-cached;
+      cache reads/writes map to ``cached`` / ``cache_write``.
+    * **OpenAI / Ollama** — ``usage``: ``input = prompt_tokens −
+      prompt_tokens_details.cached_tokens``, ``output = completion_tokens −
+      completion_tokens_details.reasoning_tokens``.
 
-    * **Google** — ``response.usage_metadata`` with ``prompt_token_count`` /
-      ``candidates_token_count`` / ``total_token_count``.
-    * **Anthropic** — ``response.usage`` with ``input_tokens`` /
-      ``output_tokens`` (no aggregated total; the sum is used).
-    * **OpenAI / Ollama** — ``response.usage`` with ``prompt_tokens`` /
-      ``completion_tokens`` / ``total_tokens``.
-
-    The "output" field (``candidates_tokens``) absorbs whichever provider name
-    is present (``candidates_token_count`` / ``output_tokens`` /
-    ``completion_tokens``). When ``total`` is absent it is computed from the
-    other two so metrics never see ``0`` for a non-empty run.
+    ``total`` prefers the provider total and falls back to the bucket sum.
+    Unreported buckets stay ``None`` — never ``0``.
 
     Args:
         response: The last raw provider response from
             :attr:`LoopResult.response`, or ``None``.
 
     Returns:
-        A ``{"prompt_tokens", "candidates_tokens", "total_tokens"}`` dict, or
-        ``{}`` when no usage is reported.
+        The canonical token dict, or ``{}`` when no usage is reported.
     """
     if response is None:
         return {}
@@ -176,38 +175,53 @@ def extract_tokens(response: Any) -> dict:
     if usage is None:
         return {}
 
-    # Try the Google attr first, then the OpenAI-style attr, then the Anthropic
-    # alias.
-    prompt = _first_int_attr(usage, "prompt_token_count", "prompt_tokens", "input_tokens")
-    candidates = _first_int_attr(
-        usage, "candidates_token_count", "completion_tokens", "output_tokens"
-    )
-    total = _first_int_attr(usage, "total_token_count", "total_tokens")
-    # Anthropic emits no aggregated total; compute it so non-zero usage never
-    # surfaces as ``total_tokens: 0`` in results.json.
-    if total == 0 and (prompt or candidates):
-        total = prompt + candidates
+    tokens = agents_result.empty_tokens()
+    if getattr(usage, "prompt_token_count", None) is not None:  # Google
+        prompt = _opt_int_attr(usage, "prompt_token_count")
+        cached = _opt_int_attr(usage, "cached_content_token_count")
+        tool_use = _opt_int_attr(usage, "tool_use_prompt_token_count")
+        inp = prompt if cached is None else prompt - cached
+        if inp is not None and tool_use:
+            inp += tool_use
+        tokens.update(
+            input=inp,
+            cached=cached,
+            reasoning=_opt_int_attr(usage, "thoughts_token_count"),
+            output=_opt_int_attr(usage, "candidates_token_count"),
+            total=_opt_int_attr(usage, "total_token_count"),
+        )
+    elif getattr(usage, "prompt_tokens", None) is not None:  # OpenAI / Ollama
+        prompt = _opt_int_attr(usage, "prompt_tokens")
+        completion = _opt_int_attr(usage, "completion_tokens")
+        cached = _opt_int_attr(getattr(usage, "prompt_tokens_details", None), "cached_tokens")
+        reasoning = _opt_int_attr(
+            getattr(usage, "completion_tokens_details", None), "reasoning_tokens"
+        )
+        tokens.update(
+            input=prompt if cached is None else prompt - cached,
+            cached=cached,
+            reasoning=reasoning,
+            output=completion if reasoning is None else completion - reasoning,
+            total=_opt_int_attr(usage, "total_tokens"),
+        )
+    else:  # Anthropic: input_tokens is already the non-cached prompt
+        tokens.update(
+            input=_opt_int_attr(usage, "input_tokens"),
+            cached=_opt_int_attr(usage, "cache_read_input_tokens"),
+            cache_write=_opt_int_attr(usage, "cache_creation_input_tokens"),
+            output=_opt_int_attr(usage, "output_tokens"),
+        )
+    if tokens["total"] is None:
+        parts = [tokens[k] for k in ("input", "cached", "cache_write", "reasoning", "output")]
+        if any(p is not None for p in parts):
+            tokens["total"] = sum(p for p in parts if p is not None)
+    return tokens
 
-    return {
-        "prompt_tokens": prompt,
-        "candidates_tokens": candidates,
-        "total_tokens": total,
-    }
 
-
-def _first_int_attr(obj: Any, *names: str) -> int:
-    """Return the first ``names`` attribute on ``obj`` that holds a non-``None`` int.
-
-    Provider usage objects are typed namespaces / pydantic models with the
-    counts as plain ints; an unset field is either absent or ``None``. The
-    helper falls through both cases and returns ``0`` when no name matches so
-    the caller never has to ``None``-guard the arithmetic.
-    """
-    for name in names:
-        value = getattr(obj, name, None)
-        if value is not None:
-            return int(value)
-    return 0
+def _opt_int_attr(obj: Any, name: str) -> int | None:
+    """Return ``obj.<name>`` as an int, or ``None`` when absent/unset."""
+    value = getattr(obj, name, None)
+    return int(value) if value is not None and not isinstance(value, bool) else None
 
 
 def _build_dispatch(

--- a/devops_bench/agents/cli/gemini_cli/parsing.py
+++ b/devops_bench/agents/cli/gemini_cli/parsing.py
@@ -22,9 +22,37 @@ from __future__ import annotations
 
 import json
 
-from devops_bench.agents.result import ToolCall
+from devops_bench.agents.result import ToolCall, empty_tokens
 
 __all__ = ["parse_stream_json"]
+
+
+def _int_or_none(value: object) -> int | None:
+    """Coerce to ``int``, rejecting ``bool`` (a JSON ``true`` is not a count)."""
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _canonical_tokens(stats: dict) -> dict:
+    """Map the terminal ``result.stats`` block onto the canonical token buckets.
+
+    The CLI reports ``input_tokens`` as the *full* prompt with ``cached`` as a
+    subset, and rolls thinking tokens into ``total_tokens`` only — so canonical
+    ``input`` is the difference, and ``reasoning`` is derived from the total gap
+    (``total - full_input - output``) when every part is reported.
+    """
+    full_input = _int_or_none(stats.get("input_tokens"))
+    output = _int_or_none(stats.get("output_tokens"))
+    total = _int_or_none(stats.get("total_tokens"))
+    cached = _int_or_none(stats.get("cached"))
+    inp = full_input - cached if full_input is not None and cached is not None else full_input
+    reasoning = None
+    if full_input is not None and output is not None and total is not None:
+        gap = total - full_input - output
+        if gap >= 0:
+            reasoning = gap
+    tokens = empty_tokens()
+    tokens.update(input=inp, cached=cached, reasoning=reasoning, output=output, total=total)
+    return tokens
 
 
 def parse_stream_json(stdout: str) -> tuple[str, list[dict], dict, list[str]]:
@@ -127,12 +155,7 @@ def parse_stream_json(stdout: str) -> tuple[str, list[dict], dict, list[str]]:
             stats = event.get("stats")
             usage = event.get("tokens") or event.get("usage")
             if isinstance(stats, dict):
-                tokens = {
-                    "input": stats.get("input_tokens"),
-                    "output": stats.get("output_tokens"),
-                    "total": stats.get("total_tokens"),
-                    "cached": stats.get("cached"),
-                }
+                tokens = _canonical_tokens(stats)
             elif isinstance(usage, dict):
                 tokens = usage
 

--- a/devops_bench/agents/result.py
+++ b/devops_bench/agents/result.py
@@ -18,7 +18,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-__all__ = ["ToolCall", "AgentResult"]
+__all__ = ["ToolCall", "AgentResult", "TOKEN_BUCKETS", "empty_tokens"]
+
+# Canonical token buckets every harness maps onto: ``input`` is the non-cached
+# prompt, ``cached`` is cache-read only (cache writes go in ``cache_write``),
+# ``output`` excludes ``reasoning``, and ``total`` is the sum of all buckets.
+TOKEN_BUCKETS = ("input", "cached", "cache_write", "reasoning", "output", "total")
+
+
+def empty_tokens() -> dict:
+    """Return the canonical token dict with every bucket ``None`` (unavailable)."""
+    return dict.fromkeys(TOKEN_BUCKETS, None)
 
 
 @dataclass

--- a/devops_bench/results/normalize.py
+++ b/devops_bench/results/normalize.py
@@ -45,17 +45,20 @@ __all__ = [
 OUTCOME_SCORE_KEY = "OutcomeValidity"
 TOOL_SCORE_KEY = "ToolInvocation"
 
-# Token usage aliases per provider, in lookup priority. Kept in sync with
-# ``devops_bench.agents.api.agent.extract_tokens`` (API providers) and the CLI
-# parsers, which emit ``input`` / ``output``.
-_INPUT_TOKEN_KEYS = ("prompt_tokens", "prompt_token_count", "input_tokens", "input")
+# Token usage aliases per provider, in lookup priority. The canonical keys
+# (``input`` / ``cached`` / ``reasoning`` / ``output``; see
+# ``devops_bench.agents.result.TOKEN_BUCKETS``) come first; the rest keep
+# historical ``results.json`` records readable.
+_INPUT_TOKEN_KEYS = ("input", "prompt_tokens", "prompt_token_count", "input_tokens")
 _OUTPUT_TOKEN_KEYS = (
+    "output",
     "candidates_tokens",
     "candidates_token_count",
     "completion_tokens",
     "output_tokens",
-    "output",
 )
+_CACHED_TOKEN_KEYS = ("cached", "cache_read_input_tokens", "cached_content_token_count")
+_REASONING_TOKEN_KEYS = ("reasoning", "thoughts_token_count", "reasoning_tokens")
 
 # Runs of characters outside ``[a-z0-9]`` collapse to a single ``-``. Mirrors the
 # dashboard's ``catalog.mjs`` / seeder ``slugify`` so the model component of a
@@ -147,23 +150,29 @@ def _first_token(tokens: Mapping[str, Any], keys: tuple[str, ...]) -> int | None
     return None
 
 
-def normalize_tokens(tokens: Mapping[str, Any] | None) -> tuple[int | None, int | None]:
-    """Flatten a provider-defined token dict to ``(input_tokens, output_tokens)``.
+def normalize_tokens(
+    tokens: Mapping[str, Any] | None,
+) -> tuple[int | None, int | None, int | None, int | None]:
+    """Flatten a token dict to ``(input, output, cached, reasoning)`` counts.
 
-    Reads the first present alias for each direction across the known provider
-    shapes; an unreported direction yields ``None`` rather than ``0`` so the
-    dashboard can distinguish "no data" from a genuine zero.
+    Reads the first present alias for each bucket across the canonical shape
+    and the known historical provider shapes; an unreported bucket yields
+    ``None`` rather than ``0`` so the dashboard can distinguish "no data" from
+    a genuine zero.
 
     Args:
         tokens: The record's ``tokens`` mapping, or ``None``.
 
     Returns:
-        An ``(input_tokens, output_tokens)`` pair, each ``int`` or ``None``.
+        An ``(input_tokens, output_tokens, cached_tokens, reasoning_tokens)``
+        tuple, each ``int`` or ``None``.
     """
     usage = tokens or {}
     return (
         _first_token(usage, _INPUT_TOKEN_KEYS),
         _first_token(usage, _OUTPUT_TOKEN_KEYS),
+        _first_token(usage, _CACHED_TOKEN_KEYS),
+        _first_token(usage, _REASONING_TOKEN_KEYS),
     )
 
 
@@ -208,7 +217,9 @@ def build_rows(records: Iterable[Mapping[str, Any]], manifest: Manifest) -> list
     rows: list[ResultRow] = []
     for record in records:
         scores = record.get("scores")
-        input_tokens, output_tokens = normalize_tokens(record.get("tokens"))
+        input_tokens, output_tokens, cached_tokens, reasoning_tokens = normalize_tokens(
+            record.get("tokens")
+        )
         rows.append(
             ResultRow(
                 setup_id=manifest.setup_id,
@@ -225,6 +236,8 @@ def build_rows(records: Iterable[Mapping[str, Any]], manifest: Manifest) -> list
                 latency_sec=float(record.get("latency") or 0.0),
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
+                cached_tokens=cached_tokens,
+                reasoning_tokens=reasoning_tokens,
                 status=record.get("status", "") or "",
                 validated=bool(record.get("validated", False)),
             )

--- a/devops_bench/results/normalize.py
+++ b/devops_bench/results/normalize.py
@@ -58,7 +58,9 @@ _OUTPUT_TOKEN_KEYS = (
     "output_tokens",
 )
 _CACHED_TOKEN_KEYS = ("cached", "cache_read_input_tokens", "cached_content_token_count")
+_CACHE_WRITE_TOKEN_KEYS = ("cache_write", "cache_creation_input_tokens")
 _REASONING_TOKEN_KEYS = ("reasoning", "thoughts_token_count", "reasoning_tokens")
+_TOTAL_TOKEN_KEYS = ("total", "total_tokens", "total_token_count")
 
 # Runs of characters outside ``[a-z0-9]`` collapse to a single ``-``. Mirrors the
 # dashboard's ``catalog.mjs`` / seeder ``slugify`` so the model component of a
@@ -152,20 +154,22 @@ def _first_token(tokens: Mapping[str, Any], keys: tuple[str, ...]) -> int | None
 
 def normalize_tokens(
     tokens: Mapping[str, Any] | None,
-) -> tuple[int | None, int | None, int | None, int | None]:
-    """Flatten a token dict to ``(input, output, cached, reasoning)`` counts.
+) -> tuple[int | None, int | None, int | None, int | None, int | None, int | None]:
+    """Flatten a token dict to per-bucket counts.
 
     Reads the first present alias for each bucket across the canonical shape
     and the known historical provider shapes; an unreported bucket yields
     ``None`` rather than ``0`` so the dashboard can distinguish "no data" from
-    a genuine zero.
+    a genuine zero. ``total`` semantics vary for pre-canonical records (some
+    eras exclude cached/reasoning); canonical records always report the full
+    footprint.
 
     Args:
         tokens: The record's ``tokens`` mapping, or ``None``.
 
     Returns:
-        An ``(input_tokens, output_tokens, cached_tokens, reasoning_tokens)``
-        tuple, each ``int`` or ``None``.
+        An ``(input, output, cached, reasoning, cache_write, total)`` tuple of
+        token counts, each ``int`` or ``None``.
     """
     usage = tokens or {}
     return (
@@ -173,6 +177,8 @@ def normalize_tokens(
         _first_token(usage, _OUTPUT_TOKEN_KEYS),
         _first_token(usage, _CACHED_TOKEN_KEYS),
         _first_token(usage, _REASONING_TOKEN_KEYS),
+        _first_token(usage, _CACHE_WRITE_TOKEN_KEYS),
+        _first_token(usage, _TOTAL_TOKEN_KEYS),
     )
 
 
@@ -217,9 +223,14 @@ def build_rows(records: Iterable[Mapping[str, Any]], manifest: Manifest) -> list
     rows: list[ResultRow] = []
     for record in records:
         scores = record.get("scores")
-        input_tokens, output_tokens, cached_tokens, reasoning_tokens = normalize_tokens(
-            record.get("tokens")
-        )
+        (
+            input_tokens,
+            output_tokens,
+            cached_tokens,
+            reasoning_tokens,
+            cache_write_tokens,
+            total_tokens,
+        ) = normalize_tokens(record.get("tokens"))
         rows.append(
             ResultRow(
                 setup_id=manifest.setup_id,
@@ -238,6 +249,8 @@ def build_rows(records: Iterable[Mapping[str, Any]], manifest: Manifest) -> list
                 output_tokens=output_tokens,
                 cached_tokens=cached_tokens,
                 reasoning_tokens=reasoning_tokens,
+                cache_write_tokens=cache_write_tokens,
+                total_tokens=total_tokens,
                 status=record.get("status", "") or "",
                 validated=bool(record.get("validated", False)),
             )

--- a/devops_bench/results/row.py
+++ b/devops_bench/results/row.py
@@ -102,8 +102,15 @@ class ResultRow(BaseModel):
             when the metric did not run (e.g. a failed task).
         tool_score: Tool-invocation judge score in ``[0, 1]``, or ``None``.
         latency_sec: Agent wall-clock seconds for the iteration.
-        input_tokens: Prompt token count, or ``None`` when unreported.
-        output_tokens: Completion token count, or ``None`` when unreported.
+        input_tokens: Non-cached prompt token count, or ``None`` when
+            unreported. (Historical records that predate the canonical token
+            schema may include cached tokens here.)
+        output_tokens: Visible completion token count (excludes reasoning
+            where the harness reports it), or ``None`` when unreported.
+        cached_tokens: Cache-read token count, or ``None`` when the harness
+            reports no cache telemetry.
+        reasoning_tokens: Thinking-token count, or ``None`` when unreported
+            (some providers bill thinking inside ``output_tokens``).
         status: Terminal record status, ``"success"`` or ``"failed"``.
         validated: Whether the task is vetted as correct and eligible for the
             leaderboard; ingest gates promotion on this (default ``False``).
@@ -125,6 +132,8 @@ class ResultRow(BaseModel):
     latency_sec: float
     input_tokens: int | None
     output_tokens: int | None
+    cached_tokens: int | None = None
+    reasoning_tokens: int | None = None
     status: str
     validated: bool = False
 

--- a/devops_bench/results/row.py
+++ b/devops_bench/results/row.py
@@ -111,6 +111,10 @@ class ResultRow(BaseModel):
             reports no cache telemetry.
         reasoning_tokens: Thinking-token count, or ``None`` when unreported
             (some providers bill thinking inside ``output_tokens``).
+        cache_write_tokens: Cache-creation token count (billed at a premium by
+            providers that report it), or ``None`` when unreported.
+        total_tokens: Provider-reported or bucket-sum total, or ``None`` when
+            unreported. Semantics vary for pre-canonical records.
         status: Terminal record status, ``"success"`` or ``"failed"``.
         validated: Whether the task is vetted as correct and eligible for the
             leaderboard; ingest gates promotion on this (default ``False``).
@@ -134,6 +138,8 @@ class ResultRow(BaseModel):
     output_tokens: int | None
     cached_tokens: int | None = None
     reasoning_tokens: int | None = None
+    cache_write_tokens: int | None = None
+    total_tokens: int | None = None
     status: str
     validated: bool = False
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ and [glossary](./components/glossary.md).
 ## Designs — proposals under discussion
 
 - [vCluster provider](./designs/vcluster-provider.md) — virtual clusters as a cheap, fast backend for parallel evals.
+- [Unified token accounting](./designs/token-accounting.md) — one canonical input/cached/reasoning/output token schema across all harnesses, carried through to the leaderboard row.
 
 ## How-to guides — get things done
 

--- a/docs/designs/token-accounting.md
+++ b/docs/designs/token-accounting.md
@@ -1,0 +1,131 @@
+# Design: Unified Token Accounting
+
+## Problem statement
+
+Every agent harness reports token usage in its own provider's terms, and
+`results/normalize.py` flattens whatever it hands back to just `input` / `output`
+on the dashboard row — dropping `cached`, `total`, and any reasoning count. This
+makes per-task token columns comparable only *within* a harness, never *across*
+them, and it blocks a stacked input/cache/output usage chart of the kind
+leaderboards such as
+[Artificial Analysis](https://artificialanalysis.ai/agents/coding-agents) publish.
+
+Two systematic distortions exist today:
+
+1. **`input` means different things per provider.** Anthropic's `input_tokens`
+   counts only the *uncached* prompt, while OpenAI's `prompt_tokens` and Gemini's
+   `prompt_token_count` count the *full* prompt including cache hits. A raw
+   `input` comparison therefore under-reports harnesses that split cached out and
+   over-reports those that fold it in — and with prompt caching on, cached tokens
+   are the majority of a multi-turn run's prompt.
+2. **Reasoning tokens are inconsistently bucketed.** Some providers report
+   thinking tokens separately; some harnesses fold them into `output`. Rows from
+   different harnesses (or eras) disagree on what `output` contains.
+
+**Goal:** one canonical token schema that every harness maps onto, so that
+(a) `input` / `cached` / `output` mean the same thing everywhere, (b) the row
+schema carries them through to the leaderboard, and (c) a stacked
+input/cache/output chart is a straight read off the row.
+
+## The canonical schema
+
+Every harness returns `AgentResult.tokens` in this shape. Missing buckets are
+`None` — never `0` — so the row can distinguish "not reported" from a genuine
+zero:
+
+```python
+{
+    "input":       int | None,  # non-cached prompt tokens
+    "cached":      int | None,  # cache-read tokens
+    "cache_write": int | None,  # cache-creation tokens (provider-dependent)
+    "reasoning":   int | None,  # thinking / thoughts tokens
+    "output":      int | None,  # visible response tokens (excludes reasoning)
+    "total":       int | None,  # full footprint: sum of all buckets
+}
+```
+
+Invariant: when all parts are present,
+`total == input + cached + (cache_write or 0) + (reasoning or 0) + output`.
+The load-bearing rule is that **`input` excludes cached tokens** — the convention
+Anthropic's API already uses and the one usage leaderboards report.
+
+The `antigravity` harness already emits this shape (harness-local; see
+`agents/cli/antigravity/parsing.py`). This design promotes it to the shared
+contract.
+
+## Per-provider normalization
+
+Provider conventions, verified against provider docs and SDKs:
+
+| Provider | Native input | Cached relationship | Non-cached `input` = |
+| --- | --- | --- | --- |
+| **Anthropic** | `input_tokens` | excluded — `input`, `cache_read`, `cache_creation` are mutually exclusive | `input_tokens` (as-is) |
+| **OpenAI / Ollama** | `prompt_tokens` | included — `prompt_tokens_details.cached_tokens` is a subset | `prompt_tokens − cached_tokens` |
+| **Gemini** | `prompt_token_count` | included — `cached_content_token_count` is a subset ("when `cached_content` is set, this also includes the number of tokens in the cached content") | `prompt_token_count − cached_content_token_count` |
+
+Per-harness mapping onto the schema:
+
+| Harness | `input` | `cached` | `cache_write` | `reasoning` | `output` |
+| --- | --- | --- | --- | --- | --- |
+| `api` (Anthropic) | `input_tokens` | `cache_read_input_tokens` | `cache_creation_input_tokens` | `None` (billed inside output) | `output_tokens` |
+| `api` (Gemini) | `prompt_token_count − cached_content_token_count` (+ `tool_use_prompt_token_count`) | `cached_content_token_count` | `None` | `thoughts_token_count` | `candidates_token_count` |
+| `api` (OpenAI) | `prompt_tokens − cached_tokens` | `cached_tokens` | `None` (SDK does not surface it) | `completion_tokens_details.reasoning_tokens` | `completion_tokens` |
+| `gemini` CLI | CLI stats input − cached | CLI stats cached | `None` | thoughts (when surfaced) | CLI stats output |
+| `openclaw` | provider-dependent (as `api`) | provider-dependent | `None` | provider-dependent | provider-dependent |
+| `antigravity` | already canonical (decoded from the conversation DB) | ✓ | `None` | ✓ | ✓ |
+
+Notes:
+
+- `cache_write` is populated only where the provider reports it (Anthropic).
+  Everywhere else it is `None`, which the schema distinguishes from `0`.
+- Where a provider's cached-inclusion convention cannot be confirmed for a given
+  surface, do **not** blind-subtract: assert the sum invariant against the
+  provider `total` and fall back to reporting the native input with
+  `cached=None`.
+- Keyless/OAuth surfaces that expose no cache telemetry report `cached=None`
+  and the full prompt as `input` — faithful, since no split is observable.
+
+## Row layer and the chart
+
+`results/normalize.py::normalize_tokens` currently returns `(input, output)`
+only. This design widens the row contract:
+
+- Add `cached_tokens` (and `reasoning_tokens`, optionally `total_tokens`) to
+  `ResultRow`, with a `SCHEMA_VERSION` bump.
+- Add `cached` / `reasoning` aliases to the normalizer's key tables; keep the
+  existing aliases for historical `results.json` files.
+- Forward the new fields through the leaderboard ingest, and render a stacked
+  `input` / `cached` / `output` bar per model × harness arm.
+
+Because `input` is non-cached everywhere, the stacked total is the true per-task
+footprint and is finally comparable across harnesses.
+
+## Shared schema location
+
+The bucket tuple and `empty_tokens()` helper move from
+`agents/cli/antigravity/parsing.py` to a shared module (`agents/result.py`), and
+each harness's extractor returns the canonical dict. Extraction stays
+per-harness (each reads a different surface); only the output shape is shared.
+
+## Migration / compatibility
+
+- **Historical rows** have no `cached` column; the chart treats a missing
+  `cached` as "telemetry unavailable" (empty segment), not zero.
+- **Mixed-era `output`**: harnesses that previously folded reasoning into
+  `output` will show a step change when reasoning splits out. The row's new
+  `reasoning_tokens` column makes the old quantity recoverable
+  (`output + reasoning`).
+- The `AgentResult.tokens` shape is provider-defined by contract, so widening it
+  is not a breaking harness-interface change; only parsers, the normalizer, and
+  the row schema change.
+
+## Open questions
+
+- **Chart segments**: stack `cache_write` / `reasoning` as extra segments, or
+  keep them row-only for cost math? They are populated unevenly across
+  providers.
+- **`total` source of truth**: provider-reported total vs. the recomputed sum
+  (they can disagree where a provider rolls extras into its total).
+- **Raw usage retention**: keep the untouched provider usage alongside the
+  canonical dict (e.g. under `metadata`) so historical runs can be re-priced
+  when provider pricing or cache accounting changes.

--- a/docs/designs/token-accounting.md
+++ b/docs/designs/token-accounting.md
@@ -27,6 +27,14 @@ Two systematic distortions exist today:
 schema carries them through to the leaderboard, and (c) a stacked
 input/cache/output chart is a straight read off the row.
 
+**Status:** implemented for the shared schema (`agents/result.py`), the `api`
+and `gemini` harnesses, the row layer (`normalize.py` / `ResultRow` /
+`schema.d.ts` / ingest validation). The `antigravity` harness emits the shape
+via its own decoder (switching it to the shared helper is a one-line follow-up
+once both changes land); `openclaw` passes provider-native usage through, which
+the normalizer's aliases still flatten (`cached`/`reasoning` stay `None` until
+it is canonicalized). The stacked chart itself is follow-up dashboard work.
+
 ## The canonical schema
 
 Every harness returns `AgentResult.tokens` in this shape. Missing buckets are
@@ -90,22 +98,25 @@ Notes:
 `results/normalize.py::normalize_tokens` currently returns `(input, output)`
 only. This design widens the row contract:
 
-- Add `cached_tokens` (and `reasoning_tokens`, optionally `total_tokens`) to
-  `ResultRow`, with a `SCHEMA_VERSION` bump.
+- Add `cached_tokens` / `reasoning_tokens` to `ResultRow` — additive nullable
+  fields, so no `SCHEMA_VERSION` bump is needed and historical rows stay valid.
 - Add `cached` / `reasoning` aliases to the normalizer's key tables; keep the
   existing aliases for historical `results.json` files.
-- Forward the new fields through the leaderboard ingest, and render a stacked
-  `input` / `cached` / `output` bar per model × harness arm.
+- Mirror the fields on the dashboard `ResultRow` interface and accept them
+  (absent-tolerant) in the ingest validator; the stacked
+  `input` / `cached` / `output` bar per model × harness arm is follow-up
+  dashboard work.
 
 Because `input` is non-cached everywhere, the stacked total is the true per-task
 footprint and is finally comparable across harnesses.
 
 ## Shared schema location
 
-The bucket tuple and `empty_tokens()` helper move from
-`agents/cli/antigravity/parsing.py` to a shared module (`agents/result.py`), and
+The bucket tuple and `empty_tokens()` helper live in `agents/result.py`, and
 each harness's extractor returns the canonical dict. Extraction stays
 per-harness (each reads a different surface); only the output shape is shared.
+The `antigravity` harness's local copy folds into the shared helper once both
+changes land.
 
 ## Migration / compatibility
 

--- a/docs/designs/token-accounting.md
+++ b/docs/designs/token-accounting.md
@@ -98,8 +98,11 @@ Notes:
 `results/normalize.py::normalize_tokens` currently returns `(input, output)`
 only. This design widens the row contract:
 
-- Add `cached_tokens` / `reasoning_tokens` to `ResultRow` — additive nullable
-  fields, so no `SCHEMA_VERSION` bump is needed and historical rows stay valid.
+- Add `cached_tokens` / `reasoning_tokens` / `cache_write_tokens` /
+  `total_tokens` to `ResultRow` — additive nullable fields, so no
+  `SCHEMA_VERSION` bump is needed and historical rows stay valid. All four
+  cost-formula inputs (`input·p_in + cached·p_cached + cache_write·p_write +
+  output·p_out`) are then readable off the row.
 - Add `cached` / `reasoning` aliases to the normalizer's key tables; keep the
   existing aliases for historical `results.json` files.
 - Mirror the fields on the dashboard `ResultRow` interface and accept them

--- a/site/ingest/load.mjs
+++ b/site/ingest/load.mjs
@@ -89,6 +89,8 @@ export function validateRow(row) {
     intOrNull("outputTokens", nonNeg);
     optIntOrNull("cachedTokens", nonNeg);
     optIntOrNull("reasoningTokens", nonNeg);
+    optIntOrNull("cacheWriteTokens", nonNeg);
+    optIntOrNull("totalTokens", nonNeg);
 
     return errs;
 }

--- a/site/ingest/load.mjs
+++ b/site/ingest/load.mjs
@@ -64,6 +64,8 @@ export function validateRow(row) {
     // uncaptured usage); otherwise apply the numeric check.
     const intOrNull = (k, check) => { if (row[k] !== null) int(k, check); };
     const floatOrNull = (k, check) => { if (row[k] !== null) float(k, check); };
+    // Additive fields: absent (historical rows) and null are both valid.
+    const optIntOrNull = (k, check) => { if (row[k] !== undefined && row[k] !== null) int(k, check); };
 
     str("setupId");
     str("model");
@@ -85,6 +87,8 @@ export function validateRow(row) {
     float("latencySec", nonNeg);
     intOrNull("inputTokens", nonNeg);
     intOrNull("outputTokens", nonNeg);
+    optIntOrNull("cachedTokens", nonNeg);
+    optIntOrNull("reasoningTokens", nonNeg);
 
     return errs;
 }

--- a/site/src/lib/schema.d.ts
+++ b/site/src/lib/schema.d.ts
@@ -133,6 +133,10 @@ export interface ResultRow {
     cachedTokens: number | null;
     /** Thinking tokens; null when unreported (some providers bill thinking inside output). */
     reasoningTokens: number | null;
+    /** Cache-creation tokens (billed at a premium where reported); null when unreported. */
+    cacheWriteTokens: number | null;
+    /** Provider or bucket-sum total; null when unreported. Semantics vary for pre-canonical rows. */
+    totalTokens: number | null;
     /** Whether the task is vetted as correct; only validated tasks promote to the leaderboard. */
     validated: boolean;
 }

--- a/site/src/lib/schema.d.ts
+++ b/site/src/lib/schema.d.ts
@@ -125,10 +125,14 @@ export interface ResultRow {
     /** Tool-use score in [0,1]; null when unscored. */
     toolScore: number | null;
     latencySec: number;
-    /** Null when token usage was not captured. */
+    /** Non-cached prompt tokens; null when token usage was not captured. */
     inputTokens: number | null;
-    /** Null when token usage was not captured. */
+    /** Visible completion tokens (excludes reasoning where reported); null when not captured. */
     outputTokens: number | null;
+    /** Cache-read tokens; null when the harness reports no cache telemetry. */
+    cachedTokens: number | null;
+    /** Thinking tokens; null when unreported (some providers bill thinking inside output). */
+    reasoningTokens: number | null;
     /** Whether the task is vetted as correct; only validated tasks promote to the leaderboard. */
     validated: boolean;
 }

--- a/tests/unit/agents/api/test_agents_api_agent.py
+++ b/tests/unit/agents/api/test_agents_api_agent.py
@@ -278,25 +278,48 @@ def test_fold_with_extraction_errors_surfaces_orphan_results():
 # ---------------------------------------------------------------------------
 
 
+def _tok(**overrides):
+    """Canonical token dict with every bucket None, overridden per test."""
+    base = {
+        "input": None,
+        "cached": None,
+        "cache_write": None,
+        "reasoning": None,
+        "output": None,
+        "total": None,
+    }
+    base.update(overrides)
+    return base
+
+
 def test_extract_tokens_reads_usage_metadata():
     usage = SimpleNamespace(prompt_token_count=3, candidates_token_count=5, total_token_count=8)
     response = SimpleNamespace(usage_metadata=usage)
-    assert extract_tokens(response) == {
-        "prompt_tokens": 3,
-        "candidates_tokens": 5,
-        "total_tokens": 8,
-    }
+    assert extract_tokens(response) == _tok(input=3, output=5, total=8)
+
+
+def test_extract_tokens_google_subtracts_cached_and_splits_reasoning():
+    # Gemini's prompt_token_count includes cached content; canonical input is
+    # the non-cached remainder plus tool-result input tokens.
+    usage = SimpleNamespace(
+        prompt_token_count=1000,
+        cached_content_token_count=600,
+        tool_use_prompt_token_count=50,
+        thoughts_token_count=30,
+        candidates_token_count=20,
+        total_token_count=1100,
+    )
+    response = SimpleNamespace(usage_metadata=usage)
+    assert extract_tokens(response) == _tok(
+        input=450, cached=600, reasoning=30, output=20, total=1100
+    )
 
 
 def test_extract_tokens_falls_back_to_usage_attribute():
     usage = SimpleNamespace(prompt_token_count=1, candidates_token_count=2, total_token_count=3)
     # No ``usage_metadata``; the function should still find ``usage``.
     response = SimpleNamespace(usage=usage)
-    assert extract_tokens(response) == {
-        "prompt_tokens": 1,
-        "candidates_tokens": 2,
-        "total_tokens": 3,
-    }
+    assert extract_tokens(response) == _tok(input=1, output=2, total=3)
 
 
 def test_extract_tokens_returns_empty_dict_when_no_usage():
@@ -304,53 +327,55 @@ def test_extract_tokens_returns_empty_dict_when_no_usage():
     assert extract_tokens(None) == {}
 
 
-def test_extract_tokens_defaults_missing_counts_to_zero():
-    """Missing counts default to 0; if the source provided no total but the
-    other two fields are non-zero, the helper computes prompt+candidates so a
-    non-empty run never shows ``total_tokens: 0`` in results.json."""
+def test_extract_tokens_missing_counts_stay_none_but_total_is_computed():
+    """Unreported buckets stay None (never a fabricated 0); the total falls
+    back to the sum of whatever was reported."""
     usage = SimpleNamespace(prompt_token_count=4)  # other counts unset
     response = SimpleNamespace(usage_metadata=usage)
-    assert extract_tokens(response) == {
-        "prompt_tokens": 4,
-        "candidates_tokens": 0,
-        # 4 + 0 (no source total provided, but a non-zero prompt → compute it).
-        "total_tokens": 4,
-    }
+    assert extract_tokens(response) == _tok(input=4, total=4)
 
 
-def test_extract_tokens_reads_anthropic_input_output_shape():
-    """Anthropic emits ``usage.input_tokens`` / ``usage.output_tokens`` and **no**
-    aggregated total. The helper must map both onto the legacy keys and compute
-    the total so non-Google providers do not silently drop tokens.
-
-    Regression test for the blocking bug found in review: the previous
-    extract_tokens only read Google-style fields and returned zeros for any
-    Anthropic response, corrupting token metrics in results.json.
-    """
+def test_extract_tokens_reads_anthropic_shape():
+    """Anthropic's input_tokens is already the non-cached prompt; cache reads
+    and writes map to their own buckets and the total is the bucket sum."""
     usage = SimpleNamespace(input_tokens=42, output_tokens=17)
     response = SimpleNamespace(usage=usage)
-    assert extract_tokens(response) == {
-        "prompt_tokens": 42,
-        "candidates_tokens": 17,
-        "total_tokens": 59,
-    }
+    assert extract_tokens(response) == _tok(input=42, output=17, total=59)
+
+
+def test_extract_tokens_anthropic_cache_buckets():
+    usage = SimpleNamespace(
+        input_tokens=5,
+        cache_read_input_tokens=1000,
+        cache_creation_input_tokens=200,
+        output_tokens=40,
+    )
+    response = SimpleNamespace(usage=usage)
+    assert extract_tokens(response) == _tok(
+        input=5, cached=1000, cache_write=200, output=40, total=1245
+    )
 
 
 def test_extract_tokens_reads_openai_ollama_shape():
-    """OpenAI / Ollama emit ``usage.prompt_tokens`` / ``completion_tokens`` /
-    ``total_tokens``. The helper must map ``completion_tokens`` → the legacy
-    ``candidates_tokens`` slot and pass ``total_tokens`` through verbatim.
-
-    Regression test for the same blocking bug — Ollama responses returned
-    all-zero tokens before the provider-shape detection landed.
-    """
     usage = SimpleNamespace(prompt_tokens=10, completion_tokens=20, total_tokens=30)
     response = SimpleNamespace(usage=usage)
-    assert extract_tokens(response) == {
-        "prompt_tokens": 10,
-        "candidates_tokens": 20,
-        "total_tokens": 30,
-    }
+    assert extract_tokens(response) == _tok(input=10, output=20, total=30)
+
+
+def test_extract_tokens_openai_subtracts_cached_and_reasoning():
+    # cached_tokens is a subset of prompt_tokens; reasoning_tokens is a subset
+    # of completion_tokens. Canonical input/output are the remainders.
+    usage = SimpleNamespace(
+        prompt_tokens=2006,
+        completion_tokens=300,
+        total_tokens=2306,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=1920),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=250),
+    )
+    response = SimpleNamespace(usage=usage)
+    assert extract_tokens(response) == _tok(
+        input=86, cached=1920, reasoning=250, output=50, total=2306
+    )
 
 
 def test_extract_tokens_google_total_passes_through_when_present():
@@ -358,18 +383,17 @@ def test_extract_tokens_google_total_passes_through_when_present():
     usage = SimpleNamespace(prompt_token_count=5, candidates_token_count=7, total_token_count=99)
     response = SimpleNamespace(usage_metadata=usage)
     # The helper does not second-guess a provider-supplied total even when it
-    # disagrees with prompt+candidates (some providers include reasoning/cached
-    # tokens in the total).
-    assert extract_tokens(response)["total_tokens"] == 99
+    # disagrees with the bucket sum (providers may roll extras into it).
+    assert extract_tokens(response)["total"] == 99
 
 
-def test_extract_tokens_preserves_legacy_on_disk_key_scheme():
-    """The on-disk dict shape must stay ``{prompt_tokens, candidates_tokens,
-    total_tokens}`` for D3 (results.json stability) — three keys, exactly.
-    """
+def test_extract_tokens_emits_canonical_key_scheme():
+    """The on-disk dict shape is the canonical six-bucket scheme (see
+    ``devops_bench.agents.result.TOKEN_BUCKETS``); results/normalize.py keeps
+    the legacy provider aliases readable for historical records."""
     usage = SimpleNamespace(input_tokens=1, output_tokens=2)
     keys = set(extract_tokens(SimpleNamespace(usage=usage)).keys())
-    assert keys == {"prompt_tokens", "candidates_tokens", "total_tokens"}
+    assert keys == {"input", "cached", "cache_write", "reasoning", "output", "total"}
 
 
 # ---------------------------------------------------------------------------
@@ -403,11 +427,7 @@ def test_execute_runs_with_no_tools_when_capabilities_default(monkeypatch):
 
     assert result.output == "done"
     assert result.trajectory == []
-    assert result.tokens == {
-        "prompt_tokens": 3,
-        "candidates_tokens": 5,
-        "total_tokens": 8,
-    }
+    assert result.tokens == _tok(input=3, output=5, total=8)
     assert result.errors == []
     # Caller-formats-tools: the agent must call format_tools on the (empty)
     # skill list before invoking the loop.
@@ -432,8 +452,8 @@ def test_execute_passes_explicit_provider_and_model_to_get_model(monkeypatch):
 
 def test_execute_records_anthropic_tokens_through_to_agentresult(monkeypatch):
     """End-to-end: an Anthropic-shaped usage object surfaces on
-    ``AgentResult.tokens`` under the legacy key scheme — regression for the
-    blocking bug where non-Google providers silently logged zero tokens."""
+    ``AgentResult.tokens`` under the canonical bucket scheme — regression for
+    the blocking bug where non-Google providers silently logged zero tokens."""
     fake = _FakeLLMClient(
         [
             _Turn(
@@ -445,16 +465,12 @@ def test_execute_records_anthropic_tokens_through_to_agentresult(monkeypatch):
     )
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
     result = ApiAgent(AgentConfig()).run("p")
-    assert result.tokens == {
-        "prompt_tokens": 42,
-        "candidates_tokens": 17,
-        "total_tokens": 59,
-    }
+    assert result.tokens == _tok(input=42, output=17, total=59)
 
 
 def test_execute_records_openai_tokens_through_to_agentresult(monkeypatch):
     """End-to-end: an OpenAI/Ollama-shaped usage object surfaces under the
-    legacy key scheme."""
+    canonical bucket scheme."""
     fake = _FakeLLMClient(
         [
             _Turn(
@@ -466,11 +482,7 @@ def test_execute_records_openai_tokens_through_to_agentresult(monkeypatch):
     )
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
     result = ApiAgent(AgentConfig()).run("p")
-    assert result.tokens == {
-        "prompt_tokens": 10,
-        "candidates_tokens": 20,
-        "total_tokens": 30,
-    }
+    assert result.tokens == _tok(input=10, output=20, total=30)
 
 
 # ---------------------------------------------------------------------------
@@ -510,11 +522,7 @@ def test_execute_folds_assistant_tool_pairs_into_canonical_trajectory(monkeypatc
             "status": "completed",
         },
     ]
-    assert result.tokens == {
-        "prompt_tokens": 10,
-        "candidates_tokens": 20,
-        "total_tokens": 30,
-    }
+    assert result.tokens == _tok(input=10, output=20, total=30)
     assert result.errors == []
     assert result.metadata["tools_used"] == ["do_thing"]
     # MCP session was entered & exited via the async-context-manager protocol.

--- a/tests/unit/agents/test_agents_cli_gemini.py
+++ b/tests/unit/agents/test_agents_cli_gemini.py
@@ -350,7 +350,16 @@ def test_parse_stream_json_real_cli_schema():
             "status": "completed",
         },
     ]
-    assert tokens == {"input": 31225, "output": 35, "total": 31489, "cached": 12173}
+    # Canonical buckets: input excludes the cached subset, and reasoning is
+    # derived from the total gap (total - full_input - output = thinking).
+    assert tokens == {
+        "input": 31225 - 12173,
+        "cached": 12173,
+        "cache_write": None,
+        "reasoning": 31489 - 31225 - 35,
+        "output": 35,
+        "total": 31489,
+    }
 
 
 def test_parse_stream_json_marks_failed_tool_result_status_field():

--- a/tests/unit/results/test_results_normalize.py
+++ b/tests/unit/results/test_results_normalize.py
@@ -89,7 +89,7 @@ def test_setup_id_matches_catalog_slug_for_dotted_model():
 
 def test_normalize_tokens_legacy_api_shape():
     tokens = {"prompt_tokens": 10, "candidates_tokens": 5, "total_tokens": 15}
-    assert normalize_tokens(tokens) == (10, 5, None, None)
+    assert normalize_tokens(tokens) == (10, 5, None, None, None, 15)
 
 
 def test_normalize_tokens_canonical_shape():
@@ -101,17 +101,17 @@ def test_normalize_tokens_canonical_shape():
         "output": 3,
         "total": 114,
     }
-    assert normalize_tokens(tokens) == (7, 3, 100, 4)
+    assert normalize_tokens(tokens) == (7, 3, 100, 4, None, 114)
 
 
 def test_normalize_tokens_google_metadata_shape():
     tokens = {"prompt_token_count": 8, "candidates_token_count": 4}
-    assert normalize_tokens(tokens) == (8, 4, None, None)
+    assert normalize_tokens(tokens) == (8, 4, None, None, None, None)
 
 
 def test_normalize_tokens_missing_yields_none():
-    assert normalize_tokens({}) == (None, None, None, None)
-    assert normalize_tokens(None) == (None, None, None, None)
+    assert normalize_tokens({}) == (None, None, None, None, None, None)
+    assert normalize_tokens(None) == (None, None, None, None, None, None)
 
 
 def test_normalize_tokens_none_valued_canonical_keys_fall_through():
@@ -121,11 +121,13 @@ def test_normalize_tokens_none_valued_canonical_keys_fall_through():
         2,
         None,
         None,
+        None,
+        None,
     )
 
 
 def test_normalize_tokens_float_coerced_to_int():
-    assert normalize_tokens({"input": 12.0, "output": 3.9}) == (12, 3, None, None)
+    assert normalize_tokens({"input": 12.0, "output": 3.9}) == (12, 3, None, None, None, None)
 
 
 # -- extract_score -----------------------------------------------------------
@@ -192,6 +194,8 @@ def test_build_rows_success_record():
         "outputTokens": 20,
         "cachedTokens": None,
         "reasoningTokens": None,
+        "cacheWriteTokens": None,
+        "totalTokens": None,
         "status": "success",
         "validated": False,
     }
@@ -216,6 +220,8 @@ def test_build_rows_failed_record_has_null_scores_and_tokens():
     assert row.output_tokens is None
     assert row.cached_tokens is None
     assert row.reasoning_tokens is None
+    assert row.cache_write_tokens is None
+    assert row.total_tokens is None
     assert row.iteration == 0
 
 
@@ -257,6 +263,8 @@ def test_result_row_keys_match_typescript_interface():
         "outputTokens",
         "cachedTokens",
         "reasoningTokens",
+        "cacheWriteTokens",
+        "totalTokens",
         "validated",
     }
     row = build_rows(
@@ -308,3 +316,24 @@ def test_build_rows_carries_cached_and_reasoning():
     assert row.cached_tokens == 12173
     assert row.reasoning_tokens == 229
     assert row.output_tokens == 35
+    assert row.total_tokens == 31489
+    assert row.cache_write_tokens is None
+
+
+def test_build_rows_carries_cache_write():
+    record = {
+        "name": "t",
+        "folder": "f",
+        "status": "success",
+        "tokens": {
+            "input": 5,
+            "cached": 1000,
+            "cache_write": 200,
+            "reasoning": None,
+            "output": 40,
+            "total": 1245,
+        },
+    }
+    row = build_rows([record], _manifest())[0]
+    assert row.cache_write_tokens == 200
+    assert row.total_tokens == 1245

--- a/tests/unit/results/test_results_normalize.py
+++ b/tests/unit/results/test_results_normalize.py
@@ -87,27 +87,45 @@ def test_setup_id_matches_catalog_slug_for_dotted_model():
 # -- normalize_tokens --------------------------------------------------------
 
 
-def test_normalize_tokens_api_shape():
+def test_normalize_tokens_legacy_api_shape():
     tokens = {"prompt_tokens": 10, "candidates_tokens": 5, "total_tokens": 15}
-    assert normalize_tokens(tokens) == (10, 5)
+    assert normalize_tokens(tokens) == (10, 5, None, None)
 
 
-def test_normalize_tokens_cli_shape():
-    assert normalize_tokens({"input": 7, "output": 3}) == (7, 3)
+def test_normalize_tokens_canonical_shape():
+    tokens = {
+        "input": 7,
+        "cached": 100,
+        "cache_write": None,
+        "reasoning": 4,
+        "output": 3,
+        "total": 114,
+    }
+    assert normalize_tokens(tokens) == (7, 3, 100, 4)
 
 
 def test_normalize_tokens_google_metadata_shape():
     tokens = {"prompt_token_count": 8, "candidates_token_count": 4}
-    assert normalize_tokens(tokens) == (8, 4)
+    assert normalize_tokens(tokens) == (8, 4, None, None)
 
 
 def test_normalize_tokens_missing_yields_none():
-    assert normalize_tokens({}) == (None, None)
-    assert normalize_tokens(None) == (None, None)
+    assert normalize_tokens({}) == (None, None, None, None)
+    assert normalize_tokens(None) == (None, None, None, None)
+
+
+def test_normalize_tokens_none_valued_canonical_keys_fall_through():
+    # A canonical dict with None buckets must not mask values under legacy keys.
+    assert normalize_tokens({"input": None, "prompt_tokens": 9, "output": 2}) == (
+        9,
+        2,
+        None,
+        None,
+    )
 
 
 def test_normalize_tokens_float_coerced_to_int():
-    assert normalize_tokens({"input": 12.0, "output": 3.9}) == (12, 3)
+    assert normalize_tokens({"input": 12.0, "output": 3.9}) == (12, 3, None, None)
 
 
 # -- extract_score -----------------------------------------------------------
@@ -172,6 +190,8 @@ def test_build_rows_success_record():
         "latencySec": 42.5,
         "inputTokens": 100,
         "outputTokens": 20,
+        "cachedTokens": None,
+        "reasoningTokens": None,
         "status": "success",
         "validated": False,
     }
@@ -194,6 +214,8 @@ def test_build_rows_failed_record_has_null_scores_and_tokens():
     assert row.tool_score is None
     assert row.input_tokens is None
     assert row.output_tokens is None
+    assert row.cached_tokens is None
+    assert row.reasoning_tokens is None
     assert row.iteration == 0
 
 
@@ -233,6 +255,8 @@ def test_result_row_keys_match_typescript_interface():
         "latencySec",
         "inputTokens",
         "outputTokens",
+        "cachedTokens",
+        "reasoningTokens",
         "validated",
     }
     row = build_rows(
@@ -263,3 +287,24 @@ def test_build_rows_propagates_validated():
     # Absent key defaults to False (unvetted tasks don't promote).
     default_row = build_rows([{"name": "t", "folder": "f", "status": "success"}], manifest)[0]
     assert default_row.to_dict()["validated"] is False
+
+
+def test_build_rows_carries_cached_and_reasoning():
+    record = {
+        "name": "t",
+        "folder": "f",
+        "status": "success",
+        "tokens": {
+            "input": 19052,
+            "cached": 12173,
+            "cache_write": None,
+            "reasoning": 229,
+            "output": 35,
+            "total": 31489,
+        },
+    }
+    row = build_rows([record], _manifest())[0]
+    assert row.input_tokens == 19052
+    assert row.cached_tokens == 12173
+    assert row.reasoning_tokens == 229
+    assert row.output_tokens == 35


### PR DESCRIPTION
Implements one canonical token schema across the agent harnesses and carries the new buckets through to the result row. (First commit is the design doc; second is the implementation.)

```python
{"input", "cached", "cache_write", "reasoning", "output", "total"}   # None = unreported, never a fabricated 0
```

## Why

- `input` means different things per provider today: Anthropic reports the *uncached* prompt, while OpenAI/Gemini report the *full* prompt including cache hits — so raw cross-harness token/cost comparisons are systematically skewed, and with prompt caching on, cached tokens dominate a multi-turn run's prompt.
- Reasoning tokens are inconsistently bucketed (separate vs. folded into output).
- `results/normalize.py` flattened everything to `input`/`output`, dropping `cached`/reasoning at the row layer.

The anchor rule: **`input` excludes cached tokens** (Anthropic's convention, and the one usage leaderboards report).

## What's implemented

- **Shared schema** — `agents/result.py`: `TOKEN_BUCKETS` + `empty_tokens()`.
- **`api` harness** — `extract_tokens` canonicalizes each provider shape: Anthropic passes through (already non-cached) with cache read/write buckets; Gemini subtracts `cached_content_token_count` (a documented subset of `prompt_token_count`) and adds tool-result input tokens; OpenAI subtracts `prompt_tokens_details.cached_tokens` and splits `reasoning_tokens` out of `completion_tokens`. Total prefers the provider total, else the bucket sum.
- **`gemini` CLI harness** — the terminal `result.stats` block maps to the canonical dict (`input = full input − cached`, empirically a subset; `reasoning` derived from the total gap).
- **Row layer** — `ResultRow` gains `cachedTokens` / `reasoningTokens` (additive nullable fields, no `SCHEMA_VERSION` bump; historical rows stay valid), `normalize_tokens` reads the canonical keys first with legacy provider aliases kept for old `results.json` records, and the dashboard `schema.d.ts` + ingest validator accept the new fields absent-tolerantly.

## Not in this PR

- `openclaw` still passes provider-native usage through (the aliases flatten it; `cached`/`reasoning` stay `None` until it is canonicalized).
- `antigravity` emits the canonical shape via its own decoder (#211); folding its local helper into the shared one is a one-line follow-up once both land.
- The stacked input/cache/output dashboard chart (consumes the new row fields).

## Verification

- 892 Python tests green (updated + new: per-provider extract_tokens cases incl. cache/reasoning subtraction, canonical + legacy + fall-through normalizer cases, row round-trip with the new fields, the pinned producer↔dashboard interface test); ruff clean on changed files.
- `site/ingest/load.mjs` change mirrors the existing `intOrNull` pattern (absent-tolerant for historical rows); JS tests not run locally (no node) — CI covers them.

Design rationale and provider-convention verification: `docs/designs/token-accounting.md` (included). Related: #211.