### PR TITLE
feat(results): emit 'turns' efficiency axis on the result row

### DIFF
--- a/devops_bench/results/normalize.py
+++ b/devops_bench/results/normalize.py
@@ -209,10 +209,12 @@ def build_rows(records: Iterable[Mapping[str, Any]], manifest: Manifest) -> list
     for record in records:
         scores = record.get("scores")
         input_tokens, output_tokens = normalize_tokens(record.get("tokens"))
-        # turns = number of trajectory steps (tool calls + text turns). ``None``
-        # only when no trajectory was captured, distinct from an empty (0-step) run.
+        # turns = number of trajectory steps (tool calls + text turns). The record
+        # defaults ``trajectory`` to ``[]``, so an empty (or missing) trajectory
+        # reads as "not captured" -> ``None`` rather than a misleading 0; only a
+        # populated trajectory yields a count.
         trajectory = record.get("trajectory")
-        turns = len(trajectory) if isinstance(trajectory, list) else None
+        turns = len(trajectory) if isinstance(trajectory, list) and trajectory else None
         rows.append(
             ResultRow(
                 setup_id=manifest.setup_id,

--- a/devops_bench/results/normalize.py
+++ b/devops_bench/results/normalize.py
@@ -209,6 +209,10 @@ def build_rows(records: Iterable[Mapping[str, Any]], manifest: Manifest) -> list
     for record in records:
         scores = record.get("scores")
         input_tokens, output_tokens = normalize_tokens(record.get("tokens"))
+        # turns = number of trajectory steps (tool calls + text turns). ``None``
+        # only when no trajectory was captured, distinct from an empty (0-step) run.
+        trajectory = record.get("trajectory")
+        turns = len(trajectory) if isinstance(trajectory, list) else None
         rows.append(
             ResultRow(
                 setup_id=manifest.setup_id,
@@ -223,6 +227,7 @@ def build_rows(records: Iterable[Mapping[str, Any]], manifest: Manifest) -> list
                 outcome_score=extract_score(scores, OUTCOME_SCORE_KEY),
                 tool_score=extract_score(scores, TOOL_SCORE_KEY),
                 latency_sec=float(record.get("latency") or 0.0),
+                turns=turns,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 status=record.get("status", "") or "",

--- a/devops_bench/results/row.py
+++ b/devops_bench/results/row.py
@@ -102,6 +102,9 @@ class ResultRow(BaseModel):
             when the metric did not run (e.g. a failed task).
         tool_score: Tool-invocation judge score in ``[0, 1]``, or ``None``.
         latency_sec: Agent wall-clock seconds for the iteration.
+        turns: Number of agent trajectory steps (tool calls + text turns) for the
+            iteration — an efficiency axis. ``None`` when no trajectory was
+            captured.
         input_tokens: Prompt token count, or ``None`` when unreported.
         output_tokens: Completion token count, or ``None`` when unreported.
         status: Terminal record status, ``"success"`` or ``"failed"``.
@@ -123,6 +126,7 @@ class ResultRow(BaseModel):
     outcome_score: float | None
     tool_score: float | None
     latency_sec: float
+    turns: int | None = None
     input_tokens: int | None
     output_tokens: int | None
     status: str

--- a/site/ingest/PROTOCOL.md
+++ b/site/ingest/PROTOCOL.md
@@ -59,6 +59,7 @@ always `0`; the schema is already shaped for multi-iteration runs (§4).
 | `outcomeScore` | number \| null | `[0, 1]` or null | Judge outcome score. Passes at `>= 0.7` (the threshold lives in `derive`). **`null` when unscored** (§5). |
 | `toolScore` | number \| null | `[0, 1]` or null | Tool-invocation score; `null` when unscored. |
 | `latencySec` | number | `>= 0` | Agent wall-clock latency, seconds. |
+| `turns` | integer \| null (optional) | `>= 0` or null | Agent trajectory steps (tool calls + text turns) — an efficiency axis. `null` when no trajectory was captured; omitted by pre-turns rows. |
 | `inputTokens` | integer \| null | `>= 0` or null | Prompt tokens consumed; `null` when usage was not captured. |
 | `outputTokens` | integer \| null | `>= 0` or null | Completion tokens produced; `null` when usage was not captured. |
 

--- a/site/ingest/load.mjs
+++ b/site/ingest/load.mjs
@@ -83,6 +83,8 @@ export function validateRow(row) {
     floatOrNull("outcomeScore", num01);
     floatOrNull("toolScore", num01);
     float("latencySec", nonNeg);
+    // turns: efficiency axis, OPTIONAL (pre-turns rows omit it). Validate only when present.
+    if ("turns" in row) intOrNull("turns", nonNeg);
     intOrNull("inputTokens", nonNeg);
     intOrNull("outputTokens", nonNeg);
 

--- a/site/ingest/load.test.mjs
+++ b/site/ingest/load.test.mjs
@@ -47,6 +47,16 @@ describe("validateRow", () => {
         expect(errs.join()).toMatch(/runId/);
     });
 
+    it("accepts turns (optional): absent, null, or a non-negative integer", () => {
+        expect(validateRow(validRow)).toEqual([]); // absent
+        expect(validateRow({ ...validRow, turns: null })).toEqual([]);
+        expect(validateRow({ ...validRow, turns: 12 })).toEqual([]);
+    });
+
+    it("flags a negative turns", () => {
+        expect(validateRow({ ...validRow, turns: -1 }).join()).toMatch(/turns/);
+    });
+
     it("accepts a runId with a uniqueness suffix (parallel/aggregated runs)", () => {
         expect(validateRow({ ...validRow, runId: "run_20260601_120000_12345" })).toEqual([]);
         expect(validateRow({ ...validRow, runId: "run_20260601_120000_matrix-7" })).toEqual([]);

--- a/site/src/lib/schema.d.ts
+++ b/site/src/lib/schema.d.ts
@@ -125,6 +125,8 @@ export interface ResultRow {
     /** Tool-use score in [0,1]; null when unscored. */
     toolScore: number | null;
     latencySec: number;
+    /** Agent trajectory steps (tool calls + text turns) — an efficiency axis; null when no trajectory captured. */
+    turns?: number | null;
     /** Null when token usage was not captured. */
     inputTokens: number | null;
     /** Null when token usage was not captured. */

--- a/tests/unit/results/test_results_normalize.py
+++ b/tests/unit/results/test_results_normalize.py
@@ -146,6 +146,7 @@ def test_build_rows_success_record():
         "folder": "task_001",
         "status": "success",
         "latency": 42.5,
+        "trajectory": [{"name": "list"}, {"name": "get"}, {"name": "apply"}],
         "tokens": {"prompt_tokens": 100, "candidates_tokens": 20},
         "scores": {
             OUTCOME_SCORE_KEY: {"score": 0.9, "success": True, "reason": "ok"},
@@ -170,6 +171,7 @@ def test_build_rows_success_record():
         "outcomeScore": 0.9,
         "toolScore": 0.7,
         "latencySec": 42.5,
+        "turns": 3,
         "inputTokens": 100,
         "outputTokens": 20,
         "status": "success",
@@ -194,7 +196,21 @@ def test_build_rows_failed_record_has_null_scores_and_tokens():
     assert row.tool_score is None
     assert row.input_tokens is None
     assert row.output_tokens is None
+    assert row.turns is None  # no trajectory captured
     assert row.iteration == 0
+
+
+def test_build_rows_turns_counts_trajectory_steps():
+    empty = build_rows(
+        [{"name": "n", "folder": "f", "status": "success", "trajectory": [], "scores": {}}],
+        _manifest(),
+    )[0]
+    assert empty.turns == 0  # ran, took no steps — distinct from None (no data)
+    stepped = build_rows(
+        [{"name": "n", "folder": "f", "status": "success", "trajectory": [{}, {}], "scores": {}}],
+        _manifest(),
+    )[0]
+    assert stepped.turns == 2
 
 
 def test_build_rows_preserves_order_and_run_identity():
@@ -231,6 +247,7 @@ def test_result_row_keys_match_typescript_interface():
         "outcomeScore",
         "toolScore",
         "latencySec",
+        "turns",
         "inputTokens",
         "outputTokens",
         "validated",

--- a/tests/unit/results/test_results_normalize.py
+++ b/tests/unit/results/test_results_normalize.py
@@ -201,11 +201,18 @@ def test_build_rows_failed_record_has_null_scores_and_tokens():
 
 
 def test_build_rows_turns_counts_trajectory_steps():
+    # The record defaults trajectory to [], so an empty list means "not captured"
+    # -> None, not a misleading 0-step count.
     empty = build_rows(
         [{"name": "n", "folder": "f", "status": "success", "trajectory": [], "scores": {}}],
         _manifest(),
     )[0]
-    assert empty.turns == 0  # ran, took no steps — distinct from None (no data)
+    assert empty.turns is None
+    missing = build_rows(
+        [{"name": "n", "folder": "f", "status": "success", "scores": {}}],
+        _manifest(),
+    )[0]
+    assert missing.turns is None
     stepped = build_rows(
         [{"name": "n", "folder": "f", "status": "success", "trajectory": [{}, {}], "scores": {}}],
         _manifest(),


### PR DESCRIPTION
## Summary

Adds **`turns`** — the number of agent trajectory steps (tool calls + text turns) per iteration — as a per-run **efficiency axis** on the result row. This unblocks the frontend Phase 2 efficiency work (latency / tokens / **turns** / cost + Pareto), which currently has latency + tokens but no turns.

## What's here

- **`results/row.py`** — `ResultRow.turns: int | None`.
- **`results/normalize.py`** — derives it from the record's `trajectory` length: `None` when no trajectory was captured, `0` for a run that took no steps (distinct from missing data).
- **Frontend contract** — `site/src/lib/schema.d.ts` (`turns?`), `ingest/load.mjs` (validates optional, `>= 0`), `PROTOCOL.md`.
- **Tests** — normalize turns counting (`None` / `0` / N) + loader validation.

## Definition (open to feedback)

`turns` = count of trajectory entries. That includes tool calls **and** interleaved text turns; if the team prefers "model round-trips only" or "tool calls only," it's a one-line change in `normalize.py` — flagging so reviewers can pin the definition.

## Coordination

- **Independent of #212** (token buckets) — turns comes from the trajectory, not token usage — but it touches the same `row.py` / `normalize.py` / `schema.d.ts` / `load.mjs` files, so whichever of {this, #212, #195, #206} merges second needs a **trivial additive rebase**.
- Optional/back-compat: pre-turns rows omit the field and still ingest.

## Test plan
- `pytest tests/unit/results` — green.
- `npm run test` (site) — **97/97**.
