### PR TITLE
fix(agents): correct the API agent per the pre-export code review

### DIFF
--- a/devops_bench/agents/api/__init__.py
+++ b/devops_bench/agents/api/__init__.py
@@ -15,11 +15,15 @@
 """API/MCP agent harness driving the shared :func:`run_tool_loop` primitive.
 
 The concrete harness lives in :mod:`devops_bench.agents.api.agent` and
-self-registers under ``"api"`` via ``@AGENTS.register``. That module and its
-siblings (:mod:`devops_bench.agents.api.mcp`,
-:mod:`devops_bench.agents.api.skills`) pull in heavy optional dependencies (the
-``mcp`` SDK, ``deepeval``) only at call time — importing this package never
-forces those imports.
+self-registers under ``"api"`` via ``@AGENTS.register`` — importing this
+package triggers that registration (matching the CLI harness packages), so
+``AGENTS.get("api")`` works after ``import devops_bench.agents.api``. Heavy
+optional dependencies (the ``mcp`` SDK, ``deepeval``, provider SDKs) still
+load only at call time.
 """
 
 from __future__ import annotations
+
+from devops_bench.agents.api.agent import ApiAgent
+
+__all__ = ["ApiAgent"]

--- a/devops_bench/agents/api/agent.py
+++ b/devops_bench/agents/api/agent.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 import asyncio
 import shlex
+import time
+from collections import deque
 from pathlib import Path
 from typing import Any
 
@@ -30,14 +32,13 @@ from devops_bench.agents.api.mcp import MCPClient, extract_tool_text
 from devops_bench.agents.api.skills import (
     SkillToolInfo,
     discover_skill_tools,
-    read_skill_file,
 )
 from devops_bench.agents.base import AGENTS, AgentHarness
 from devops_bench.agents.config import AgentConfig
 from devops_bench.agents.result import AgentResult, ToolCall
 from devops_bench.core import get_logger
 from devops_bench.models import LLMClient, get_model
-from devops_bench.models.utils.loop import LoopResult, run_tool_loop
+from devops_bench.models.utils.loop import LoopResult, ToolDispatcher, run_tool_loop
 
 __all__ = ["ApiAgent", "fold_trajectory", "extract_tokens"]
 
@@ -53,7 +54,10 @@ def fold_trajectory(contents: list[dict]) -> list[dict]:
     """Fold a :class:`LoopResult.contents` history into canonical trajectory entries.
 
     Each assistant tool call is paired by ``tool_call_id`` with its tool result
-    and emitted as one :class:`ToolCall`.
+    and emitted as one :class:`ToolCall`. Calls with no id — Gemini emits every
+    function call with ``id=None`` — are paired FIFO with the id-less results,
+    which is exact under :func:`run_tool_loop`'s contract of appending one
+    result per dispatched call in call order.
 
     Args:
         contents: The conversation history produced by :func:`run_tool_loop`.
@@ -82,20 +86,27 @@ def _fold_with_extraction_errors(
         A ``(trajectory, orphan_errors)`` tuple. ``orphan_errors`` lists one
         message per unpaired ``role: tool`` entry; empty on a clean fold.
     """
-    # Index assistant call ids first so we can detect orphans on the result pass.
+    # Index assistant call ids first so we can detect orphans on the result
+    # pass; id-less calls (Gemini emits every function call with ``id=None``)
+    # are counted so their results can be paired FIFO instead of dropped.
     assistant_call_ids: set[str] = set()
+    unkeyed_call_count = 0
     for msg in contents:
         if msg.get("role") != "assistant":
             continue
         for call in msg.get("tool_calls") or []:
             cid = call.get("id")
-            if cid is not None:
+            if cid is None:
+                unkeyed_call_count += 1
+            else:
                 assistant_call_ids.add(str(cid))
 
     # Pre-build call-id → (text, is_error) map so an out-of-order or absent
     # result still leaves the call as ``status="called"``/``result=None`` rather
-    # than crashing on a lookup.
+    # than crashing on a lookup. Id-less results queue up FIFO — exact pairing
+    # under run_tool_loop's append-one-result-per-call-in-order contract.
     results_by_id: dict[str, tuple[str, bool]] = {}
+    unkeyed_results: deque[tuple[str, bool]] = deque()
     orphan_errors: list[str] = []
     for msg in contents:
         if msg.get("role") != "tool":
