### PR TITLE
fix(task): align lustre-csi-deployment expected_output with live deploy

### DIFF
--- a/tasks/gcp/lustre-csi-deployment/task.yaml
+++ b/tasks/gcp/lustre-csi-deployment/task.yaml
@@ -28,90 +28,15 @@ prompt: |
   4. Create a ClusterIP Service named `gemma-service` exposing port 8000.
 expected_output: |
   critical requirements:
-  - Expected Tool Call: generate_manifest
-  - Create a PersistentVolume with driver lustre.csi.storage.gke.io referencing the existing instance.
-  - Set the PV volumeHandle to {{GCP_PROJECT_ID}}/us-central1-a/lustre-{{GKE_CLUSTER_NAME}}.
-  - Query the Lustre instance mount point and specify the IP and filesystem in the PV volumeAttributes.
-  - Create a PersistentVolumeClaim named gemma-pvc referencing the gemma-pv volume.
-  - Deploy gemma-inference-staging using nginx:alpine.
-  - Configure the deployment to request 1 GPU (nvidia.com/gpu: 1) and mount gemma-pvc at /models.
-  - Create a ClusterIP Service named gemma-service exposing port 8000.
 
-  Expected Manifest Generated:
-  apiVersion: v1
-  kind: PersistentVolume
-  metadata:
-    name: gemma-pv
-  spec:
-    storageClassName: lustre-sc
-    capacity:
-      storage: 18000Gi
-    accessModes:
-    - ReadWriteMany
-    persistentVolumeReclaimPolicy: Retain
-    volumeMode: Filesystem
-    csi:
-      driver: lustre.csi.storage.gke.io
-      volumeHandle: {{GCP_PROJECT_ID}}/us-central1-a/lustre-{{GKE_CLUSTER_NAME}}
-      volumeAttributes:
-        ip: <instance-mount-point-ip>
-        filesystem: lustrefs
-  ---
-  apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: gemma-pvc
-    namespace: default
-  spec:
-    accessModes:
-    - ReadWriteMany
-    storageClassName: lustre-sc
-    volumeName: gemma-pv
-    resources:
-      requests:
-        storage: 18000Gi
-  ---
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: gemma-inference-staging
-    namespace: default
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: gemma
-    template:
-      metadata:
-        labels:
-          app: gemma
-      spec:
-        containers:
-        - name: gemma-container
-          image: nginx:alpine
-          volumeMounts:
-          - name: model-volume
-            mountPath: /models
-          resources:
-            limits:
-              nvidia.com/gpu: 1
-        volumes:
-        - name: model-volume
-          persistentVolumeClaim:
-            claimName: gemma-pvc
-  ---
-  apiVersion: v1
-  kind: Service
-  metadata:
-    name: gemma-service
-    namespace: default
-  spec:
-    type: ClusterIP
-    ports:
-    - port: 8000
-      targetPort: 80
-    selector:
-      app: gemma
+  - Query the pre-provisioned Managed Lustre instance 'lustre-{{GKE_CLUSTER_NAME}}' in zone us-central1-a (e.g. via 'gcloud lustre instances describe') to obtain its mount IP and filesystem name.
+  - Apply a PersistentVolume named gemma-pv backed by the Managed Lustre CSI driver lustre.csi.storage.gke.io, with volumeHandle {{GCP_PROJECT_ID}}/us-central1-a/lustre-{{GKE_CLUSTER_NAME}} and volumeAttributes populated with the queried mount IP and filesystem.
+  - Apply a PersistentVolumeClaim named gemma-pvc that statically binds to gemma-pv (volumeName gemma-pv, with a storageClassName consistent with the PV) rather than dynamically provisioning storage.
+  - Apply the gemma-inference-staging Deployment using image nginx:alpine, requesting 1 GPU (nvidia.com/gpu: 1) and mounting the gemma-pvc volume at /models.
+  - Apply a ClusterIP Service named gemma-service exposing port 8000 and selecting the gemma-inference-staging pods.
+  - Confirm that all four resources (the PersistentVolume, PersistentVolumeClaim, Deployment, and Service) were successfully applied to the '{{GKE_CLUSTER_NAME}}' cluster in project '{{GCP_PROJECT_ID}}'.
+
+  Expected Manifest Generated: N/A, not a manifest generation request.
 
 documentation:
   - doc_name: "GKE Managed Lustre CSI Driver Guide (existing instance)"


### PR DESCRIPTION
## Summary

`tasks/gcp/lustre-csi-deployment/task.yaml` had an inconsistency between its deployer and its expected_output, found during a verifier-coverage audit.

- The task sets `infrastructure.deployer: tofu`, so the harness sets `generation_only=False` (`devops_bench/evalharness/default.py:958`, where `generation_only = deployer == "noop"`).
- But its `expected_output` was written with the noop generation-only template: an `Expected Tool Call: generate_manifest` line plus a full `Expected Manifest Generated:` YAML block.

With `generation_only=False`, the OutcomeValidity GEval judge does not apply the generation-only override. It requires the agent to actually apply resources to a live cluster and confirm the apply (manifest-only is graded a significant failure). The generate_manifest framing contradicted that, so the judge would expect a live apply the criteria never described, mis-scoring the task.

## Why this is a live-deploy task

The intent is unambiguously live-deploy, so correcting the expected_output (rather than flipping the deployer) is the minimal fix:

- It provisions a real GPU cluster (`prebuilt/lustre-csi` stack, `g2-standard-4` node) and references a pre-provisioned Managed Lustre instance.
- Objective 1 requires querying that live instance for its mount IP and filesystem (`gcloud lustre instances describe`), which is impossible in a generation-only task.
- The prompt says "Deploy a live vLLM inference server ... onto the GKE cluster."

Flipping to `deployer: noop` would be the wrong fix: it would strip the cluster and the Lustre instance and break objective 1.

## Change

Rewrite `expected_output` from the generate_manifest template to an applied-to-cluster success criterion, matching the convention used by the other tofu tasks (`tasks/gcp/deploy-config`, `tasks/gcp/deploy-hello-app`).

We are no longer generating a manifest, but the `critical requirements` checklist still verifies the substantive properties the old manifest block encoded: the Managed Lustre CSI driver, the volumeHandle format, the queried mount IP and filesystem attributes, static PV/PVC binding, the 1-GPU request, the `/models` mount, and the ClusterIP Service on port 8000. Values the prompt states are enforced; incidental reference-solution values it never states (exact storage-class name, capacity, reclaim policy, target port, replica count) are left out so a valid deployment is not failed for choosing different ones, per the repo's graded-on-outcome convention.

This was the only tofu task using the generate_manifest template.

## Testing

- `uv run pytest tests/unit/tasks/test_tasks_schema.py tests/unit/metrics/test_metrics_pipeline.py tests/unit/evalharness/test_reporter.py -q` -> 67 passed
- `uv run ruff check .` -> no new findings (pre-existing errors are confined to legacy `deployers/` and `pkg/`)
- YAML re-parses; `deployer` unchanged (`tofu`).
