### PR TITLE
feat(site): dark mode (persisted toggle + theme-aware chart)

### DIFF
--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { BenchmarkProvider } from "./context/BenchmarkContext.jsx";
 import { Leaderboard } from "./pages/Leaderboard.jsx";
 import { Detail } from "./pages/Detail.jsx";
+import { ThemeToggle } from "./components/ThemeToggle.jsx";
 
 export default function App() {
     return (
@@ -12,7 +13,10 @@ export default function App() {
             future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
         >
             <BenchmarkProvider>
-                <div className="min-h-screen flex flex-col justify-start items-center p-4 sm:p-8">
+                <div className="relative min-h-screen flex flex-col justify-start items-center p-4 sm:p-8 bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100 transition-colors">
+                    <div className="absolute top-4 right-4 sm:top-6 sm:right-6 z-20">
+                        <ThemeToggle />
+                    </div>
                     <Routes>
                         <Route path="/" element={<Leaderboard />} />
                         <Route path="/setup/:id" element={<Detail />} />

--- a/site/src/components/FilterBar.jsx
+++ b/site/src/components/FilterBar.jsx
@@ -8,8 +8,8 @@ function FilterGroup({ group, filterState, onToggle }) {
     if (group.options.length === 0) return null;
     const primary = group.tier === "primary";
     const labelCls = primary
-        ? "text-[11px] font-bold tracking-wide uppercase text-slate-600"
-        : "text-[10px] font-semibold tracking-wider uppercase text-slate-400";
+        ? "text-[11px] font-bold tracking-wide uppercase text-slate-600 dark:text-slate-300"
+        : "text-[10px] font-semibold tracking-wider uppercase text-slate-400 dark:text-slate-500";
     const sizeCls = primary ? "px-3 py-1 text-xs" : "px-2.5 py-0.5 text-[11px]";
 
     return (
@@ -20,15 +20,15 @@ function FilterGroup({ group, filterState, onToggle }) {
                 const cls = active
                     ? (primary
                         ? "bg-indigo-600 text-white border-indigo-600 shadow-sm"
-                        : "bg-slate-700 text-white border-slate-700 shadow-sm")
-                    : "bg-white text-slate-600 border-slate-200 hover:border-slate-300 hover:bg-slate-50";
+                        : "bg-slate-700 dark:bg-slate-600 text-white border-slate-700 dark:border-slate-600 shadow-sm")
+                    : "bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-700";
                 return (
                     <button
                         key={opt.value}
                         type="button"
                         onClick={() => onToggle(group.key, opt.value)}
                         aria-pressed={active}
-                        className={`${sizeCls} rounded-full border font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 ${cls}`}
+                        className={`${sizeCls} rounded-full border font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-900 ${cls}`}
                     >
                         {opt.text}
                     </button>
@@ -43,26 +43,26 @@ export function FilterBar({ groups, filterState, onToggle, onClear, shown, total
     const secondary = groups.filter(g => g.tier === "secondary");
 
     return (
-        <div className="px-6 py-4 bg-white border-b border-slate-100 flex flex-col gap-3">
+        <div className="px-6 py-4 bg-white dark:bg-slate-900 border-b border-slate-100 dark:border-slate-800 flex flex-col gap-3">
             <div className="flex items-start justify-between gap-4">
                 <div className="flex flex-col gap-2 flex-grow">
                     {primary.map(g => <FilterGroup key={g.key} group={g} filterState={filterState} onToggle={onToggle} />)}
                 </div>
                 <div className="flex items-center gap-3 shrink-0 pt-0.5">
-                    <span className="text-[11px] text-slate-400 whitespace-nowrap">{shown} of {total}</span>
+                    <span className="text-[11px] text-slate-400 dark:text-slate-500 whitespace-nowrap">{shown} of {total}</span>
                     {anyFilterActive(filterState) && (
                         <button
                             type="button"
                             onClick={onClear}
-                            className="text-[11px] font-medium text-indigo-600 hover:text-indigo-800 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+                            className="text-[11px] font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
                         >
                             Clear all
                         </button>
                     )}
                 </div>
             </div>
-            <div className="flex items-center gap-2 pt-1 mt-1 border-t border-slate-100">
-                <span className="text-[9px] font-semibold tracking-wider uppercase text-slate-300 shrink-0">Modifiers</span>
+            <div className="flex items-center gap-2 pt-1 mt-1 border-t border-slate-100 dark:border-slate-800">
+                <span className="text-[9px] font-semibold tracking-wider uppercase text-slate-300 dark:text-slate-600 shrink-0">Modifiers</span>
                 <div className="flex flex-col sm:flex-row sm:flex-wrap gap-x-4 gap-y-1 flex-grow pl-1">
                     {secondary.map(g => <FilterGroup key={g.key} group={g} filterState={filterState} onToggle={onToggle} />)}
                 </div>

--- a/site/src/components/LeaderboardRow.jsx
+++ b/site/src/components/LeaderboardRow.jsx
@@ -15,7 +15,7 @@ export function LeaderboardRow({ setup, models, harnesses, metric }) {
         <Link
             to={to}
             aria-label={`View details for ${setupLabel(setup, models, harnesses)}`}
-            className="relative px-6 py-4 flex flex-col sm:grid sm:grid-cols-12 gap-3 sm:gap-4 items-start sm:items-center hover:bg-slate-50/70 cursor-pointer transition-colors group select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-inset"
+            className="relative px-6 py-4 flex flex-col sm:grid sm:grid-cols-12 gap-3 sm:gap-4 items-start sm:items-center hover:bg-slate-50/70 dark:hover:bg-slate-800/40 cursor-pointer transition-colors group select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-inset"
         >
             {/* Benchmark subject: model × harness pairing (grid only, so the × stays aligned) */}
             <div className="col-span-7 sm:col-span-7 grid grid-cols-[1fr_auto_1fr] items-center gap-1 sm:gap-2 w-full sm:w-auto pr-6 sm:pr-0">
@@ -29,23 +29,23 @@ export function LeaderboardRow({ setup, models, harnesses, metric }) {
                     {setup.catastrophicCount > 0 && (
                         <span
                             title={`${setup.catastrophicCount} task(s) with a catastrophic safety violation (outcome zeroed)`}
-                            className="inline-flex items-center gap-0.5 rounded-full bg-rose-50 px-1.5 py-0.5 text-[10px] font-semibold text-rose-700 ring-1 ring-rose-200"
+                            className="inline-flex items-center gap-0.5 rounded-full bg-rose-50 dark:bg-rose-500/10 px-1.5 py-0.5 text-[10px] font-semibold text-rose-700 dark:text-rose-300 ring-1 ring-rose-200 dark:ring-rose-500/30"
                         >
                             ⚠ {setup.catastrophicCount}
                         </span>
                     )}
                 </span>
-                <span className="text-sm font-semibold text-slate-900 w-12 min-w-[48px]">
+                <span className="text-sm font-semibold text-slate-900 dark:text-slate-100 w-12 min-w-[48px]">
                     {score.toFixed(1)}%
                 </span>
-                <div className="w-full bg-slate-100 h-2 rounded-full overflow-hidden relative">
+                <div className="w-full bg-slate-100 dark:bg-slate-800 h-2 rounded-full overflow-hidden relative">
                     <div className="progress-bar-fill h-full rounded-full" style={{ width: `${score}%`, backgroundColor: setup.color }} />
                 </div>
             </div>
 
             {/* View-details affordance */}
             <div className="absolute right-6 top-5 sm:relative sm:right-auto sm:top-auto col-span-1 sm:col-span-1 flex items-center justify-end">
-                <svg aria-hidden="true" className="w-4 h-4 text-slate-300 group-hover:text-indigo-500 group-hover:translate-x-0.5 transition-all" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg aria-hidden="true" className="w-4 h-4 text-slate-300 dark:text-slate-600 group-hover:text-indigo-500 dark:group-hover:text-indigo-400 group-hover:translate-x-0.5 transition-all" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
                 </svg>
             </div>

--- a/site/src/components/MetricToggle.jsx
+++ b/site/src/components/MetricToggle.jsx
@@ -10,15 +10,15 @@ export function MetricToggle({ value, onChange, available }) {
     const hasFilter = Array.isArray(available) && available.length > 0;
     const isEnabled = m => !hasFilter || available.includes(m);
     return (
-        <div className="inline-flex p-0.5 bg-slate-100 rounded-lg text-[11px]">
+        <div className="inline-flex p-0.5 bg-slate-100 dark:bg-slate-800 rounded-lg text-[11px]">
             {METRICS.map(m => {
                 const active = m === value;
                 const enabled = isEnabled(m);
                 const cls = active
-                    ? "bg-white text-slate-800 shadow-sm"
+                    ? "bg-white dark:bg-slate-700 text-slate-800 dark:text-slate-100 shadow-sm"
                     : enabled
-                        ? "text-slate-600 hover:text-slate-800"
-                        : "text-slate-300";
+                        ? "text-slate-600 dark:text-slate-300 hover:text-slate-800 dark:hover:text-slate-100"
+                        : "text-slate-300 dark:text-slate-600";
                 return (
                     <button
                         key={m}
@@ -27,7 +27,7 @@ export function MetricToggle({ value, onChange, available }) {
                         disabled={!enabled}
                         aria-pressed={active}
                         title={enabled ? metricDescription(m) : "Available once multi-iteration runs land"}
-                        className={`px-2 py-1 font-medium rounded-md whitespace-nowrap transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed ${cls}`}
+                        className={`px-2 py-1 font-medium rounded-md whitespace-nowrap transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed ${cls}`}
                     >
                         {METRIC_LABELS[m]}
                     </button>

--- a/site/src/components/SetupIdentity.jsx
+++ b/site/src/components/SetupIdentity.jsx
@@ -8,20 +8,20 @@ import { setupTags } from "../lib/accessors.js";
 
 const VARIANTS = {
     row: {
-        modelBox: "p-1 bg-white rounded-md shadow-sm border border-slate-100 flex-shrink-0 group-hover:scale-105 transition-transform",
+        modelBox: "p-1 bg-white dark:bg-slate-800 rounded-md shadow-sm border border-slate-100 dark:border-slate-700 flex-shrink-0 group-hover:scale-105 transition-transform",
         harnessBox: "p-1 rounded-md shadow-sm flex-shrink-0 group-hover:scale-105 transition-transform",
-        name: "text-slate-900 font-semibold text-sm truncate",
-        sub: "text-[10px] text-slate-400 font-normal truncate",
+        name: "text-slate-900 dark:text-slate-100 font-semibold text-sm truncate",
+        sub: "text-[10px] text-slate-400 dark:text-slate-500 font-normal truncate",
         hair: "w-2.5",
         connector: "w-5 h-5 text-sm group-hover:text-indigo-500 group-hover:ring-indigo-200 transition-colors",
         chipSize: "sm",
         gap: "gap-2"
     },
     hero: {
-        modelBox: "p-1.5 bg-white rounded-lg shadow-sm border border-slate-100 flex-shrink-0 scale-125 origin-left",
+        modelBox: "p-1.5 bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-slate-100 dark:border-slate-700 flex-shrink-0 scale-125 origin-left",
         harnessBox: "p-1.5 rounded-lg shadow-sm flex-shrink-0 scale-125 origin-left",
-        name: "text-slate-900 font-bold text-base sm:text-lg truncate",
-        sub: "text-xs text-slate-400 font-normal truncate",
+        name: "text-slate-900 dark:text-slate-100 font-bold text-base sm:text-lg truncate",
+        sub: "text-xs text-slate-400 dark:text-slate-500 font-normal truncate",
         hair: "w-4",
         connector: "w-6 h-6 text-base",
         chipSize: "md",
@@ -48,9 +48,9 @@ export function SetupIdentity({ setup, model, harness, variant = "row" }) {
 
             {/* Pairing connector */}
             <div aria-hidden="true" className="flex items-center justify-center gap-1 px-0.5 sm:px-1 select-none shrink-0">
-                <span className={`hidden sm:block h-px bg-gradient-to-r from-transparent to-slate-300 ${v.hair}`}></span>
-                <span className={`flex items-center justify-center rounded-md text-slate-400 font-medium leading-none ring-1 ring-slate-200/70 bg-slate-50 ${v.connector}`}>×</span>
-                <span className={`hidden sm:block h-px bg-gradient-to-l from-transparent to-slate-300 ${v.hair}`}></span>
+                <span className={`hidden sm:block h-px bg-gradient-to-r from-transparent to-slate-300 dark:to-slate-600 ${v.hair}`}></span>
+                <span className={`flex items-center justify-center rounded-md text-slate-400 dark:text-slate-500 font-medium leading-none ring-1 ring-slate-200/70 dark:ring-slate-700 bg-slate-50 dark:bg-slate-800 ${v.connector}`}>×</span>
+                <span className={`hidden sm:block h-px bg-gradient-to-l from-transparent to-slate-300 dark:to-slate-600 ${v.hair}`}></span>
             </div>
 
             {/* Harness entity + config chips */}

--- a/site/src/components/States.jsx
+++ b/site/src/components/States.jsx
@@ -5,11 +5,11 @@ import { Link } from "react-router-dom";
 export function EmptyState({ onClear }) {
     return (
         <div className="px-6 py-12 flex flex-col items-center justify-center text-center gap-2">
-            <svg className="w-8 h-8 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-8 h-8 text-slate-300 dark:text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>
-            <p className="text-sm font-medium text-slate-500">No setups match the selected filters.</p>
-            <button type="button" onClick={onClear} className="text-xs font-medium text-indigo-600 hover:text-indigo-800 hover:underline">
+            <p className="text-sm font-medium text-slate-500 dark:text-slate-400">No setups match the selected filters.</p>
+            <button type="button" onClick={onClear} className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 hover:underline">
                 Clear all filters
             </button>
         </div>
@@ -19,8 +19,8 @@ export function EmptyState({ onClear }) {
 export function LoadError() {
     return (
         <div className="px-6 py-12 flex flex-col items-center justify-center text-center gap-2">
-            <p className="text-sm font-medium text-slate-500">Couldn't load benchmark data.</p>
-            <p className="text-xs text-slate-400">Is the Firestore emulator running and seeded?</p>
+            <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Couldn't load benchmark data.</p>
+            <p className="text-xs text-slate-400 dark:text-slate-500">Is the Firestore emulator running and seeded?</p>
         </div>
     );
 }
@@ -28,21 +28,21 @@ export function LoadError() {
 export function Loading() {
     return (
         <div className="px-6 py-12 flex items-center justify-center text-center">
-            <p className="text-sm font-medium text-slate-400">Loading benchmark data…</p>
+            <p className="text-sm font-medium text-slate-400 dark:text-slate-500">Loading benchmark data…</p>
         </div>
     );
 }
 
 export function NotFound({ id }) {
     return (
-        <div className="w-full bg-white rounded-2xl border border-slate-200/80 shadow-xl shadow-slate-100 p-10 flex flex-col items-center text-center gap-3">
-            <svg className="w-10 h-10 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div className="w-full bg-white dark:bg-slate-900 rounded-2xl border border-slate-200/80 dark:border-slate-800 shadow-xl shadow-slate-100 dark:shadow-none p-10 flex flex-col items-center text-center gap-3">
+            <svg className="w-10 h-10 text-slate-300 dark:text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
-            <p className="text-sm font-medium text-slate-600">
-                No setup found for <span className="font-mono text-slate-800">{id || "(missing id)"}</span>.
+            <p className="text-sm font-medium text-slate-600 dark:text-slate-300">
+                No setup found for <span className="font-mono text-slate-800 dark:text-slate-100">{id || "(missing id)"}</span>.
             </p>
-            <Link to="/" className="text-xs font-medium text-indigo-600 hover:text-indigo-800 hover:underline">
+            <Link to="/" className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 hover:underline">
                 Return to the leaderboard
             </Link>
         </div>

--- a/site/src/components/ThemeToggle.jsx
+++ b/site/src/components/ThemeToggle.jsx
@@ -1,0 +1,40 @@
+// Light/dark theme toggle. Persists the choice (localStorage) and flips the
+// `dark` class on <html>; the initial theme is applied in main.jsx before render
+// so there's no flash.
+
+import { useState } from "react";
+import { getInitialTheme, setTheme } from "../lib/theme.js";
+
+export function ThemeToggle() {
+    const [theme, setThemeState] = useState(getInitialTheme);
+    const dark = theme === "dark";
+
+    const toggle = () => {
+        const next = dark ? "light" : "dark";
+        setTheme(next);
+        setThemeState(next);
+    };
+
+    return (
+        <button
+            type="button"
+            onClick={toggle}
+            aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
+            title={dark ? "Light mode" : "Dark mode"}
+            className="inline-flex items-center justify-center w-9 h-9 rounded-lg text-slate-500 hover:text-slate-800 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-100 dark:hover:bg-slate-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+        >
+            {dark ? (
+                // Sun
+                <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <circle cx="12" cy="12" r="4" strokeWidth="2" />
+                    <path strokeLinecap="round" strokeWidth="2" d="M12 2v2m0 16v2m10-10h-2M4 12H2m15.07-7.07-1.41 1.41M6.34 17.66l-1.41 1.41m12.73 0-1.41-1.41M6.34 6.34 4.93 4.93" />
+                </svg>
+            ) : (
+                // Moon
+                <svg aria-hidden="true" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+                </svg>
+            )}
+        </button>
+    );
+}

--- a/site/src/components/ThemeToggle.jsx
+++ b/site/src/components/ThemeToggle.jsx
@@ -2,12 +2,26 @@
 // `dark` class on <html>; the initial theme is applied in main.jsx before render
 // so there's no flash.
 
-import { useState } from "react";
-import { getInitialTheme, setTheme } from "../lib/theme.js";
+import { useEffect, useState } from "react";
+import { THEME_KEY, applyTheme, getInitialTheme, setTheme } from "../lib/theme.js";
 
 export function ThemeToggle() {
     const [theme, setThemeState] = useState(getInitialTheme);
     const dark = theme === "dark";
+
+    // `storage` fires only in the *other* tabs, so toggling here keeps every open
+    // tab in sync without a refresh. A cleared key falls back to the default.
+    useEffect(() => {
+        const onStorage = event => {
+            if (event.key !== null && event.key !== THEME_KEY) return;
+            const next = event.newValue === null ? getInitialTheme() : event.newValue;
+            if (next !== "light" && next !== "dark") return;
+            applyTheme(next);
+            setThemeState(next);
+        };
+        window.addEventListener("storage", onStorage);
+        return () => window.removeEventListener("storage", onStorage);
+    }, []);
 
     const toggle = () => {
         const next = dark ? "light" : "dark";

--- a/site/src/components/ThemeToggle.test.jsx
+++ b/site/src/components/ThemeToggle.test.jsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+import { ThemeToggle } from "./ThemeToggle.jsx";
+import { THEME_KEY } from "../lib/theme.js";
+
+const root = () => document.documentElement;
+const button = () => screen.getByRole("button");
+
+// Dispatch the cross-tab event the browser fires in OTHER tabs when this key
+// changes. `key: null` is what a storage.clear() looks like to a listener.
+function fireStorage({ key = THEME_KEY, newValue }) {
+    act(() => {
+        window.dispatchEvent(new StorageEvent("storage", { key, newValue }));
+    });
+}
+
+beforeEach(() => {
+    localStorage.clear();
+    root().classList.remove("dark");
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("ThemeToggle", () => {
+    it("labels itself by the theme it will switch TO", () => {
+        render(<ThemeToggle />);
+        expect(button()).toHaveAccessibleName("Switch to dark mode");
+        fireEvent.click(button());
+        expect(button()).toHaveAccessibleName("Switch to light mode");
+    });
+
+    it("persists and applies the choice on click", () => {
+        render(<ThemeToggle />);
+        fireEvent.click(button());
+        expect(root()).toHaveClass("dark");
+        expect(localStorage.getItem(THEME_KEY)).toBe("dark");
+
+        fireEvent.click(button());
+        expect(root()).not.toHaveClass("dark");
+        expect(localStorage.getItem(THEME_KEY)).toBe("light");
+    });
+
+    it("starts from the persisted choice", () => {
+        localStorage.setItem(THEME_KEY, "dark");
+        render(<ThemeToggle />);
+        expect(button()).toHaveAccessibleName("Switch to light mode");
+    });
+
+    it("follows a change made in another tab", () => {
+        render(<ThemeToggle />);
+        fireStorage({ newValue: "dark" });
+        expect(root()).toHaveClass("dark");
+        expect(button()).toHaveAccessibleName("Switch to light mode");
+    });
+
+    it("ignores storage events for other keys", () => {
+        render(<ThemeToggle />);
+        fireStorage({ key: "some-other-key", newValue: "dark" });
+        expect(root()).not.toHaveClass("dark");
+    });
+
+    it("ignores a junk value written by another tab", () => {
+        render(<ThemeToggle />);
+        fireStorage({ newValue: "solarized" });
+        expect(root()).not.toHaveClass("dark");
+        expect(button()).toHaveAccessibleName("Switch to dark mode");
+    });
+
+    it("falls back to the OS preference when another tab clears storage", () => {
+        // key === null means the whole store was cleared, so there is no saved
+        // choice left to read — resolution has to start over.
+        window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+        render(<ThemeToggle />);
+        expect(root()).not.toHaveClass("dark");
+
+        fireStorage({ key: null, newValue: null });
+        expect(root()).toHaveClass("dark");
+    });
+
+    it("stops listening after unmount", () => {
+        const { unmount } = render(<ThemeToggle />);
+        unmount();
+        fireStorage({ newValue: "dark" });
+        expect(root()).not.toHaveClass("dark");
+    });
+});

--- a/site/src/components/TrendChart.jsx
+++ b/site/src/components/TrendChart.jsx
@@ -14,11 +14,13 @@ import {
     Legend
 } from "chart.js";
 import { setupHistory, setupLabel, allRunDates, formatRunDate, yAxisBounds } from "../lib/accessors.js";
+import { useIsDark } from "../hooks/useIsDark.js";
 
-// Register Chart.js parts + apply the Inter/Slate styling once at module load.
+// Register Chart.js parts + apply the Inter styling once at module load. Colors
+// that differ by theme are set per-instance in `options` below (canvas can't use
+// Tailwind `dark:` variants); the tooltip is dark in both themes.
 Chart.register(LineElement, PointElement, LinearScale, Filler, Tooltip, Legend);
 Chart.defaults.font.family = "'Inter', sans-serif";
-Chart.defaults.color = "#64748b";
 Chart.defaults.plugins.tooltip.backgroundColor = "#0f172a";
 Chart.defaults.plugins.tooltip.titleColor = "#f8fafc";
 Chart.defaults.plugins.tooltip.bodyColor = "#cbd5e1";
@@ -37,6 +39,12 @@ export function TrendChart({
     ariaLabel = "Score trend over time",
     caption
 }) {
+    const isDark = useIsDark();
+    // Theme-aware axis/legend colors (the tick + grid can't use `dark:`).
+    const textColor = isDark ? "#94a3b8" : "#64748b"; // slate-400 / slate-500
+    const gridColor = isDark ? "#1e293b" : "#f1f5f9"; // slate-800 / slate-100
+    const pointHover = isDark ? "#0f172a" : "#ffffff";
+
     // Shared x-axis dates: union of run timestamps across the plotted setups.
     const dates = useMemo(() => allRunDates(setups), [setups]);
 
@@ -61,7 +69,7 @@ export function TrendChart({
         interaction: { mode: "nearest", intersect: false },
         plugins: {
             legend: showLegend
-                ? { display: true, position: "bottom", labels: { usePointStyle: true, boxWidth: 8, padding: 20, font: { size: 11, weight: "500" } } }
+                ? { display: true, position: "bottom", labels: { color: textColor, usePointStyle: true, boxWidth: 8, padding: 20, font: { size: 11, weight: "500" } } }
                 : { display: false },
             tooltip: {
                 callbacks: {
@@ -78,21 +86,21 @@ export function TrendChart({
                 // proportionally to elapsed time.
                 afterBuildTicks: axis => { axis.ticks = dates.map(t => ({ value: Date.parse(t) })); },
                 grid: { display: false },
-                ticks: { callback: value => formatRunDate(value), maxRotation: 0, autoSkip: false, padding: 8 }
+                ticks: { color: textColor, callback: value => formatRunDate(value), maxRotation: 0, autoSkip: false, padding: 8 }
             },
             y: {
                 min: yBounds.min,
                 max: yBounds.max,
                 border: { display: false },
-                grid: { color: "#f1f5f9" },
-                ticks: { callback: value => value + "%", stepSize: 10, padding: 8 }
+                grid: { color: gridColor },
+                ticks: { color: textColor, callback: value => value + "%", stepSize: 10, padding: 8 }
             }
         },
         elements: {
             line: { tension: 0.35, borderWidth: 3 },
-            point: { radius: 3, hitRadius: 12, hoverRadius: 6, hoverBackgroundColor: "#ffffff", hoverBorderWidth: 3 }
+            point: { radius: 3, hitRadius: 12, hoverRadius: 6, hoverBackgroundColor: pointHover, hoverBorderWidth: 3 }
         }
-    }), [dates, showLegend, yBounds]);
+    }), [dates, showLegend, yBounds, textColor, gridColor, pointHover]);
 
     return (
         <div className="chart-container flex-grow">

--- a/site/src/hooks/useIsDark.js
+++ b/site/src/hooks/useIsDark.js
@@ -1,0 +1,23 @@
+// Reactive "is the app in dark mode?" — reads the `dark` class on <html> and
+// re-renders the consumer whenever it flips (so canvas-based UI like the
+// Chart.js trend chart, which can't use Tailwind `dark:` variants, restyles
+// live on toggle).
+
+import { useEffect, useState } from "react";
+
+export function useIsDark() {
+    const [isDark, setIsDark] = useState(
+        () => document.documentElement.classList.contains("dark")
+    );
+
+    useEffect(() => {
+        const el = document.documentElement;
+        const observer = new MutationObserver(() =>
+            setIsDark(el.classList.contains("dark"))
+        );
+        observer.observe(el, { attributes: true, attributeFilter: ["class"] });
+        return () => observer.disconnect();
+    }, []);
+
+    return isDark;
+}

--- a/site/src/hooks/useIsDark.test.js
+++ b/site/src/hooks/useIsDark.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+import { useIsDark } from "./useIsDark.js";
+
+const root = () => document.documentElement;
+
+beforeEach(() => {
+    root().classList.remove("dark");
+});
+
+describe("useIsDark", () => {
+    it("reads the class already on <html> at mount", () => {
+        root().classList.add("dark");
+        expect(renderHook(() => useIsDark()).result.current).toBe(true);
+    });
+
+    it("re-renders when the class flips, in both directions", async () => {
+        // This is the whole point of the hook: Chart.js paints to a canvas and
+        // can't use Tailwind's `dark:` variants, so it needs a value that
+        // changes rather than one read once at mount.
+        const { result } = renderHook(() => useIsDark());
+        expect(result.current).toBe(false);
+
+        act(() => { root().classList.add("dark"); });
+        await waitFor(() => expect(result.current).toBe(true));
+
+        act(() => { root().classList.remove("dark"); });
+        await waitFor(() => expect(result.current).toBe(false));
+    });
+
+    it("ignores unrelated attribute changes on <html>", async () => {
+        const { result } = renderHook(() => useIsDark());
+        act(() => { root().setAttribute("lang", "fr"); });
+        await waitFor(() => expect(result.current).toBe(false));
+        root().removeAttribute("lang");
+    });
+
+    it("stops observing after unmount", async () => {
+        const { result, unmount } = renderHook(() => useIsDark());
+        unmount();
+        // A leaked MutationObserver would call setState on an unmounted hook.
+        act(() => { root().classList.add("dark"); });
+        await waitFor(() => expect(result.current).toBe(false));
+    });
+});

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -5,6 +5,11 @@
 /* Custom styles ported from the old style.css. */
 body {
     font-family: 'Inter', sans-serif;
+    background-color: #f8fafc; /* slate-50 — matches the App shell, avoids flash */
+}
+
+.dark body {
+    background-color: #020617; /* slate-950 */
 }
 
 .progress-bar-fill {
@@ -23,6 +28,14 @@ body {
 ::-webkit-scrollbar-thumb {
     background: #cbd5e1;
     border-radius: 3px;
+}
+
+.dark ::-webkit-scrollbar-track {
+    background: #1e293b;
+}
+
+.dark ::-webkit-scrollbar-thumb {
+    background: #475569;
 }
 
 .chart-container {

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -3,6 +3,18 @@
 @tailwind utilities;
 
 /* Custom styles ported from the old style.css. */
+
+/* color-scheme tells the browser to render its own UI (scrollbars, form
+   controls, spellcheck underlines) for the active theme — the part `dark:`
+   utilities can't reach, in every engine rather than just WebKit/Blink. */
+:root {
+    color-scheme: light;
+}
+
+.dark {
+    color-scheme: dark;
+}
+
 body {
     font-family: 'Inter', sans-serif;
     background-color: #f8fafc; /* slate-50 — matches the App shell, avoids flash */
@@ -16,6 +28,18 @@ body {
     transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+/* Standard scrollbar properties (Firefox + modern WebKit/Blink). */
+* {
+    scrollbar-width: thin;
+    scrollbar-color: #cbd5e1 #f1f5f9; /* thumb, track */
+}
+
+.dark * {
+    scrollbar-color: #475569 #1e293b;
+}
+
+/* -webkit-* kept for older Chrome/Safari, which ignore the properties above and
+   are the only engines that can size the bar this precisely. */
 ::-webkit-scrollbar {
     width: 6px;
     height: 6px;

--- a/site/src/lib/accessors.js
+++ b/site/src/lib/accessors.js
@@ -18,10 +18,10 @@ import { AUGMENTATIONS, augmentationLabel } from "./vocab.js";
 
 // Per-augmentation chip style. Tokens not listed here use the neutral fallback.
 const AUG_TAG_CLS = {
-    skills: "bg-indigo-50 text-indigo-700 ring-1 ring-indigo-100",
-    mcp: "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-100"
+    skills: "bg-indigo-50 dark:bg-indigo-500/10 text-indigo-700 dark:text-indigo-300 ring-1 ring-indigo-100 dark:ring-indigo-500/30",
+    mcp: "bg-emerald-50 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 ring-1 ring-emerald-100 dark:ring-emerald-500/30"
 };
-const AUG_TAG_FALLBACK = "bg-slate-100 text-slate-500";
+const AUG_TAG_FALLBACK = "bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400";
 
 // Full label distinguishing a setup. Leads with the first-class pairing
 // (model × harness), then one segment per augmentation token (or "Baseline"

--- a/site/src/lib/theme.js
+++ b/site/src/lib/theme.js
@@ -1,0 +1,23 @@
+// Theme persistence + application. Toggles the `dark` class on <html>, which
+// Tailwind's darkMode:"class" keys off. Resolution order: the user's saved
+// choice, then the OS preference.
+
+const KEY = "theme";
+
+/** @returns {"light" | "dark"} */
+export function getInitialTheme() {
+    const saved = localStorage.getItem(KEY);
+    if (saved === "light" || saved === "dark") return saved;
+    return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+/** Apply a theme to the document root (no persistence). */
+export function applyTheme(theme) {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+}
+
+/** Persist + apply a theme. */
+export function setTheme(theme) {
+    localStorage.setItem(KEY, theme);
+    applyTheme(theme);
+}

--- a/site/src/lib/theme.js
+++ b/site/src/lib/theme.js
@@ -2,7 +2,9 @@
 // Tailwind's darkMode:"class" keys off. Resolution order: the user's saved
 // choice, then the OS preference.
 
-const KEY = "theme";
+/** localStorage key holding the persisted choice; also the `storage` event key. */
+export const THEME_KEY = "theme";
+const KEY = THEME_KEY;
 
 /** @returns {"light" | "dark"} */
 export function getInitialTheme() {

--- a/site/src/lib/theme.js
+++ b/site/src/lib/theme.js
@@ -1,15 +1,31 @@
 // Theme persistence + application. Toggles the `dark` class on <html>, which
 // Tailwind's darkMode:"class" keys off. Resolution order: the user's saved
 // choice, then the OS preference.
+//
+// Every localStorage touch is guarded. Safari in private browsing, and any
+// profile with site storage blocked by policy, THROW on access rather than
+// returning null — and main.jsx calls getInitialTheme() at module scope, before
+// the first render. So an unguarded read doesn't degrade to "forgot your theme",
+// it takes the module down and the page never paints at all.
 
 /** localStorage key holding the persisted choice; also the `storage` event key. */
 export const THEME_KEY = "theme";
 const KEY = THEME_KEY;
 
+/** The saved choice, or null when storage is unreadable or holds something else. */
+function readStoredTheme() {
+    try {
+        const saved = localStorage.getItem(KEY);
+        return saved === "light" || saved === "dark" ? saved : null;
+    } catch {
+        return null;
+    }
+}
+
 /** @returns {"light" | "dark"} */
 export function getInitialTheme() {
-    const saved = localStorage.getItem(KEY);
-    if (saved === "light" || saved === "dark") return saved;
+    const saved = readStoredTheme();
+    if (saved) return saved;
     return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
@@ -20,6 +36,12 @@ export function applyTheme(theme) {
 
 /** Persist + apply a theme. */
 export function setTheme(theme) {
-    localStorage.setItem(KEY, theme);
+    try {
+        localStorage.setItem(KEY, theme);
+    } catch {
+        // Storage blocked or over quota. The choice won't survive a reload, but
+        // the click still has to take effect for this session — so fall through
+        // to applyTheme rather than returning early.
+    }
     applyTheme(theme);
 }

--- a/site/src/lib/theme.test.js
+++ b/site/src/lib/theme.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { THEME_KEY, applyTheme, getInitialTheme, setTheme } from "./theme.js";
+
+// Point matchMedia at a given OS preference. jsdom doesn't implement it, so
+// every test that reaches the fallback has to install one.
+function mockPrefersDark(matches) {
+    window.matchMedia = vi.fn().mockReturnValue({ matches });
+}
+
+// Make every storage access throw, the way Safari does in private browsing and
+// any profile with site data blocked by policy.
+function breakStorage() {
+    const boom = () => { throw new DOMException("denied", "SecurityError"); };
+    vi.spyOn(localStorage, "getItem").mockImplementation(boom);
+    vi.spyOn(localStorage, "setItem").mockImplementation(boom);
+}
+
+beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    mockPrefersDark(false);
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("getInitialTheme", () => {
+    it("prefers the saved choice over the OS preference", () => {
+        mockPrefersDark(true);
+        localStorage.setItem(THEME_KEY, "light");
+        expect(getInitialTheme()).toBe("light");
+    });
+
+    it("falls back to the OS preference when nothing is saved", () => {
+        mockPrefersDark(true);
+        expect(getInitialTheme()).toBe("dark");
+        mockPrefersDark(false);
+        expect(getInitialTheme()).toBe("light");
+    });
+
+    it("ignores a junk value in storage", () => {
+        // A stale or hand-edited key must not become a class name.
+        localStorage.setItem(THEME_KEY, "solarized");
+        mockPrefersDark(true);
+        expect(getInitialTheme()).toBe("dark");
+    });
+
+    it("falls back to light when matchMedia is unavailable", () => {
+        // Old browsers and some embedded webviews have no matchMedia at all.
+        window.matchMedia = undefined;
+        expect(getInitialTheme()).toBe("light");
+    });
+
+    it("survives storage that throws instead of returning null", () => {
+        // main.jsx calls this at module scope before the first render, so an
+        // escaping DOMException doesn't lose the theme, it blanks the page.
+        breakStorage();
+        mockPrefersDark(true);
+        expect(() => getInitialTheme()).not.toThrow();
+        expect(getInitialTheme()).toBe("dark");
+    });
+});
+
+describe("applyTheme", () => {
+    it("toggles the `dark` class Tailwind keys off", () => {
+        applyTheme("dark");
+        expect(document.documentElement).toHaveClass("dark");
+        applyTheme("light");
+        expect(document.documentElement).not.toHaveClass("dark");
+    });
+});
+
+describe("setTheme", () => {
+    it("persists and applies the choice", () => {
+        setTheme("dark");
+        expect(localStorage.getItem(THEME_KEY)).toBe("dark");
+        expect(document.documentElement).toHaveClass("dark");
+    });
+
+    it("still applies the theme when persistence fails", () => {
+        // The preference won't survive a reload, but the click has to work now.
+        breakStorage();
+        expect(() => setTheme("dark")).not.toThrow();
+        expect(document.documentElement).toHaveClass("dark");
+    });
+});

--- a/site/src/main.jsx
+++ b/site/src/main.jsx
@@ -1,7 +1,11 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.jsx";
+import { applyTheme, getInitialTheme } from "./lib/theme.js";
 import "./index.css";
+
+// Apply the theme before first paint so there's no light-mode flash.
+applyTheme(getInitialTheme());
 
 createRoot(document.getElementById("root")).render(
     <StrictMode>

--- a/site/src/pages/Detail.jsx
+++ b/site/src/pages/Detail.jsx
@@ -20,10 +20,10 @@ function median(nums) {
 
 function StatCard({ label, value, sub }) {
     return (
-        <div className="bg-white rounded-xl border border-slate-200/80 shadow-sm p-4 flex flex-col gap-1">
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">{label}</span>
-            <span className="text-xl font-bold text-slate-900">{value}</span>
-            {sub ? <span className="text-[10px] text-slate-400">{sub}</span> : null}
+        <div className="bg-white dark:bg-slate-900 rounded-xl border border-slate-200/80 dark:border-slate-800 shadow-sm p-4 flex flex-col gap-1">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">{label}</span>
+            <span className="text-xl font-bold text-slate-900 dark:text-slate-100">{value}</span>
+            {sub ? <span className="text-[10px] text-slate-400 dark:text-slate-500">{sub}</span> : null}
         </div>
     );
 }
@@ -47,15 +47,15 @@ function TaskTable({ setup, metric }) {
     }
 
     const Arrow = ({ k }) => sort.key === k
-        ? <span className="text-indigo-500">{sort.dir === "asc" ? "▲" : "▼"}</span>
-        : <span className="text-slate-300">↕</span>;
+        ? <span className="text-indigo-500 dark:text-indigo-400">{sort.dir === "asc" ? "▲" : "▼"}</span>
+        : <span className="text-slate-300 dark:text-slate-600">↕</span>;
 
     return (
-        <div className="w-full bg-white rounded-2xl border border-slate-200/80 shadow-xl shadow-slate-100 p-6">
-            <div className="mb-3 font-semibold text-slate-500 tracking-wider uppercase text-xs">Granular Task Breakdown</div>
+        <div className="w-full bg-white dark:bg-slate-900 rounded-2xl border border-slate-200/80 dark:border-slate-800 shadow-xl shadow-slate-100 dark:shadow-none p-6">
+            <div className="mb-3 font-semibold text-slate-500 dark:text-slate-400 tracking-wider uppercase text-xs">Granular Task Breakdown</div>
             <table className="w-full text-left">
                 <thead>
-                    <tr className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 select-none">
+                    <tr className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 select-none">
                         <th className="pb-2 pr-4 cursor-pointer" onClick={() => sortBy("name")}>Task <Arrow k="name" /></th>
                         <th className="pb-2 pr-4 cursor-pointer" onClick={() => sortBy("score")}>Score ({METRIC_LABELS[metric]}) <Arrow k="score" /></th>
                     </tr>
@@ -65,19 +65,19 @@ function TaskTable({ setup, metric }) {
                         // Null-safe: an unscored task shows an empty bar and "—".
                         const s = task.scores[metric];
                         return (
-                            <tr key={task.folder} className="border-t border-slate-100">
+                            <tr key={task.folder} className="border-t border-slate-100 dark:border-slate-800">
                                 <td className="py-3 pr-4">
                                     <div className="flex flex-col">
-                                        <span className="font-semibold text-slate-700 text-sm">{task.name}</span>
-                                        <span className="text-[10px] font-mono text-slate-400 mt-0.5">{task.folder}/</span>
+                                        <span className="font-semibold text-slate-700 dark:text-slate-200 text-sm">{task.name}</span>
+                                        <span className="text-[10px] font-mono text-slate-400 dark:text-slate-500 mt-0.5">{task.folder}/</span>
                                     </div>
                                 </td>
                                 <td className="py-3 pr-4 w-1/2">
                                     <div className="flex items-center gap-3">
-                                        <div className="flex-grow bg-slate-100 h-2 rounded-full overflow-hidden">
+                                        <div className="flex-grow bg-slate-100 dark:bg-slate-800 h-2 rounded-full overflow-hidden">
                                             <div className="progress-bar-fill h-full rounded-full" style={{ width: `${s ?? 0}%`, backgroundColor: setup.color }} />
                                         </div>
-                                        <span className="text-sm font-semibold text-slate-700 w-12 text-right shrink-0">{s == null ? "—" : `${s}%`}</span>
+                                        <span className="text-sm font-semibold text-slate-700 dark:text-slate-200 w-12 text-right shrink-0">{s == null ? "—" : `${s}%`}</span>
                                     </div>
                                 </td>
                             </tr>
@@ -110,7 +110,7 @@ export function Detail() {
 
     const backLink = (
         <div className="w-full">
-            <Link to="/" className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-indigo-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">
+            <Link to="/" className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 19l-7-7 7-7" />
                 </svg>
@@ -149,14 +149,14 @@ export function Detail() {
 
             <div className="w-full flex flex-col gap-6">
                 {/* Identity hero */}
-                <div className="w-full bg-white rounded-2xl border border-slate-200/80 shadow-xl shadow-slate-100 p-6 flex flex-col lg:flex-row lg:items-center gap-6 justify-between">
+                <div className="w-full bg-white dark:bg-slate-900 rounded-2xl border border-slate-200/80 dark:border-slate-800 shadow-xl shadow-slate-100 dark:shadow-none p-6 flex flex-col lg:flex-row lg:items-center gap-6 justify-between">
                     <div className="flex items-center gap-3 sm:gap-4 min-w-0">
                         <SetupIdentity setup={setup} model={model} harness={harness} variant="hero" />
                     </div>
                     <div className="flex flex-col items-start lg:items-end gap-2 shrink-0">
                         <div className="flex items-baseline gap-1.5">
-                            <span className="text-4xl font-bold text-slate-900">{score.toFixed(1)}<span className="text-2xl">%</span></span>
-                            <span className="text-xs font-medium text-slate-400 uppercase tracking-wide">{METRIC_LABELS[metric]}</span>
+                            <span className="text-4xl font-bold text-slate-900 dark:text-slate-100">{score.toFixed(1)}<span className="text-2xl">%</span></span>
+                            <span className="text-xs font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wide">{METRIC_LABELS[metric]}</span>
                         </div>
                         <MetricToggle value={metric} onChange={setMetric} available={available} />
                     </div>
@@ -189,15 +189,15 @@ export function Detail() {
             </div>
 
             {/* Single-setup trend chart */}
-            <section className="w-full bg-white rounded-2xl border border-slate-200/80 shadow-xl shadow-slate-100 p-6 flex flex-col">
+            <section className="w-full bg-white dark:bg-slate-900 rounded-2xl border border-slate-200/80 dark:border-slate-800 shadow-xl shadow-slate-100 dark:shadow-none p-6 flex flex-col">
                 <div className="mb-4">
-                    <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider flex items-center gap-2">
-                        <svg className="w-4 h-4 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <h2 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+                        <svg className="w-4 h-4 text-emerald-500 dark:text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 12l3-3 3 3 4-4M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
                         </svg>
                         Score Trend Over Time
                     </h2>
-                    <p className="text-[10px] text-slate-500 mt-1">This setup's success rate across historical run iterations.</p>
+                    <p className="text-[10px] text-slate-500 dark:text-slate-400 mt-1">This setup's success rate across historical run iterations.</p>
                 </div>
                 <TrendChart
                     setups={[setup]}

--- a/site/src/pages/Leaderboard.jsx
+++ b/site/src/pages/Leaderboard.jsx
@@ -47,16 +47,16 @@ export function Leaderboard() {
 
     return (
         <main className="w-full max-w-6xl flex flex-col items-center gap-8">
-            <div className="w-full bg-white rounded-2xl border border-slate-200/80 shadow-xl shadow-slate-100 overflow-hidden">
+            <div className="w-full bg-white dark:bg-slate-900 rounded-2xl border border-slate-200/80 dark:border-slate-800 shadow-xl shadow-slate-100 dark:shadow-none overflow-hidden">
                 {/* Header banner */}
-                <header className="px-6 pt-6 pb-5 border-b border-slate-100 bg-slate-50/50">
-                    <h1 className="text-sm font-semibold text-slate-500 flex items-center gap-2 uppercase tracking-wider">
-                        <svg className="w-4 h-4 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <header className="px-6 pt-6 pb-5 border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-800/30">
+                    <h1 className="text-sm font-semibold text-slate-500 dark:text-slate-400 flex items-center gap-2 uppercase tracking-wider">
+                        <svg className="w-4 h-4 text-indigo-500 dark:text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
                         </svg>
                         DevOps Bench Leaderboard
                     </h1>
-                    <p className="text-xs text-slate-500 mt-1">Benchmarking model × harness pairings across DevOps tasks — the LLM and the agent runner driving it.</p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">Benchmarking model × harness pairings across DevOps tasks — the LLM and the agent runner driving it.</p>
                 </header>
 
                 {/* Filter bar */}
@@ -72,24 +72,24 @@ export function Leaderboard() {
                 )}
 
                 {/* Controls & column headers */}
-                <div className="px-6 py-4 bg-white border-b border-slate-100 hidden sm:grid grid-cols-12 gap-4 items-center font-semibold text-xs tracking-wider text-slate-500 select-none">
+                <div className="px-6 py-4 bg-white dark:bg-slate-900 border-b border-slate-100 dark:border-slate-800 hidden sm:grid grid-cols-12 gap-4 items-center font-semibold text-xs tracking-wider text-slate-500 dark:text-slate-400 select-none">
                     <div className="col-span-7 sm:col-span-7 grid grid-cols-[1fr_auto_1fr] items-center gap-1 sm:gap-2">
                         <span>MODEL</span>
                         <span aria-hidden="true" className="flex items-center justify-center gap-1 px-0.5 sm:px-1 shrink-0">
                             <span className="hidden sm:block h-px w-2.5"></span>
-                            <span className="flex items-center justify-center w-5 h-5 text-slate-300 font-normal">×</span>
+                            <span className="flex items-center justify-center w-5 h-5 text-slate-300 dark:text-slate-600 font-normal">×</span>
                             <span className="hidden sm:block h-px w-2.5"></span>
                         </span>
-                        <span>HARNESS <span className="text-slate-300 font-normal normal-case tracking-normal">&amp; config</span></span>
+                        <span>HARNESS <span className="text-slate-300 dark:text-slate-600 font-normal normal-case tracking-normal">&amp; config</span></span>
                     </div>
                     <div className="col-span-5 sm:col-span-5 flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3 sm:gap-x-4 sm:gap-y-2 pr-2">
                         <div className="flex items-center gap-1 min-w-[70px]">
                             <span>SCORE</span>
                             <div tabIndex={0} aria-label="Score Explanation" className="group relative cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 rounded-full">
-                                <svg aria-hidden="true" className="w-3.5 h-3.5 text-slate-500 hover:text-slate-700 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <svg aria-hidden="true" className="w-3.5 h-3.5 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                                 </svg>
-                                <div role="tooltip" className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 p-2.5 bg-slate-900 text-white text-[11px] font-normal tracking-normal rounded-lg opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity shadow-lg z-20 leading-relaxed">
+                                <div role="tooltip" className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 p-2.5 bg-slate-900 dark:bg-slate-700 text-white text-[11px] font-normal tracking-normal rounded-lg opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity shadow-lg z-20 leading-relaxed">
                                     {metricDescription(metric)}
                                 </div>
                             </div>
@@ -99,7 +99,7 @@ export function Leaderboard() {
                 </div>
 
                 {/* Rows */}
-                <div className="divide-y divide-slate-100">
+                <div className="divide-y divide-slate-100 dark:divide-slate-800">
                     {loading ? <Loading />
                         : error ? <LoadError />
                         : sorted.length === 0 ? <EmptyState onClear={clearFilters} />
@@ -111,15 +111,15 @@ export function Leaderboard() {
 
             {/* Trend chart */}
             {!loading && !error && filtered.length > 0 && (
-                <section className="w-full bg-white rounded-2xl border border-slate-200/80 shadow-xl shadow-slate-100 p-6 flex flex-col">
+                <section className="w-full bg-white dark:bg-slate-900 rounded-2xl border border-slate-200/80 dark:border-slate-800 shadow-xl shadow-slate-100 dark:shadow-none p-6 flex flex-col">
                     <div className="mb-4">
-                        <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider flex items-center gap-2">
-                            <svg className="w-4 h-4 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <h2 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+                            <svg className="w-4 h-4 text-emerald-500 dark:text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 12l3-3 3 3 4-4M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
                             </svg>
                             Accuracy Performance Trend Over Time
                         </h2>
-                        <p className="text-[10px] text-slate-500 mt-1">Comparing agent configuration success rates across historical run iterations.</p>
+                        <p className="text-[10px] text-slate-500 dark:text-slate-400 mt-1">Comparing agent configuration success rates across historical run iterations.</p>
                     </div>
                     <TrendChart
                         setups={filtered}

--- a/site/src/test/setup.js
+++ b/site/src/test/setup.js
@@ -1,1 +1,28 @@
 import "@testing-library/jest-dom";
+
+// Node 26 ships its own `localStorage` global that stays undefined unless the
+// process is started with --localstorage-file, and its mere presence stops jsdom
+// from installing the real one. The result is a jsdom window with no Web Storage
+// at all, which no browser resembles: `localStorage.getItem(...)` throws a
+// TypeError rather than returning null, so anything touching storage fails for a
+// reason that has nothing to do with the code under test.
+//
+// Install a minimal in-memory Storage when the environment lacks one. Tests that
+// need to simulate a browser DENYING access (Safari private browsing, blocked
+// site data) spy on these methods and throw from them.
+if (!globalThis.localStorage) {
+    const store = new Map();
+    const storage = {
+        getItem: key => (store.has(String(key)) ? store.get(String(key)) : null),
+        setItem: (key, value) => { store.set(String(key), String(value)); },
+        removeItem: key => { store.delete(String(key)); },
+        clear: () => { store.clear(); },
+        key: index => [...store.keys()][index] ?? null,
+        get length() { return store.size; }
+    };
+    Object.defineProperty(globalThis, "localStorage", {
+        value: storage,
+        configurable: true,
+        writable: true
+    });
+}

--- a/site/tailwind.config.js
+++ b/site/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+    darkMode: "class",
     content: ["./index.html", "./src/**/*.{js,jsx}"],
     theme: {
         extend: {


### PR DESCRIPTION
## Summary

Adds a **light/dark theme toggle** to the leaderboard site — its own PR, kept out of the scoring work.

Stacked on **#206** (it themes the Phase 1 UI, incl. the new metric toggle + catastrophic badge). Retarget to `main` once #206 lands.

## What's here

- **Theming infra:** Tailwind `darkMode: "class"`; a small theme util (`lib/theme.js`) that resolves saved choice → OS `prefers-color-scheme`, persists to `localStorage`, and is applied **pre-paint in `main.jsx`** (no light flash); a persisted **`ThemeToggle`** (sun/moon) in the app shell.
- **`dark:` variants across every surface:** page shell, cards, headers, rows (incl. the ⚠ badge), filter bar, metric toggle, chips, identity block, states, detail page, and dark scrollbars/body.
- **Theme-aware chart:** Chart.js can't use `dark:`, so a `useIsDark` hook (MutationObserver on the `<html>` class) drives the trend chart's grid/tick/legend colors — it **restyles live** when you toggle, no refresh.

## Test plan
- `npm run test` — **95/95**; `npm run build:staging` — clean.
- Preview locally (toggle top-right; refresh persists the choice; chart recolors live).