@@ -104,6 +115,9 @@ def _fold_with_extraction_errors(
         text = msg.get("content")
         text_str = text if isinstance(text, str) else "" if text is None else str(text)
         is_error = isinstance(text, str) and text.startswith("Error: ")
+        if call_id is None and len(unkeyed_results) < unkeyed_call_count:
+            unkeyed_results.append((text_str, is_error))
+            continue
         if call_id is None or str(call_id) not in assistant_call_ids:
             # Drop the orphan from the trajectory but surface it for diagnostics.
             preview = text_str[:80].replace("\n", " ")
@@ -132,10 +146,12 @@ def _fold_with_extraction_errors(
             )
             if call_id is not None:
                 hit = results_by_id.get(str(call_id))
-                if hit is not None:
-                    text, is_error = hit
-                    entry.result = text
-                    entry.status = "error" if is_error else "completed"
+            else:
+                hit = unkeyed_results.popleft() if unkeyed_results else None
+            if hit is not None:
+                text, is_error = hit
+                entry.result = text
+                entry.status = "error" if is_error else "completed"
             trajectory.append(entry)
 
     return [entry.to_dict() for entry in trajectory], orphan_errors
@@ -214,7 +230,7 @@ def _build_dispatch(
     mcp_client: MCPClient | None,
     skill_resources: dict[str, str],
     errors: list[str],
-):
+) -> ToolDispatcher:
     """Build the dispatcher passed to :func:`run_tool_loop`.
 
     Wraps each tool call in its own ``try/except`` because ``run_tool_loop``
@@ -225,8 +241,9 @@ def _build_dispatch(
 
     Args:
         mcp_client: Active :class:`MCPClient`, or ``None`` when MCP is off.
-        skill_resources: Map of skill tool name to local file path; populated
-            by :func:`devops_bench.agents.api.skills.discover_skill_tools`.
+        skill_resources: Map of skill tool name to the skill file's content
+            (captured at discovery); populated by
+            :func:`devops_bench.agents.api.skills.discover_skill_tools`.
         errors: Errors list to mutate when a dispatch raises.
 
     Returns:
@@ -237,11 +254,11 @@ def _build_dispatch(
     async def dispatch(name: str, args: Any, call_id: str | None) -> str:
         try:
             # Skill tools take priority — they are advertised in the same tool
-            # list but are served locally without round-tripping the MCP server.
+            # list but are served locally from the content captured at
+            # discovery, without round-tripping the MCP server or the disk.
             if name in skill_resources:
-                file_path = skill_resources[name]
-                _log.info("Calling skill tool %s for file %s", name, file_path)
-                return await asyncio.to_thread(read_skill_file, file_path)
+                _log.info("Serving skill tool %s from discovery-time content", name)
+                return skill_resources[name]
             if mcp_client is None:
                 msg = (
                     f"Error: tool {name!r} requested but no MCP server is "
@@ -251,7 +268,16 @@ def _build_dispatch(
                 return msg
             arg_dict = args if isinstance(args, dict) else {}
             tool_result = await mcp_client.call_tool(name, arg_dict)
-            return extract_tool_text(tool_result)
+            text = extract_tool_text(tool_result)
+            # MCP servers report tool failure via ``isError`` rather than
+            # raising; surface it through the same error protocol as a raised
+            # dispatch so the fold and metrics see the failure mode.
+            if getattr(tool_result, "isError", False):
+                msg = f"Error calling tool {name}: {text}"
+                _log.warning(msg)
+                errors.append(msg)
+                return text if text.startswith("Error: ") else f"Error: {text}"
+            return text
         except Exception as exc:  # noqa: BLE001 - one tool failure must not abort the run
             msg = f"Error calling tool {name}: {exc}"
             _log.warning(msg)
@@ -400,10 +426,20 @@ class ApiAgent(AgentHarness):
         Returns:
             An :class:`AgentResult` whose ``trajectory`` is a list of canonical
             :class:`ToolCall` entries, ``output`` is :attr:`LoopResult.final_text`,
-            and ``tokens`` / ``latency`` carry the loop's accumulated values.
+            and ``latency`` carries the loop's accumulated wall-clock.
+            ``tokens`` reflects the final provider turn only — per-turn
+            accumulation is a pending ``run_tool_loop`` follow-up.
         """
         llm_client = get_model(self.config.provider, self.config.model)
-        max_turns = self.config.max_turns or _DEFAULT_MAX_TURNS
+        max_turns = (
+            self.config.max_turns if self.config.max_turns is not None else _DEFAULT_MAX_TURNS
+        )
+        mcp_servers = self.config.capabilities.mcp_servers
+        if len(mcp_servers) > 1:
+            _log.warning(
+                "API agent honors only the first MCP binding; ignoring %d additional server(s)",
+                len(mcp_servers) - 1,
+            )
         mcp_binding = self.config.capabilities.mcp
         # Only open an MCPClient when an MCP binding carries a launch command;
         # an empty-command binding is treated as "no MCP". ``shlex.join``
@@ -415,21 +451,33 @@ class ApiAgent(AgentHarness):
         skills_paths = self.config.capabilities.skills.paths
         rules_text = self.config.capabilities.rules.text
 
+        run_coro = _run_async(
+            llm_client,
+            prompt,
+            mcp_server_path,
+            skills_paths,
+            rules_text,
+            max_turns,
+        )
+        # Honor the config's wall-clock budget over the whole run (MCP session
+        # + every provider turn), matching the CLI harnesses' whole-call
+        # timeout semantics. ``wait_for`` with ``timeout=None`` imposes none.
+        timeout = self.config.timeout_sec
+        start = time.monotonic()
         try:
             loop_result, dispatch_errors, skill_names = asyncio.run(
-                _run_async(
-                    llm_client,
-                    prompt,
-                    mcp_server_path,
-                    skills_paths,
-                    rules_text,
-                    max_turns,
-                )
+                asyncio.wait_for(run_coro, timeout=timeout)
             )
-        except ValueError as exc:
-            # E.g. empty MCP server command; surface as a clean errored result
-            # rather than letting it bubble through the base safety net.
-            return AgentResult.errored(str(exc))
+        except TimeoutError:
+            # ``wait_for``'s TimeoutError can only fire once the deadline has
+            # elapsed (and never with ``timeout=None``) — anything earlier came
+            # from inside the run (e.g. a provider socket timeout;
+            # socket.timeout is TimeoutError since 3.10). Re-raise those so the
+            # base safety net logs the traceback instead of relabeling them.
+            elapsed = time.monotonic() - start
+            if timeout is None or elapsed < timeout:
+                raise
+            return AgentResult.errored(f"API agent timed out after {timeout}s", latency=elapsed)
 
         trajectory, orphan_errors = _fold_with_extraction_errors(loop_result.contents)
         tokens = extract_tokens(loop_result.response)

--- a/devops_bench/agents/api/mcp.py
+++ b/devops_bench/agents/api/mcp.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 
 import shlex
 from contextlib import AsyncExitStack
