### PR TITLE
Set an explicit provider on all GCP task configs

### DIFF
--- a/tasks/gcp/deploy-config/task.yaml
+++ b/tasks/gcp/deploy-config/task.yaml
@@ -2,6 +2,7 @@ task_id: 3
 name: "deploy-config"
 infrastructure:
   deployer: "tofu"
+  provider: "gcp"
   # Provides the cluster + the hypercomputer-d1-vllm-sa KSA (Workload Identity)
   # + the hypercomputer-d1-models-* GCS bucket the manifest's gcsfuse volume
   # references. seed_mode=infra-only deliberately does NOT pre-deploy the vllm

--- a/tasks/gcp/deploy-hello-app/task.yaml
+++ b/tasks/gcp/deploy-hello-app/task.yaml
@@ -2,6 +2,7 @@ task_id: 6
 name: "deploy-hello-app"
 infrastructure:
   deployer: "tofu"
+  provider: "gcp"
   stack: "prebuilt/minimum"
   teardown: true
   variables:

--- a/tasks/gcp/fix-config/task.yaml
+++ b/tasks/gcp/fix-config/task.yaml
@@ -2,6 +2,7 @@ task_id: 5
 name: "fix-config"
 infrastructure:
   deployer: "tofu"
+  provider: "gcp"
   # seed_mode=broken-frontend pre-seeds the hypercomputer-d1-frontend Deployment
   # with USE_GEMINI_API="true" (the misconfiguration). The agent's job is to
   # re-apply the manifest below, which flips USE_GEMINI_API back to "false".

--- a/tasks/gcp/get-app-architecture/task.yaml
+++ b/tasks/gcp/get-app-architecture/task.yaml
@@ -2,6 +2,7 @@ task_id: 1
 name: "get-app-architecture"
 infrastructure:
   deployer: "tofu"
+  provider: "gcp"
   stack: "prebuilt/hypercomputer-d1"
   teardown: true
   variables:

--- a/tasks/gcp/gpu-stress-test-diagnosis/task.yaml
+++ b/tasks/gcp/gpu-stress-test-diagnosis/task.yaml
@@ -3,6 +3,7 @@ task_id: 14
 name: "gpu-stress-test-diagnosis"
 infrastructure:
   deployer: "tofu"
+  provider: "gcp"
   stack: "prebuilt/gpu-stress-test"
   teardown: true
   variables:

--- a/tasks/gcp/lustre-csi-deployment/task.yaml
+++ b/tasks/gcp/lustre-csi-deployment/task.yaml
@@ -3,6 +3,7 @@ task_id: 13
 name: "lustre-csi-deployment"
 infrastructure:
   deployer: "tofu"
+  provider: "gcp"
   stack: "prebuilt/lustre-csi"
   teardown: true
   variables:

--- a/tasks/gcp/multi-region-failover/task.yaml
+++ b/tasks/gcp/multi-region-failover/task.yaml
@@ -8,6 +8,7 @@ name: "multi-region-failover"
 # regions. See docs/bastion.md.
 infrastructure:
   deployer: "tofu"
+  provider: "gcp"
   stack: "prebuilt/multi-region-failover"
   teardown: true
 prompt: |

--- a/tasks/gcp/secret-rotation/task.yaml
+++ b/tasks/gcp/secret-rotation/task.yaml
@@ -2,6 +2,7 @@ task_id: 18
 name: "secret-rotation"
 infrastructure:
   deployer: "tofu"
+  provider: "gcp"
   stack: "prebuilt/secret-rotation"
   teardown: true
 prompt: |


### PR DESCRIPTION
Add an explicit GCP provider in the gcp specific task configs 

* Since we are vendor neutralizing the code, we made requiring an explicit provider for any stack not named kind, so these configs would start raising ConfigError once that change reaches this repo through back-sync. Setting provider: gcp explicitly on each keeps them working regardless of when that lands.