### PR TITLE
fix(metrics): normalize doc URL host in DocRetrievalRate [preventive]

### DIFF
--- a/devops_bench/metrics/grounding.py
+++ b/devops_bench/metrics/grounding.py
@@ -41,13 +41,36 @@ __all__ = [
 _log = get_logger("metrics.grounding")
 
 
+def _normalize_doc_url(url: str) -> str:
+    """Canonicalize a doc URL for host-tolerant substring matching.
+
+    Lowercases, collapses the ``docs.cloud.google.com`` host onto
+    ``cloud.google.com`` (the Cloud docs site is served under both, and task
+    mappings and retrieved URIs disagree on the prefix — e.g. a mapping of
+    ``https://cloud.google.com/...`` vs a retrieved ``docs.cloud.google.com/...``
+    URI otherwise never matches), drops any ``#fragment``, and trims a trailing
+    slash. The scheme is kept so short/toy URLs stay specific enough not to
+    match unrelated step text.
+
+    Args:
+        url: A raw documentation URL (may be empty).
+
+    Returns:
+        The normalized URL, or ``""`` for an empty input.
+    """
+    u = url.lower().split("#", 1)[0].replace("docs.cloud.google.com", "cloud.google.com")
+    return u.rstrip("/")
+
+
 def calculate_doc_retrieval_rate(
     documentation: list[dict[str, Any]], trajectory: list[Any]
 ) -> float:
     """Compute the fraction of mapped documentation guides seen in a trajectory.
 
-    A guide counts as accessed when its ``doc_name`` or ``url`` (case-insensitive)
-    appears anywhere in the JSON-serialized trajectory steps.
+    A guide counts as accessed when its ``doc_name`` (case-insensitive) or its
+    ``url`` (normalized via :func:`_normalize_doc_url` so scheme, the
+    ``docs.``-prefixed Cloud docs host, and ``#fragment`` differences don't
+    cause misses) appears anywhere in the JSON-serialized trajectory steps.
 
     Args:
         documentation: Mapped guides, each with ``doc_name`` and ``url`` keys.
@@ -62,19 +85,24 @@ def calculate_doc_retrieval_rate(
 
     # Serialize each step once up front rather than re-serializing the whole
     # trajectory for every documentation guide (it does not depend on the doc).
-    step_strs = [json.dumps(step).lower() for step in trajectory]
+    # Collapse the docs-host on each step too, so a mapping URL without the
+    # ``docs.`` prefix still matches a retrieved URI that carries it.
+    step_strs = [
+        json.dumps(step).lower().replace("docs.cloud.google.com", "cloud.google.com")
+        for step in trajectory
+    ]
 
     accessed_docs = set()
     for doc in documentation:
         doc_name = doc.get("doc_name") or ""
         doc_name_lower = doc_name.lower()
-        url_lower = (doc.get("url") or "").lower()
+        url_norm = _normalize_doc_url(doc.get("url") or "")
         found_in_trajectory = False
         for step_str in step_strs:
             # Guard both substrings on truthiness so a missing name/url (now "")
             # does not spuriously match every step (``"" in s`` is always True).
             if (doc_name_lower and doc_name_lower in step_str) or (
-                url_lower and url_lower in step_str
+                url_norm and url_norm in step_str
             ):
                 found_in_trajectory = True
                 break

--- a/pkg/evaluator/evaluate.py
+++ b/pkg/evaluator/evaluate.py
@@ -497,19 +497,38 @@ def evaluate_documentation_grounding(documentation, all_test_case, judge_model, 
     scores["ParameterRecallAccuracy"] = recall_accuracy
 
 
+def _normalize_doc_url(url: str) -> str:
+    """Canonicalize a doc URL for host-tolerant substring matching.
+
+    Collapses the ``docs.cloud.google.com`` host onto ``cloud.google.com`` (the
+    Cloud docs site is served under both, and task mappings and retrieved URIs
+    disagree on the prefix), drops any ``#fragment``, and trims a trailing slash.
+    The scheme is kept so short URLs stay specific enough not to match unrelated
+    step text.
+    """
+    u = url.lower().split("#", 1)[0].replace("docs.cloud.google.com", "cloud.google.com")
+    return u.rstrip("/")
+
+
 def calculate_doc_retrieval_rate(documentation, trajectory) -> float:
     """Calculates the percentage of mapped documentation guides accessed in trajectory."""
     if not documentation:
         return 0.0
 
+    # Collapse the docs-host on each step so a mapping URL without the ``docs.``
+    # prefix still matches a retrieved URI that carries it.
+    step_strs = [
+        json.dumps(step).lower().replace("docs.cloud.google.com", "cloud.google.com")
+        for step in trajectory
+    ]
+
     accessed_docs = set()
     for doc in documentation:
         doc_name_lower = doc["doc_name"].lower()
-        url_lower = doc["url"].lower()
+        url_norm = _normalize_doc_url(doc["url"] or "")
         found_in_trajectory = False
-        for step in trajectory:
-            step_str = json.dumps(step).lower()
-            if doc_name_lower in step_str or (url_lower and url_lower in step_str):
+        for step_str in step_strs:
+            if doc_name_lower in step_str or (url_norm and url_norm in step_str):
                 found_in_trajectory = True
                 break
         if found_in_trajectory:

--- a/tests/unit/metrics/test_metrics_grounding.py
+++ b/tests/unit/metrics/test_metrics_grounding.py
@@ -71,6 +71,31 @@ def test_retrieval_rate_tolerates_missing_name_and_url():
     assert calculate_doc_retrieval_rate(docs, trajectory) == pytest.approx(1 / 3)
 
 
+def test_retrieval_rate_matches_across_docs_host_prefix():
+    # Mapping uses the bare ``cloud.google.com`` host; the retrieved URI carries
+    # the ``docs.`` prefix (and vice versa) — both must still match.
+    docs = [
+        {"doc_name": "GPU Setup", "url": "https://cloud.google.com/kubernetes-engine/docs/how-to/gpus"},
+        {"doc_name": "Fuse CSI", "url": "https://docs.cloud.google.com/kubernetes-engine/docs/how-to/fuse"},
+    ]
+    trajectory = [
+        {"output": "see https://docs.cloud.google.com/kubernetes-engine/docs/how-to/gpus"},
+        {"output": "see https://cloud.google.com/kubernetes-engine/docs/how-to/fuse"},
+    ]
+    assert calculate_doc_retrieval_rate(docs, trajectory) == 1.0
+
+
+def test_retrieval_rate_ignores_url_fragment():
+    docs = [
+        {
+            "doc_name": "Quantization",
+            "url": "https://cloud.google.com/kubernetes-engine/docs/best-practices/inference#apply-quantization",
+        }
+    ]
+    trajectory = [{"output": "https://docs.cloud.google.com/kubernetes-engine/docs/best-practices/inference"}]
+    assert calculate_doc_retrieval_rate(docs, trajectory) == 1.0
+
+
 # --- evaluate_documentation_grounding (GEval mocked) --------------------------
 
 


### PR DESCRIPTION
> **Status: draft / preventive hardening — not a fix for an observed failure.**
> Held until a real kube-agents run gives us a trajectory that actually contains
> retrieved doc URIs, so we can confirm whether the host prefix genuinely
> mismatches the task mappings for the *same* page. If it does, this fixes a
> confirmed bug; if hosts line up, we may not need it.

## Context

`DocRetrievalRate` matches each mapped doc's `url` against the JSON-serialized
trajectory via an exact, case-insensitive substring check. It hardcodes no host —
it just uses whatever the task mapping carries.

The latent inconsistency: the GKE Cloud docs site is served under **both**
`cloud.google.com` and `docs.cloud.google.com`, and task mappings and retrieved
doc URIs disagree on the `docs.` prefix **per-doc, in both directions** (verified:
task.yaml files mix both hosts; `gke-mcp.log` retrieved URIs mix both too). So an
exact substring match can miss when the two sides differ on a page they otherwise
agree on.

## Why this is preventive, not a confirmed fix

Every `DocRetrievalRate: 0.0` we investigated for b/527099071 is explained by the
*primary* root cause — the retrieved docs never reach the outer trajectory at all
(the nested-MCP `generate_manifest` returns only the manifest YAML; docs live only
in gke-mcp server logs). We have **not** observed a case where a same-page doc was
present in the trajectory yet scored 0 purely due to the host prefix. This change
guards against that once docs *do* start reaching the trajectory (post gke-mcp /
kube-agents fix, or via direct DK tool calls in kube-agents).

## Change

Add `_normalize_doc_url`: lowercase, collapse `docs.cloud.google.com` ->
`cloud.google.com`, drop any `#fragment`, trim a trailing slash. Scheme is kept so
short URLs stay specific. Each trajectory step is collapsed the same way, so
matching is symmetric regardless of which side carries the prefix.

Applied to `devops_bench/metrics/grounding.py` (canonical) and mirrored into
`pkg/evaluator/evaluate.py` (the evaluator the kube-agents harness runs today).

## Tests

- New: cross-host-prefix matching and `#fragment` tolerance.
- All 14 grounding tests pass; canonical files ruff-clean.
- Behavioral check is synthetic (constructed trajectory), not from an observed run.