+from types import TracebackType
 from typing import Any
 
-from devops_bench.core import MissingDependencyError, get_logger
+from devops_bench.core import get_logger
 
 __all__ = ["MCPClient", "extract_tool_text"]
 
@@ -39,7 +40,8 @@ class MCPClient:
         session: The active ``ClientSession`` once entered, else ``None``.
 
     Raises:
-        MissingDependencyError: If the ``mcp`` SDK is not installed (on enter).
+        ImportError: If the ``mcp`` package is missing (a broken install —
+            ``mcp`` is a required dependency; on enter).
         ValueError: If ``server_path`` is empty or whitespace-only (on enter).
     """
 
@@ -52,8 +54,11 @@ class MCPClient:
         try:
             from mcp.client.session import ClientSession
             from mcp.client.stdio import StdioServerParameters, stdio_client
-        except ImportError as exc:  # pragma: no cover - exercised via MissingDependencyError
-            raise MissingDependencyError("the API agent's MCP client", "mcp") from exc
+        except ImportError as exc:  # pragma: no cover - broken install only
+            raise ImportError(
+                "The API agent's MCP client needs the 'mcp' package, a required "
+                "dependency of devops-bench; reinstall the package to restore it."
+            ) from exc
 
         # Split the command so a multi-word server_path (e.g. "uv run mcp-server")
         # is spawned as program + args rather than a single executable name; the
@@ -66,15 +71,27 @@ class MCPClient:
                 "MCP server command."
             )
         server_params = StdioServerParameters(command=parts[0], args=parts[1:])
-        stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
-        self.read_stream, self.write_stream = stdio_transport
-        self.session = await self.exit_stack.enter_async_context(
-            ClientSession(self.read_stream, self.write_stream)
-        )
-        await self.session.initialize()
+        # Unwind anything already entered (e.g. the spawned server subprocess)
+        # when a later setup step fails — __aexit__ never runs if __aenter__
+        # raises, so cleanup must happen here.
+        try:
+            stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
+            self.read_stream, self.write_stream = stdio_transport
+            self.session = await self.exit_stack.enter_async_context(
+                ClientSession(self.read_stream, self.write_stream)
+            )
+            await self.session.initialize()
+        except BaseException:
+            await self.exit_stack.aclose()
+            raise
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         await self.exit_stack.aclose()
 
     async def list_tools(self) -> Any:

--- a/devops_bench/agents/api/skills.py
+++ b/devops_bench/agents/api/skills.py
@@ -27,19 +27,16 @@ provider SDK, ``mcp``, or ``deepeval``.
 
 from __future__ import annotations
 
-import glob
-import os
 from collections.abc import Iterable
 from typing import Any
 
-from devops_bench.agents.shared.skills import parse_skill_md
+from devops_bench.agents.shared.skills import iter_skills, parse_skill_md
 from devops_bench.core import get_logger
 
 __all__ = [
     "SkillToolInfo",
     "parse_skill_md",
     "discover_skill_tools",
-    "read_skill_file",
 ]
 
 _log = get_logger("agents.api.skills")
@@ -56,35 +53,46 @@ class SkillToolInfo:
     Attributes:
         name: Tool name as exposed to the model (prefixed ``skill_``).
         description: Free-form description shown to the model.
-        inputSchema: JSON schema for arguments; defaults to ``None`` since
-            skills take no arguments today.
+        inputSchema: JSON schema for arguments. Defaults to an empty object
+            schema (skills take no arguments today) — never ``None``, because
+            the Anthropic/OpenAI-style adapters forward the attribute verbatim
+            and those APIs reject a null schema.
     """
 
     def __init__(self, name: str, description: str, inputSchema: Any = None) -> None:  # noqa: N803 - matches MCP tool attr
         self.name = name
         self.description = description
-        self.inputSchema = inputSchema
+        self.inputSchema = (
+            inputSchema if inputSchema is not None else {"type": "object", "properties": {}}
+        )
 
 
 def discover_skill_tools(
     paths: Iterable[str],
 ) -> tuple[list[SkillToolInfo], dict[str, str], list[str]]:
-    """Walk ``paths`` for ``SKILL.md`` files and build tool descriptors.
+    """Discover skills under ``paths`` and build tool descriptors.
+
+    Discovery goes through the shared
+    :func:`~devops_bench.agents.shared.skills.iter_skills` walk, so semantics
+    (expanduser, sorted order, first-wins dedupe, missing paths warned) are
+    identical across harnesses. The file content is captured at discovery time
+    so invoking a skill tool later serves the exact text that was advertised —
+    no re-read, no window for the file to change or vanish mid-run.
 
     Performs blocking filesystem I/O; callers in async contexts should run this
     via :func:`asyncio.to_thread` to keep the event loop responsive.
 
     Args:
         paths: Filesystem locations to search (each is walked recursively for
-            ``SKILL.md`` files). Missing paths are warned and skipped.
+            ``SKILL.md`` files).
 
     Returns:
         A ``(tools, resources, names)`` tuple:
 
         * ``tools`` — :class:`SkillToolInfo` descriptors ready to merge into the
           MCP tool list before formatting.
-        * ``resources`` — map of normalized tool name to source file path,
-          consumed by the agent's dispatch closure.
+        * ``resources`` — map of normalized tool name to the skill file's full
+          content, consumed by the agent's dispatch closure.
         * ``names`` — discovered skill names (the unnormalized values from each
           file's frontmatter); useful for diagnostics.
     """
@@ -92,43 +100,16 @@ def discover_skill_tools(
     resources: dict[str, str] = {}
     names: list[str] = []
 
-    for skills_dir in paths:
-        if not skills_dir:
-            continue
-        if not os.path.exists(skills_dir):
-            _log.warning("Skills directory not found: %s", skills_dir)
-            continue
-        skill_files = glob.glob(os.path.join(skills_dir, "**", "SKILL.md"), recursive=True)
-        for file_path in skill_files:
-            skill_name, description, _ = parse_skill_md(file_path)
-            if not skill_name:
-                continue
-            normalized = "skill_" + skill_name.replace("-", "_")
-            tools.append(
-                SkillToolInfo(
-                    name=normalized,
-                    description=description or f"Exposes skill: {skill_name}",
-                )
+    for skill in iter_skills(paths):
+        normalized = "skill_" + skill.name.replace("-", "_")
+        tools.append(
+            SkillToolInfo(
+                name=normalized,
+                description=skill.description or f"Exposes skill: {skill.name}",
             )
-            resources[normalized] = file_path
-            names.append(skill_name)
-            _log.info("Loaded local skill as tool: %s -> %s", normalized, file_path)
+        )
+        resources[normalized] = skill.content
+        names.append(skill.name)
+        _log.info("Loaded local skill as tool: %s -> %s", normalized, skill.path)
 
     return tools, resources, names
-
-
-def read_skill_file(file_path: str) -> str:
-    """Read a skill file's contents, returning an error string on failure.
-
-    Args:
-        file_path: Path to the skill file to read.
-
-    Returns:
-        The file contents, or an ``Error reading skill file ...`` message when
-        the file cannot be read.
-    """
-    try:
-        with open(file_path, encoding="utf-8") as f:
-            return f.read()
-    except OSError as exc:
-        return f"Error reading skill file {file_path}: {exc}"

--- a/devops_bench/agents/shared/cli_capabilities.py
+++ b/devops_bench/agents/shared/cli_capabilities.py
@@ -28,7 +28,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from devops_bench.agents.shared.skills import parse_skill_md
+from devops_bench.agents.shared.skills import iter_skills
 from devops_bench.core import get_logger
 
 if TYPE_CHECKING:
@@ -115,27 +115,19 @@ def materialize_skills(skills_root: Path, paths: tuple[str, ...]) -> list[str]:
 
     Args:
         skills_root: The destination skills directory to populate.
-        paths: Skill source directories to walk recursively. Missing paths are
-            warned and skipped (matching the API agent's discovery semantic).
+        paths: Skill source directories, discovered via the shared
+            :func:`~devops_bench.agents.shared.skills.iter_skills` walk
+            (expanduser, sorted order, escaping/duplicate names warned and
+            skipped, missing paths warned).
 
     Returns:
         The names of the skills materialized, in discovery order.
     """
     written: list[str] = []
-    for raw_path in paths:
-        if not raw_path:
-            continue
-        source = Path(os.path.expanduser(raw_path))
-        if not source.exists():
-            _log.warning("Skills directory not found: %s", source)
-            continue
-        for skill_file in sorted(source.rglob(_SKILL_FILE)):
-            name, _description, content = parse_skill_md(str(skill_file))
-            if not name or content is None:
-                continue
-            dest_dir = skills_root / name
-            dest_dir.mkdir(parents=True, exist_ok=True)
-            (dest_dir / _SKILL_FILE).write_text(content, encoding="utf-8")
-            written.append(name)
-            _log.info("Linked skill %s -> %s", name, dest_dir)
+    for skill in iter_skills(paths):
+        dest_dir = skills_root / skill.name
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / _SKILL_FILE).write_text(skill.content, encoding="utf-8")
+        written.append(skill.name)
+        _log.info("Linked skill %s -> %s", skill.name, dest_dir)
     return written

--- a/devops_bench/agents/shared/skills.py
+++ b/devops_bench/agents/shared/skills.py
@@ -22,17 +22,96 @@ into the other's package. Importing this module pulls no provider SDK.
 
 from __future__ import annotations
 
+import os
 import re
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import NamedTuple
 
 import yaml
 
 from devops_bench.core import get_logger
 
-__all__ = ["parse_skill_md"]
+__all__ = ["SkillFile", "iter_skills", "parse_skill_md"]
 
 _log = get_logger("agents.shared.skills")
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL | re.MULTILINE)
+
+_SKILL_FILE = "SKILL.md"
+
+
+class SkillFile(NamedTuple):
+    """One discovered skill: its frontmatter fields plus source location.
+
+    Attributes:
+        name: The ``name`` declared in the file's frontmatter.
+        description: The ``description`` declared in the frontmatter, or ``None``.
+        content: The full file text (frontmatter + body).
+        path: Absolute or as-given path to the source ``SKILL.md``.
+    """
+
+    name: str
+    description: str | None
+    content: str
+    path: str
+
+
+def iter_skills(paths: Iterable[str]) -> Iterator[SkillFile]:
+    """Discover ``SKILL.md`` files beneath ``paths`` with the shared semantics.
+
+    Every harness discovers skills through this single walk so behavior cannot
+    diverge per agent flavor:
+
+    * each path is ``os.path.expanduser``-expanded (``~/skills`` works),
+    * empty path strings are skipped, missing directories are warned and
+      skipped,
+    * files are visited in ``sorted(rglob)`` order for determinism,
+    * names carrying a path separator, ``..``, or an absolute prefix are
+      warned and skipped — consumers use the name as a directory or tool
+      name, and such a name would escape the destination root,
+    * duplicate skill names are first-wins with a warning,
+    * files with no parseable ``name`` are skipped.
+
+    Args:
+        paths: Skill source directories to walk recursively.
+
+    Yields:
+        A :class:`SkillFile` per unique, parseable skill, in discovery order.
+    """
+    seen: set[str] = set()
+    for raw_path in paths:
+        if not raw_path:
+            continue
+        source = Path(os.path.expanduser(raw_path))
+        if not source.exists():
+            _log.warning("Skills directory not found: %s", source)
+            continue
+        for skill_file in sorted(source.rglob(_SKILL_FILE)):
+            name, description, content = parse_skill_md(str(skill_file))
+            if not name or content is None:
+                continue
+            # Path("..").name is ".." itself, so ".." needs its own rejection.
+            if name == ".." or name != Path(name).name:
+                _log.warning(
+                    "Skipping skill %r from %s: name must not contain path separators, "
+                    "'..', or an absolute prefix",
+                    name,
+                    skill_file,
+                )
+                continue
+            if name in seen:
+                _log.warning(
+                    "Skipping duplicate skill %r from %s: already discovered from an "
+                    "earlier source",
+                    name,
+                    skill_file,
+                )
+                continue
+            seen.add(name)
+            yield SkillFile(
+                name=name, description=description, content=content, path=str(skill_file)
+            )
 
 
 def parse_skill_md(file_path: str) -> tuple[str | None, str | None, str | None]:

--- a/tests/unit/agents/api/test_agents_api_agent.py
+++ b/tests/unit/agents/api/test_agents_api_agent.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Any
@@ -157,6 +158,30 @@ def test_api_agent_registered_under_canonical_key():
     assert AGENTS.get("api") is ApiAgent
 
 
+def test_package_import_alone_registers_api_agent():
+    """``import devops_bench.agents.api`` (no ``.agent`` submodule import) must
+    register the harness — the documented consumer convention resolves via
+    ``AGENTS.get`` after a package import. Runs in a fresh interpreter because
+    this test module itself imports ``.agent``, which would mask a regression
+    (review finding: the package ``__init__`` didn't import the module, so the
+    registration decorator never ran)."""
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import devops_bench.agents.api
+        from devops_bench.agents.base import AGENTS
+        assert AGENTS.get("api").__name__ == "ApiAgent"
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+
+
 # ---------------------------------------------------------------------------
 # fold_trajectory
 # ---------------------------------------------------------------------------
@@ -242,6 +267,55 @@ def test_fold_trajectory_handles_none_args_and_none_call_id():
     assert fold_trajectory(contents) == [
         {"name": "t", "args": {}, "result": None, "status": "called"},
     ]
+
+
+def test_fold_trajectory_pairs_unkeyed_gemini_style_calls_fifo():
+    """Gemini emits every function call with ``id=None`` and ``run_tool_loop``
+    appends one result per call in order — the fold must pair them FIFO
+    instead of dropping every result as an orphan (review finding: the default
+    provider produced all-'called' trajectories and errored every clean run)."""
+    contents = [
+        {"role": "user", "content": "g"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"name": "alpha", "args": {"a": 1}, "id": None},
+                {"name": "beta", "args": {"b": 2}, "id": None},
+            ],
+        },
+        {"role": "tool", "tool_call_id": None, "name": "alpha", "content": "A-result"},
+        {"role": "tool", "tool_call_id": None, "name": "beta", "content": "Error: b"},
+        {"role": "assistant", "content": "done"},
+    ]
+    from devops_bench.agents.api.agent import _fold_with_extraction_errors
+
+    folded, orphans = _fold_with_extraction_errors(contents)
+    assert orphans == []
+    assert folded == [
+        {"name": "alpha", "args": {"a": 1}, "result": "A-result", "status": "completed"},
+        {"name": "beta", "args": {"b": 2}, "result": "Error: b", "status": "error"},
+    ]
+
+
+def test_fold_trajectory_extra_unkeyed_result_is_still_an_orphan():
+    """Id-less results beyond the number of id-less calls stay orphans —
+    FIFO pairing must not absorb genuinely unmatched results."""
+    contents = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "t", "args": {}, "id": None}],
+        },
+        {"role": "tool", "tool_call_id": None, "name": "t", "content": "paired"},
+        {"role": "tool", "tool_call_id": None, "name": "ghost", "content": "stray"},
+    ]
+    from devops_bench.agents.api.agent import _fold_with_extraction_errors
+
+    folded, orphans = _fold_with_extraction_errors(contents)
+    assert folded == [{"name": "t", "args": {}, "result": "paired", "status": "completed"}]
+    assert len(orphans) == 1
+    assert "stray" in orphans[0]
 
 
 def test_fold_trajectory_drops_unpaired_tool_results_silently_from_trajectory():
@@ -558,6 +632,36 @@ def test_execute_dispatch_error_lands_in_errors_and_continues(monkeypatch):
     ]
 
 
+def test_execute_marks_mcp_iserror_result_as_error(monkeypatch):
+    """An MCP server reporting failure via ``CallToolResult.isError`` (rather
+    than raising) must fold as ``status="error"`` and land on ``errors`` —
+    previously the flag was ignored and failures scored as completed (review
+    finding)."""
+
+    class _IsErrorMCP(_FakeMCPClient):
+        async def call_tool(self, name: str, arguments: dict) -> Any:
+            block = SimpleNamespace(text="unknown pod foo")
+            return SimpleNamespace(content=[block], isError=True)
+
+    fc = [{"name": "get_pod", "args": {}, "id": "c1"}]
+    fake = _FakeLLMClient([_Turn(text="trying", calls=fc), _Turn(text="giving up")])
+    mcp = _IsErrorMCP(tools=[SimpleNamespace(name="get_pod", description="d", inputSchema=None)])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+
+    result = ApiAgent(AgentConfig(capabilities=_mcp_caps("server"))).run("ping")
+
+    assert any("Error calling tool get_pod" in e for e in result.errors)
+    assert result.trajectory == [
+        {
+            "name": "get_pod",
+            "args": {},
+            "result": "Error: unknown pod foo",
+            "status": "error",
+        },
+    ]
+
+
 def test_execute_records_missing_mcp_when_tool_requested_without_server(monkeypatch):
     """No MCP server, but the model still requests a tool → recorded, not crashed."""
     fc = [{"name": "ghost", "args": {}, "id": "c2"}]
@@ -610,7 +714,8 @@ def test_execute_skills_discover_without_mcp(monkeypatch, tmp_path):
     result = ApiAgent(cfg).run("p")
 
     assert result.errors == []  # skill dispatch hit the file, not the MCP error
-    # ``read_skill_file`` returns the whole file (frontmatter + body) so the
+    # Dispatch serves the whole file (frontmatter + body) captured at
+    # discovery so the
     # model can read either as it sees fit — matches the legacy semantic.
     assert result.trajectory == [
         {
@@ -641,25 +746,23 @@ def test_execute_no_skills_no_mcp_runs_tool_less(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_execute_returns_errored_on_mcpclient_value_error(monkeypatch):
-    """A ``ValueError`` from ``MCPClient.__aenter__`` (e.g. an unspawnable
-    server command) must convert to an errored :class:`AgentResult` rather
-    than bubbling through the base safety net.
+def test_execute_lets_value_error_reach_base_safety_net(monkeypatch):
+    """A ``ValueError`` raised inside the run (MCP setup, provider adapter,
+    anywhere) must bubble to :meth:`AgentHarness.run`'s safety net, which logs
+    the full traceback and converts to an errored result tagged with the
+    exception type.
 
-    After PR3's ``shlex.join`` fix, a whitespace-only binding command is no
-    longer lossy-collapsed to ``""``, so the *binding* path no longer
-    triggers MCPClient's empty-string guard naturally. We instead patch
-    ``MCPClient`` to raise the same ``ValueError`` directly, which exercises
-    the agent-side conversion path.
+    The agent previously intercepted ``ValueError`` itself "for empty MCP
+    commands" — a case its own pre-guard makes unreachable — thereby swallowing
+    unrelated ValueErrors without a traceback (review finding); the catch is
+    gone.
     """
 
     class _BoomMCP:
         def __init__(self, _path: str) -> None: ...
 
         async def __aenter__(self) -> _BoomMCP:
-            raise ValueError(
-                "MCP server_path is empty; set AGENT_MCP_SERVER to the MCP server command."
-            )
+            raise ValueError("bad provider argument")
 
         async def __aexit__(self, *_a: Any) -> None: ...
 
@@ -672,9 +775,72 @@ def test_execute_returns_errored_on_mcpclient_value_error(monkeypatch):
     )
     result = ApiAgent(AgentConfig(capabilities=caps)).run("p")
     assert result.has_errors()
-    assert "MCP server_path is empty" in result.errors[0]
-    # The base safety net was NOT used (we converted the ValueError ourselves).
+    # The base safety net formats as "<ExcType>: <msg>" — proof it was used.
+    assert result.errors[0] == "ValueError: bad provider argument"
     assert result.output.startswith("Error: ")
+
+
+def test_execute_times_out_via_config_timeout_sec(monkeypatch):
+    """``AgentConfig.timeout_sec`` must bound the whole run — a hanging MCP
+    server or provider call converts to an errored result at the deadline
+    instead of wedging the benchmark (review finding: the field was ignored)."""
+
+    async def _hang(*_a: Any, **_kw: Any):
+        await asyncio.sleep(30)
+
+    monkeypatch.setattr(agent_mod, "_run_async", _hang)
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: _FakeLLMClient([]))
+
+    result = ApiAgent(AgentConfig(timeout_sec=0.05)).run("p")
+    assert result.has_errors()
+    assert "timed out after 0.05s" in result.errors[0]
+
+
+def test_execute_reraises_internal_timeout_before_deadline(monkeypatch):
+    """A ``TimeoutError`` from inside the run (e.g. a provider socket timeout —
+    ``socket.timeout`` is ``TimeoutError`` since 3.10) raised well before the
+    configured deadline must not be relabeled as the agent-level timeout: it
+    re-raises to the base safety net, which tags the exception type and logs
+    the traceback."""
+
+    async def _boom(*_a: Any, **_kw: Any):
+        raise TimeoutError("socket read timed out")
+
+    monkeypatch.setattr(agent_mod, "_run_async", _boom)
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: _FakeLLMClient([]))
+
+    result = ApiAgent(AgentConfig(timeout_sec=600.0)).run("p")
+    assert result.has_errors()
+    assert result.errors[0] == "TimeoutError: socket read timed out"
+
+
+def test_execute_honors_max_turns_zero(monkeypatch):
+    """``max_turns=0`` means zero model turns — it must not be silently
+    replaced by the 50-turn default via a falsy-``or`` (review finding)."""
+    fake = _FakeLLMClient([_Turn(text="never called")])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    result = ApiAgent(AgentConfig(max_turns=0)).run("p")
+    # The loop never invoked the model.
+    assert fake.calls == []
+    assert result.output == ""
+
+
+def test_execute_warns_when_extra_mcp_servers_dropped(monkeypatch, caplog):
+    """Only the first MCP binding is honored (documented aggregate behavior);
+    dropping servers 2..N must at least be visible in the logs."""
+    fake = _FakeLLMClient([_Turn(text="ok")])
+    mcp = _FakeMCPClient(tools=[])
+    monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
+    monkeypatch.setattr(agent_mod, "MCPClient", lambda _path: mcp)
+    caps = AllCapabilities(
+        mcp_servers=(
+            McpBinding(name="one", command=("server-a",)),
+            McpBinding(name="two", command=("server-b",)),
+        ),
+    )
+    with caplog.at_level("WARNING", logger="devops_bench.agents.api.agent"):
+        ApiAgent(AgentConfig(capabilities=caps)).run("p")
+    assert any("only the first MCP binding" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/agents/api/test_agents_api_mcp.py
+++ b/tests/unit/agents/api/test_agents_api_mcp.py
@@ -55,6 +55,42 @@ def test_mcp_client_enter_rejects_empty_server_path():
         asyncio.run(client.__aenter__())
 
 
+def test_aenter_unwinds_exit_stack_when_session_setup_fails(monkeypatch):
+    """If session setup fails after the stdio transport spawned the server,
+    ``__aenter__`` must unwind its exit stack — ``__aexit__`` never runs when
+    ``__aenter__`` raises, so without the unwind the server subprocess leaks
+    (regression for the review finding)."""
+    import mcp.client.session as session_mod
+    import mcp.client.stdio as stdio_mod
+
+    state = {"transport_exited": False}
+
+    class _Transport:
+        def __init__(self, _params) -> None: ...
+
+        async def __aenter__(self):
+            return (SimpleNamespace(), SimpleNamespace())
+
+        async def __aexit__(self, *_a) -> None:
+            state["transport_exited"] = True
+
+    class _BoomSession:
+        def __init__(self, _r, _w) -> None: ...
+
+        async def __aenter__(self):
+            raise RuntimeError("handshake failed")
+
+        async def __aexit__(self, *_a) -> None: ...
+
+    monkeypatch.setattr(stdio_mod, "stdio_client", lambda params: _Transport(params))
+    monkeypatch.setattr(session_mod, "ClientSession", _BoomSession)
+
+    client = MCPClient("server")
+    with pytest.raises(RuntimeError, match="handshake failed"):
+        asyncio.run(client.__aenter__())
+    assert state["transport_exited"] is True
+
+
 def test_call_tool_degrades_gracefully_when_deepeval_missing(monkeypatch):
     """If ``deepeval`` is not installed, ``call_tool`` still works (untraced).
 

--- a/tests/unit/agents/api/test_agents_api_skills.py
+++ b/tests/unit/agents/api/test_agents_api_skills.py
@@ -20,7 +20,6 @@ from devops_bench.agents.api.skills import (
     SkillToolInfo,
     discover_skill_tools,
     parse_skill_md,
-    read_skill_file,
 )
 
 
@@ -83,14 +82,17 @@ def test_discover_skill_tools_missing_path_is_skipped(tmp_path):
 def test_discover_skill_tools_normalizes_dashes_to_underscores(tmp_path):
     skill = tmp_path / "first" / "SKILL.md"
     skill.parent.mkdir(parents=True)
-    skill.write_text('---\nname: "my-cool-skill"\ndescription: ok\n---\nbody\n')
+    body = '---\nname: "my-cool-skill"\ndescription: ok\n---\nbody\n'
+    skill.write_text(body)
 
     tools, resources, names = discover_skill_tools((str(tmp_path),))
     assert len(tools) == 1
     assert isinstance(tools[0], SkillToolInfo)
     assert tools[0].name == "skill_my_cool_skill"
     assert tools[0].description == "ok"
-    assert resources == {"skill_my_cool_skill": str(skill)}
+    # Resources carry the file *content* captured at discovery, so dispatch
+    # serves exactly what was advertised with no re-read / TOCTOU window.
+    assert resources == {"skill_my_cool_skill": body}
     assert names == ["my-cool-skill"]
 
 
@@ -121,16 +123,42 @@ def test_discover_skill_tools_skips_empty_path_strings(tmp_path):
     assert tools == []
 
 
-def test_read_skill_file_returns_contents(tmp_path):
-    f = tmp_path / "SKILL.md"
-    f.write_text("hello, skill")
-    assert read_skill_file(str(f)) == "hello, skill"
+def test_skill_tool_info_defaults_to_empty_object_schema():
+    """``inputSchema`` must never be ``None`` — the Anthropic/OpenAI-style
+    adapters forward the attribute verbatim and those APIs reject a null
+    schema (regression for the review finding that broke every skills-enabled
+    Anthropic run on turn 1)."""
+    tool = SkillToolInfo(name="skill_x", description="d")
+    assert tool.inputSchema == {"type": "object", "properties": {}}
+    # Fresh dict per instance — no shared mutable default.
+    assert SkillToolInfo(name="skill_y", description="d").inputSchema is not tool.inputSchema
 
 
-def test_read_skill_file_returns_error_message_when_missing():
-    out = read_skill_file("/no/such/file")
-    assert out.startswith("Error reading skill file")
-    assert "/no/such/file" in out
+def test_discover_skill_tools_expands_user_home(tmp_path, monkeypatch):
+    """A ``~/...`` skills path must work — the shared walk expanduser-expands it
+    (previously the API agent warned-and-skipped where CLI agents loaded it)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    skill = tmp_path / "sk" / "demo" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text('---\nname: "home-skill"\ndescription: d\n---\nbody\n')
+    tools, _resources, names = discover_skill_tools(("~/sk",))
+    assert [t.name for t in tools] == ["skill_home_skill"]
+    assert names == ["home-skill"]
+
+
+def test_discover_skill_tools_dedupes_duplicate_names_first_wins(tmp_path):
+    """Duplicate skill names are first-wins in sorted order (shared-walk
+    semantics) — previously both were advertised and the resources map was
+    last-wins, nondeterministically."""
+    for d, desc in [("a", "first"), ("b", "second")]:
+        f = tmp_path / d / "SKILL.md"
+        f.parent.mkdir(parents=True)
+        f.write_text(f'---\nname: "dup"\ndescription: {desc}\n---\nbody-{d}\n')
+    tools, resources, names = discover_skill_tools((str(tmp_path),))
+    assert len(tools) == 1
+    assert tools[0].description == "first"
+    assert resources["skill_dup"].endswith("body-a\n")
+    assert names == ["dup"]
 
 
 def test_skills_module_pulls_no_heavy_dependencies():

--- a/tests/unit/agents/shared/test_cli_capabilities.py
+++ b/tests/unit/agents/shared/test_cli_capabilities.py
@@ -69,6 +69,53 @@ def test_materialize_skills_writes_named_skill_files(tmp_path: Path):
     assert "body" in copied.read_text(encoding="utf-8")
 
 
+def test_materialize_skills_rejects_malicious_names(tmp_path: Path, caplog) -> None:
+    """Frontmatter names that would escape ``skills_root`` are warned and skipped."""
+    src = tmp_path / "src"
+    abs_escape = tmp_path / "abs-escape"
+    bad_names = ("../rel-escape", str(abs_escape), "nested/name", "..")
+    for index, bad_name in enumerate(bad_names):
+        skill_dir = src / f"skill{index}"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {bad_name}\ndescription: d\n---\nbody\n", encoding="utf-8"
+        )
+    good = src / "zz-good"
+    good.mkdir(parents=True)
+    (good / "SKILL.md").write_text(
+        "---\nname: good-skill\ndescription: d\n---\nbody\n", encoding="utf-8"
+    )
+    dest = tmp_path / "skills" / "dest"
+
+    written = materialize_skills(dest, (str(src),))
+
+    assert written == ["good-skill"]
+    assert not (tmp_path / "skills" / "rel-escape").exists()
+    assert not abs_escape.exists()
+    assert sorted(p.name for p in dest.iterdir()) == ["good-skill"]
+    assert "Skipping skill '../rel-escape'" in caplog.text
+
+
+def test_materialize_skills_warns_and_keeps_first_on_duplicate_names(
+    tmp_path: Path, caplog
+) -> None:
+    """A second SKILL.md with an already-seen name is skipped, not overwritten."""
+    first = tmp_path / "src1" / "dup"
+    second = tmp_path / "src2" / "dup"
+    for source_dir, body in ((first, "first body"), (second, "second body")):
+        source_dir.mkdir(parents=True)
+        (source_dir / "SKILL.md").write_text(
+            f"---\nname: dup-skill\ndescription: d\n---\n{body}\n", encoding="utf-8"
+        )
+    dest = tmp_path / "dest"
+
+    written = materialize_skills(dest, (str(tmp_path / "src1"), str(tmp_path / "src2")))
+
+    assert written == ["dup-skill"]
+    assert "first body" in (dest / "dup-skill" / "SKILL.md").read_text(encoding="utf-8")
+    assert "Skipping duplicate skill 'dup-skill'" in caplog.text
+
+
 def test_materialize_skills_skips_missing_paths(tmp_path: Path):
     """A non-existent source path is warned and skipped, not fatal."""
     assert materialize_skills(tmp_path / "dest", (str(tmp_path / "nope"),)) == []


### PR DESCRIPTION
Diffs vs the previous agents/api implementation:
- agents/api/__init__.py imports the agent module, so importing the package registers "api" in AGENTS (matches the CLI harness packages; AGENTS.get("api") previously raised NotRegisteredError)
- fold_trajectory pairs id-less (Gemini-style) tool calls with id-less results FIFO instead of dropping every result as an orphan; clean Gemini runs no longer report has_errors()
- the dispatcher checks CallToolResult.isError and folds server-side tool failures as status="error" (previously scored "completed")
- AgentConfig.timeout_sec bounds the whole run via asyncio.wait_for (previously ignored — a hanging MCP server wedged the benchmark)
- max_turns=0 is honored (previously falsy-or coerced to the 50 default)
- the unreachable 'except ValueError' is gone; errors reach the base safety net and keep their tracebacks
- MCPClient.__aenter__ unwinds its exit stack when session setup fails (previously leaked the spawned server subprocess)
- MCPClient raises a plain ImportError naming mcp as a required dependency (the old MissingDependencyError advertised a nonexistent [mcp] extra)
- SkillToolInfo.inputSchema defaults to an empty object schema; None previously reached the Anthropic/Ollama APIs verbatim and 400'd every skills-enabled run on turn 1
- skill discovery goes through a new shared iter_skills walk (expanduser, sorted order, first-wins dedupe with warning) consumed by both materialize_skills and discover_skill_tools; dispatch serves the content captured at discovery, deleting read_skill_file and its unprefixed error string (reads no longer misfold as "completed")
- _execute warns when MCP servers beyond the first binding are dropped
- typing: _build_dispatch returns ToolDispatcher; __aexit__ params typed
- _execute docstring now states tokens reflect the final turn only

Left undone (follow-ups, deliberately out of scope):
- structured is_error flag on the loop's tool messages to replace the "Error: " string-prefix protocol (needs a models/utils/loop change, upstream-first since that path is flipped)
- per-turn token accumulation in run_tool_loop (tokens stay final-turn only, now documented instead of misdocumented)
- multi-server MCP sessions and McpBinding.tools enforcement (documented aggregate behavior; a warning now surfaces the drop)
- async-aware harness bridging (asyncio.run still breaks under a running event loop)
- cleanup: dedupe the MCP-on/off branches of _run_async, cache the get_model client per harness instance, hoist the per-call deepeval observe import