### PR TITLE
chore(migration): flip content-ready paths into the frontier

### DIFF
--- a/devops_bench/agents/api/skills.py
+++ b/devops_bench/agents/api/skills.py
@@ -75,9 +75,11 @@ def discover_skill_tools(
     Discovery goes through the shared
     :func:`~devops_bench.agents.shared.skills.iter_skills` walk, so semantics
     (expanduser, sorted order, first-wins dedupe, missing paths warned) are
-    identical across harnesses. The file content is captured at discovery time
-    so invoking a skill tool later serves the exact text that was advertised —
-    no re-read, no window for the file to change or vanish mid-run.
+    identical across harnesses; names that collide after tool-name
+    normalization are additionally deduped here, first-wins with a warning.
+    The file content is captured at discovery time so invoking a skill tool
+    later serves the exact text that was advertised — no re-read, no window
+    for the file to change or vanish mid-run.
 
     Performs blocking filesystem I/O; callers in async contexts should run this
     via :func:`asyncio.to_thread` to keep the event loop responsive.
@@ -99,9 +101,23 @@ def discover_skill_tools(
     tools: list[SkillToolInfo] = []
     resources: dict[str, str] = {}
     names: list[str] = []
+    seen_normalized: set[str] = set()
 
     for skill in iter_skills(paths):
         normalized = "skill_" + skill.name.replace("-", "_")
+        # iter_skills dedupes raw names, but distinct raw names can still
+        # normalize to the same tool name (``my-skill`` vs ``my_skill``) —
+        # first wins, so the advertised tool list never carries duplicates and
+        # ``resources`` is never silently overwritten.
+        if normalized in seen_normalized:
+            _log.warning(
+                "Skipping skill %r from %s: normalized tool name %r collides with an earlier skill",
+                skill.name,
+                skill.path,
+                normalized,
+            )
+            continue
+        seen_normalized.add(normalized)
         tools.append(
             SkillToolInfo(
                 name=normalized,

--- a/devops_bench/agents/shared/skills.py
+++ b/devops_bench/agents/shared/skills.py
@@ -28,7 +28,8 @@ from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import NamedTuple
 
-import yaml
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
 
 from devops_bench.core import get_logger
 
@@ -39,6 +40,10 @@ _log = get_logger("agents.shared.skills")
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL | re.MULTILINE)
 
 _SKILL_FILE = "SKILL.md"
+
+# YAML 1.2 semantics (matching tasks/loader.py): only ``true``/``false`` are
+# booleans, so a description like ``yes`` stays a plain string.
+_yaml = YAML(typ="safe")
 
 
 class SkillFile(NamedTuple):
@@ -117,9 +122,9 @@ def iter_skills(paths: Iterable[str]) -> Iterator[SkillFile]:
 def parse_skill_md(file_path: str) -> tuple[str | None, str | None, str | None]:
     """Parse a ``SKILL.md`` file's YAML frontmatter.
 
-    The frontmatter block is parsed with :func:`yaml.safe_load`, so multi-line
-    block scalars (e.g. a ``description: >-`` spanning several lines) are read
-    in full rather than truncated to the first line.
+    The frontmatter block is parsed as safe YAML, so multi-line block scalars
+    (e.g. a ``description: >-`` spanning several lines) are read in full
+    rather than truncated to the first line.
 
     Args:
         file_path: Path to a skill markdown file.
@@ -141,8 +146,8 @@ def parse_skill_md(file_path: str) -> tuple[str | None, str | None, str | None]:
         return None, None, None
 
     try:
-        frontmatter = yaml.safe_load(match.group(1))
-    except yaml.YAMLError as exc:
+        frontmatter = _yaml.load(match.group(1))
+    except YAMLError as exc:
         _log.warning("Invalid YAML frontmatter in skill file %s: %s", file_path, exc)
         return None, None, content
 

--- a/migrated.bara.sky
+++ b/migrated.bara.sky
@@ -81,13 +81,17 @@ MIGRATED = [
     "devops_bench/agents/cli/gemini_cli/**",
     "devops_bench/agents/cli/__init__.py",
     # "tests/unit/agents/test_agents_cli_gemini.py",
+    # PR: antigravity CLI agent (merged upstream from an older revision; flips once the
+    # newer gke-labs content is exported and reaches blob parity)
+    # "devops_bench/agents/cli/antigravity/**",
+    # "tests/unit/agents/test_agents_cli_antigravity.py",
     # PR: openclaw CLI agent + agents shared + chaos base
     # (chaos base replaces upstream agents/chaos/ — git rm the 3 superseded files in this PR)
     # "devops_bench/agents/cli/openclaw/**",
     # "tests/unit/agents/test_agents_cli_openclaw.py",
     # "tests/unit/agents/test_legacy_openclaw_tokens.py",
-    # "devops_bench/agents/shared/**",
-    # "tests/unit/agents/shared/**",
+    "devops_bench/agents/shared/**",
+    "tests/unit/agents/shared/**",
     # "devops_bench/chaos/base.py",
     # "devops_bench/chaos/agent.py",
     # "devops_bench/chaos/schema.py",
@@ -126,14 +130,14 @@ MIGRATED = [
 
     # --- Wave 5: concretes on the components (parallel; one batched PR per owner — pr-plan.md §3.2) ---
     # PR: API agent + MCP client (mcp.py's only importer is the API agent, so it travels here)
-    # "devops_bench/agents/api/agent.py",
-    # "devops_bench/agents/api/skills.py",
-    # "devops_bench/agents/api/mcp.py",
-    # "devops_bench/agents/api/__init__.py",
-    # "tests/unit/agents/api/test_agents_api_agent.py",
-    # "tests/unit/agents/api/test_agents_api_skills.py",
-    # "tests/unit/agents/api/test_agents_api_mcp.py",
-    # "tests/unit/agents/api/test_agents_api_import_hygiene.py",
+    "devops_bench/agents/api/agent.py",
+    "devops_bench/agents/api/skills.py",
+    "devops_bench/agents/api/mcp.py",
+    "devops_bench/agents/api/__init__.py",
+    "tests/unit/agents/api/test_agents_api_agent.py",
+    "tests/unit/agents/api/test_agents_api_skills.py",
+    "tests/unit/agents/api/test_agents_api_mcp.py",
+    "tests/unit/agents/api/test_agents_api_import_hygiene.py",
     # PR: chaos concretes (generate-load fault + time-delay trigger)
     # "devops_bench/chaos/faults/**",
     # "tests/unit/chaos/test_generate_load.py",
@@ -158,6 +162,10 @@ MIGRATED = [
     # "devops_bench/metrics/outcome_validity.py",
     # "devops_bench/metrics/chaos_metrics.py",
     # "tests/unit/metrics/test_metrics_chaos.py",
+    # PR: composite outcome score (added upstream first; no gke-labs copy predates it, so the
+    # back-sync materializes both files here)
+    "devops_bench/metrics/scoring.py",
+    "tests/unit/metrics/test_metrics_scoring.py",
 
     # --- Wave 6: harness base + scenario, and module docs/skills (each after its module lands) ---
     # "devops_bench/evalharness/base.py",

--- a/tests/unit/agents/api/__init__.py
+++ b/tests/unit/agents/api/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/agents/api/test_agents_api_agent.py
+++ b/tests/unit/agents/api/test_agents_api_agent.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -154,11 +155,11 @@ class _FakeMCPClient:
 # ---------------------------------------------------------------------------
 
 
-def test_api_agent_registered_under_canonical_key():
+def test_api_agent_registered_under_canonical_key() -> None:
     assert AGENTS.get("api") is ApiAgent
 
 
-def test_package_import_alone_registers_api_agent():
+def test_package_import_alone_registers_api_agent() -> None:
     """``import devops_bench.agents.api`` (no ``.agent`` submodule import) must
     register the harness — the documented consumer convention resolves via
     ``AGENTS.get`` after a package import. Runs in a fresh interpreter because
@@ -187,7 +188,7 @@ def test_package_import_alone_registers_api_agent():
 # ---------------------------------------------------------------------------
 
 
-def test_fold_trajectory_pairs_assistant_calls_with_tool_results():
+def test_fold_trajectory_pairs_assistant_calls_with_tool_results() -> None:
     contents = [
         {"role": "user", "content": "g"},
         {
@@ -208,7 +209,7 @@ def test_fold_trajectory_pairs_assistant_calls_with_tool_results():
     ]
 
 
-def test_fold_trajectory_marks_dispatcher_errors_as_error_status():
+def test_fold_trajectory_marks_dispatcher_errors_as_error_status() -> None:
     # The dispatcher returns ``"Error: ..."`` for a failed tool call (matching
     # the agent's _build_dispatch contract) — folding must surface that as the
     # ``"error"`` status so metrics see the failure mode, not a clean call.
@@ -228,7 +229,7 @@ def test_fold_trajectory_marks_dispatcher_errors_as_error_status():
     ]
 
 
-def test_fold_trajectory_leaves_unmatched_call_as_called_status():
+def test_fold_trajectory_leaves_unmatched_call_as_called_status() -> None:
     # If a result never lands (e.g. dispatch raised before appending), the call
     # entry survives with ``status="called"`` and ``result=None`` rather than
     # being silently dropped.
@@ -245,7 +246,7 @@ def test_fold_trajectory_leaves_unmatched_call_as_called_status():
     ]
 
 
-def test_fold_trajectory_skips_text_only_turns():
+def test_fold_trajectory_skips_text_only_turns() -> None:
     contents = [
         {"role": "user", "content": "hi"},
         {"role": "assistant", "content": "hello"},
@@ -254,7 +255,7 @@ def test_fold_trajectory_skips_text_only_turns():
     assert fold_trajectory(contents) == []
 
 
-def test_fold_trajectory_handles_none_args_and_none_call_id():
+def test_fold_trajectory_handles_none_args_and_none_call_id() -> None:
     # Defensive: missing ``args`` becomes ``{}``; an entry with no ``id`` is
     # emitted as ``status="called"`` (no result to pair with).
     contents = [
@@ -269,7 +270,7 @@ def test_fold_trajectory_handles_none_args_and_none_call_id():
     ]
 
 
-def test_fold_trajectory_pairs_unkeyed_gemini_style_calls_fifo():
+def test_fold_trajectory_pairs_unkeyed_gemini_style_calls_fifo() -> None:
     """Gemini emits every function call with ``id=None`` and ``run_tool_loop``
     appends one result per call in order — the fold must pair them FIFO
     instead of dropping every result as an orphan (review finding: the default
@@ -298,7 +299,7 @@ def test_fold_trajectory_pairs_unkeyed_gemini_style_calls_fifo():
     ]
 
 
-def test_fold_trajectory_extra_unkeyed_result_is_still_an_orphan():
+def test_fold_trajectory_extra_unkeyed_result_is_still_an_orphan() -> None:
     """Id-less results beyond the number of id-less calls stay orphans —
     FIFO pairing must not absorb genuinely unmatched results."""
     contents = [
@@ -318,7 +319,7 @@ def test_fold_trajectory_extra_unkeyed_result_is_still_an_orphan():
     assert "stray" in orphans[0]
 
 
-def test_fold_trajectory_drops_unpaired_tool_results_silently_from_trajectory():
+def test_fold_trajectory_drops_unpaired_tool_results_silently_from_trajectory() -> None:
     """An orphan ``role: tool`` (no matching assistant call_id) is dropped from
     the canonical trajectory — synthesizing a free-floating entry would break
     the "every trajectory item is a real ToolCall the model issued" invariant
@@ -333,7 +334,7 @@ def test_fold_trajectory_drops_unpaired_tool_results_silently_from_trajectory():
     assert fold_trajectory(contents) == []
 
 
-def test_fold_with_extraction_errors_surfaces_orphan_results():
+def test_fold_with_extraction_errors_surfaces_orphan_results() -> None:
     from devops_bench.agents.api.agent import _fold_with_extraction_errors
 
     contents = [
@@ -352,7 +353,7 @@ def test_fold_with_extraction_errors_surfaces_orphan_results():
 # ---------------------------------------------------------------------------
 
 
-def test_extract_tokens_reads_usage_metadata():
+def test_extract_tokens_reads_usage_metadata() -> None:
     usage = SimpleNamespace(prompt_token_count=3, candidates_token_count=5, total_token_count=8)
     response = SimpleNamespace(usage_metadata=usage)
     assert extract_tokens(response) == {
@@ -362,7 +363,7 @@ def test_extract_tokens_reads_usage_metadata():
     }
 
 
-def test_extract_tokens_falls_back_to_usage_attribute():
+def test_extract_tokens_falls_back_to_usage_attribute() -> None:
     usage = SimpleNamespace(prompt_token_count=1, candidates_token_count=2, total_token_count=3)
     # No ``usage_metadata``; the function should still find ``usage``.
     response = SimpleNamespace(usage=usage)
@@ -373,12 +374,12 @@ def test_extract_tokens_falls_back_to_usage_attribute():
     }
 
 
-def test_extract_tokens_returns_empty_dict_when_no_usage():
+def test_extract_tokens_returns_empty_dict_when_no_usage() -> None:
     assert extract_tokens(SimpleNamespace()) == {}
     assert extract_tokens(None) == {}
 
 
-def test_extract_tokens_defaults_missing_counts_to_zero():
+def test_extract_tokens_defaults_missing_counts_to_zero() -> None:
     """Missing counts default to 0; if the source provided no total but the
     other two fields are non-zero, the helper computes prompt+candidates so a
     non-empty run never shows ``total_tokens: 0`` in results.json."""
@@ -392,7 +393,7 @@ def test_extract_tokens_defaults_missing_counts_to_zero():
     }
 
 
-def test_extract_tokens_reads_anthropic_input_output_shape():
+def test_extract_tokens_reads_anthropic_input_output_shape() -> None:
     """Anthropic emits ``usage.input_tokens`` / ``usage.output_tokens`` and **no**
     aggregated total. The helper must map both onto the legacy keys and compute
     the total so non-Google providers do not silently drop tokens.
@@ -410,7 +411,7 @@ def test_extract_tokens_reads_anthropic_input_output_shape():
     }
 
 
-def test_extract_tokens_reads_openai_ollama_shape():
+def test_extract_tokens_reads_openai_ollama_shape() -> None:
     """OpenAI / Ollama emit ``usage.prompt_tokens`` / ``completion_tokens`` /
     ``total_tokens``. The helper must map ``completion_tokens`` → the legacy
     ``candidates_tokens`` slot and pass ``total_tokens`` through verbatim.
@@ -427,7 +428,7 @@ def test_extract_tokens_reads_openai_ollama_shape():
     }
 
 
-def test_extract_tokens_google_total_passes_through_when_present():
+def test_extract_tokens_google_total_passes_through_when_present() -> None:
     """When the provider supplies its own total it wins over the computed sum."""
     usage = SimpleNamespace(prompt_token_count=5, candidates_token_count=7, total_token_count=99)
     response = SimpleNamespace(usage_metadata=usage)
@@ -437,7 +438,7 @@ def test_extract_tokens_google_total_passes_through_when_present():
     assert extract_tokens(response)["total_tokens"] == 99
 
 
-def test_extract_tokens_preserves_legacy_on_disk_key_scheme():
+def test_extract_tokens_preserves_legacy_on_disk_key_scheme() -> None:
     """The on-disk dict shape must stay ``{prompt_tokens, candidates_tokens,
     total_tokens}`` for D3 (results.json stability) — three keys, exactly.
     """
@@ -451,7 +452,9 @@ def test_extract_tokens_preserves_legacy_on_disk_key_scheme():
 # ---------------------------------------------------------------------------
 
 
-def test_execute_runs_with_no_tools_when_capabilities_default(monkeypatch):
+def test_execute_runs_with_no_tools_when_capabilities_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Default capabilities (no MCP binding, no skills) → loop runs tool-less.
 
     Renamed from ``..._when_target_unset`` because the MCP gate is no longer
@@ -490,7 +493,9 @@ def test_execute_runs_with_no_tools_when_capabilities_default(monkeypatch):
     assert fake.calls[0]["tools"] == ("formatted", ())
 
 
-def test_execute_passes_explicit_provider_and_model_to_get_model(monkeypatch):
+def test_execute_passes_explicit_provider_and_model_to_get_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured: dict[str, Any] = {}
 
     def fake_get_model(provider, model):
@@ -504,7 +509,9 @@ def test_execute_passes_explicit_provider_and_model_to_get_model(monkeypatch):
     assert captured == {"provider": "anthropic", "model": "claude-3-5"}
 
 
-def test_execute_records_anthropic_tokens_through_to_agentresult(monkeypatch):
+def test_execute_records_anthropic_tokens_through_to_agentresult(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """End-to-end: an Anthropic-shaped usage object surfaces on
     ``AgentResult.tokens`` under the legacy key scheme — regression for the
     blocking bug where non-Google providers silently logged zero tokens."""
@@ -526,7 +533,9 @@ def test_execute_records_anthropic_tokens_through_to_agentresult(monkeypatch):
     }
 
 
-def test_execute_records_openai_tokens_through_to_agentresult(monkeypatch):
+def test_execute_records_openai_tokens_through_to_agentresult(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """End-to-end: an OpenAI/Ollama-shaped usage object surfaces under the
     legacy key scheme."""
     fake = _FakeLLMClient(
@@ -552,7 +561,9 @@ def test_execute_records_openai_tokens_through_to_agentresult(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_execute_folds_assistant_tool_pairs_into_canonical_trajectory(monkeypatch):
+def test_execute_folds_assistant_tool_pairs_into_canonical_trajectory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """End-to-end: an MCP tool turn followed by a finishing turn → one ToolCall."""
     fc = [{"name": "do_thing", "args": {"a": 1}, "id": "call-1"}]
     fake = _FakeLLMClient(
@@ -603,7 +614,9 @@ def test_execute_folds_assistant_tool_pairs_into_canonical_trajectory(monkeypatc
 # ---------------------------------------------------------------------------
 
 
-def test_execute_dispatch_error_lands_in_errors_and_continues(monkeypatch):
+def test_execute_dispatch_error_lands_in_errors_and_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A tool call that raises must surface on errors, not crash the agent."""
 
     class _ExplodingMCP(_FakeMCPClient):
@@ -632,7 +645,7 @@ def test_execute_dispatch_error_lands_in_errors_and_continues(monkeypatch):
     ]
 
 
-def test_execute_marks_mcp_iserror_result_as_error(monkeypatch):
+def test_execute_marks_mcp_iserror_result_as_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """An MCP server reporting failure via ``CallToolResult.isError`` (rather
     than raising) must fold as ``status="error"`` and land on ``errors`` —
     previously the flag was ignored and failures scored as completed (review
@@ -662,7 +675,9 @@ def test_execute_marks_mcp_iserror_result_as_error(monkeypatch):
     ]
 
 
-def test_execute_records_missing_mcp_when_tool_requested_without_server(monkeypatch):
+def test_execute_records_missing_mcp_when_tool_requested_without_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """No MCP server, but the model still requests a tool → recorded, not crashed."""
     fc = [{"name": "ghost", "args": {}, "id": "c2"}]
     fake = _FakeLLMClient(
@@ -692,7 +707,9 @@ def test_execute_records_missing_mcp_when_tool_requested_without_server(monkeypa
 # ---------------------------------------------------------------------------
 
 
-def test_execute_skills_discover_without_mcp(monkeypatch, tmp_path):
+def test_execute_skills_discover_without_mcp(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Skills must be loadable on the MCP-off path, not gated on MCP being on."""
     skill_dir = tmp_path / "skills"
     skill = skill_dir / "demo" / "SKILL.md"
@@ -731,7 +748,7 @@ def test_execute_skills_discover_without_mcp(monkeypatch, tmp_path):
     assert fake.format_tools_calls[0][0].name == "skill_demo_skill"
 
 
-def test_execute_no_skills_no_mcp_runs_tool_less(monkeypatch):
+def test_execute_no_skills_no_mcp_runs_tool_less(monkeypatch: pytest.MonkeyPatch) -> None:
     """Empty skills + no target → loop seen no tools, no metadata noise."""
     fake = _FakeLLMClient([_Turn(text="hi")])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
@@ -746,7 +763,7 @@ def test_execute_no_skills_no_mcp_runs_tool_less(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_execute_lets_value_error_reach_base_safety_net(monkeypatch):
+def test_execute_lets_value_error_reach_base_safety_net(monkeypatch: pytest.MonkeyPatch) -> None:
     """A ``ValueError`` raised inside the run (MCP setup, provider adapter,
     anywhere) must bubble to :meth:`AgentHarness.run`'s safety net, which logs
     the full traceback and converts to an errored result tagged with the
@@ -780,7 +797,7 @@ def test_execute_lets_value_error_reach_base_safety_net(monkeypatch):
     assert result.output.startswith("Error: ")
 
 
-def test_execute_times_out_via_config_timeout_sec(monkeypatch):
+def test_execute_times_out_via_config_timeout_sec(monkeypatch: pytest.MonkeyPatch) -> None:
     """``AgentConfig.timeout_sec`` must bound the whole run — a hanging MCP
     server or provider call converts to an errored result at the deadline
     instead of wedging the benchmark (review finding: the field was ignored)."""
@@ -796,7 +813,7 @@ def test_execute_times_out_via_config_timeout_sec(monkeypatch):
     assert "timed out after 0.05s" in result.errors[0]
 
 
-def test_execute_reraises_internal_timeout_before_deadline(monkeypatch):
+def test_execute_reraises_internal_timeout_before_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
     """A ``TimeoutError`` from inside the run (e.g. a provider socket timeout —
     ``socket.timeout`` is ``TimeoutError`` since 3.10) raised well before the
     configured deadline must not be relabeled as the agent-level timeout: it
@@ -814,7 +831,7 @@ def test_execute_reraises_internal_timeout_before_deadline(monkeypatch):
     assert result.errors[0] == "TimeoutError: socket read timed out"
 
 
-def test_execute_honors_max_turns_zero(monkeypatch):
+def test_execute_honors_max_turns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
     """``max_turns=0`` means zero model turns — it must not be silently
     replaced by the 50-turn default via a falsy-``or`` (review finding)."""
     fake = _FakeLLMClient([_Turn(text="never called")])
@@ -825,7 +842,9 @@ def test_execute_honors_max_turns_zero(monkeypatch):
     assert result.output == ""
 
 
-def test_execute_warns_when_extra_mcp_servers_dropped(monkeypatch, caplog):
+def test_execute_warns_when_extra_mcp_servers_dropped(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Only the first MCP binding is honored (documented aggregate behavior);
     dropping servers 2..N must at least be visible in the logs."""
     fake = _FakeLLMClient([_Turn(text="ok")])
@@ -848,7 +867,7 @@ def test_execute_warns_when_extra_mcp_servers_dropped(monkeypatch, caplog):
 # ---------------------------------------------------------------------------
 
 
-def test_execute_ignores_bench_use_mcp_env(monkeypatch):
+def test_execute_ignores_bench_use_mcp_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Setting BENCH_USE_MCP must not change the agent's behavior.
 
     The MCP on/off gate is ``config.capabilities.mcp`` (a binding with a
@@ -862,7 +881,7 @@ def test_execute_ignores_bench_use_mcp_env(monkeypatch):
     assert result.output == "ok"
 
 
-def test_agent_source_has_no_bench_use_mcp_or_environ_reads():
+def test_agent_source_has_no_bench_use_mcp_or_environ_reads() -> None:
     """Statically verify the agents/api source carries no env-smuggling.
 
     The conventions doc forbids agents from reading ``BENCH_USE_MCP`` (the
@@ -951,7 +970,7 @@ def test_agent_source_has_no_bench_use_mcp_or_environ_reads():
                 )
 
 
-def test_api_package_does_not_expose_legacy_context_or_system_instruction():
+def test_api_package_does_not_expose_legacy_context_or_system_instruction() -> None:
     """The PR2 contract drops the ``context``/``system_instruction`` grab-bag.
 
     No symbol or kwarg with that name should remain in the public surface.
@@ -971,7 +990,7 @@ def test_api_package_does_not_expose_legacy_context_or_system_instruction():
 
 
 @pytest.mark.parametrize("method_name", ["_execute"])
-def test_execute_is_synchronous_and_safe_for_harness_invocation(method_name):
+def test_execute_is_synchronous_and_safe_for_harness_invocation(method_name: str) -> None:
     """The harness calls ``run(prompt)`` synchronously; ``_execute`` must be sync too."""
     import inspect
 
@@ -987,7 +1006,7 @@ def test_execute_is_synchronous_and_safe_for_harness_invocation(method_name):
 # ---------------------------------------------------------------------------
 
 
-def test_api_agent_satisfies_all_three_capability_protocols():
+def test_api_agent_satisfies_all_three_capability_protocols() -> None:
     """``isinstance`` against each Protocol is how the harness negotiates
     capabilities before granting a binding (handoff §6). ApiAgent declares
     every capability it can drive — MCP, skills, rules — so an instance must
@@ -998,7 +1017,7 @@ def test_api_agent_satisfies_all_three_capability_protocols():
     assert isinstance(agent, SupportsRules)
 
 
-def test_api_agent_mirrors_capability_bindings_onto_mixin_attributes():
+def test_api_agent_mirrors_capability_bindings_onto_mixin_attributes() -> None:
     """The structural-Protocol attributes (``mcp_servers``/``skills``/``rules``)
     must reflect the bindings the orchestrator granted; otherwise capability
     negotiation would see the mixin defaults instead of the live config."""
@@ -1019,7 +1038,7 @@ def test_api_agent_mirrors_capability_bindings_onto_mixin_attributes():
 # ---------------------------------------------------------------------------
 
 
-def test_execute_runs_with_mcp_only_no_skills(monkeypatch):
+def test_execute_runs_with_mcp_only_no_skills(monkeypatch: pytest.MonkeyPatch) -> None:
     """MCP binding present, skills binding empty → MCP path opens, no skills loaded."""
     fc = [{"name": "do_thing", "args": {}, "id": "c1"}]
     fake = _FakeLLMClient([_Turn(text="working", calls=fc), _Turn(text="done")])
@@ -1034,7 +1053,9 @@ def test_execute_runs_with_mcp_only_no_skills(monkeypatch):
     assert "skills_loaded" not in result.metadata  # SkillBinding stayed empty
 
 
-def test_execute_runs_with_both_mcp_and_skills(monkeypatch, tmp_path):
+def test_execute_runs_with_both_mcp_and_skills(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Both bindings populated → MCP session is opened *and* skills are discovered."""
     skill_dir = tmp_path / "skills"
     (skill_dir / "demo").mkdir(parents=True)
@@ -1058,7 +1079,7 @@ def test_execute_runs_with_both_mcp_and_skills(monkeypatch, tmp_path):
     assert result.metadata["skills_loaded"] == ["demo"]
 
 
-def test_execute_runs_with_neither_mcp_nor_skills(monkeypatch):
+def test_execute_runs_with_neither_mcp_nor_skills(monkeypatch: pytest.MonkeyPatch) -> None:
     """Default capabilities → tool-less run, no MCP session, no skills loaded."""
     fake = _FakeLLMClient([_Turn(text="bare")])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
@@ -1077,7 +1098,9 @@ def test_execute_runs_with_neither_mcp_nor_skills(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_execute_threads_rules_text_into_system_instruction(monkeypatch):
+def test_execute_threads_rules_text_into_system_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Non-empty rules text must ride on the provider's ``system_instruction``."""
     fake = _FakeLLMClient([_Turn(text="ok")])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
@@ -1086,7 +1109,9 @@ def test_execute_threads_rules_text_into_system_instruction(monkeypatch):
     assert fake.calls[0]["system_instruction"] == "be careful"
 
 
-def test_execute_empty_rules_text_yields_none_system_instruction(monkeypatch):
+def test_execute_empty_rules_text_yields_none_system_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Empty rules text → ``system_instruction=None`` (the loop's "no preamble")."""
     fake = _FakeLLMClient([_Turn(text="ok")])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
@@ -1100,7 +1125,7 @@ def test_execute_empty_rules_text_yields_none_system_instruction(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_execute_skips_mcp_when_binding_has_no_command(monkeypatch):
+def test_execute_skips_mcp_when_binding_has_no_command(monkeypatch: pytest.MonkeyPatch) -> None:
     """A binding with no launch command (CLI-agent shape) → API agent runs MCP-off."""
     fake = _FakeLLMClient([_Turn(text="ok")])
     monkeypatch.setattr(agent_mod, "get_model", lambda *a, **kw: fake)
@@ -1114,7 +1139,9 @@ def test_execute_skips_mcp_when_binding_has_no_command(monkeypatch):
     assert result.output == "ok"
 
 
-def test_execute_preserves_spaced_command_token_through_shlex_roundtrip(monkeypatch):
+def test_execute_preserves_spaced_command_token_through_shlex_roundtrip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A spaced argv token (``("uv run", "mcp-server")``) must reach MCPClient
     intact: ``shlex.join`` quotes it on the way in, ``MCPClient``'s
     ``shlex.split`` recovers the original parts on the way out.

--- a/tests/unit/agents/api/test_agents_api_import_hygiene.py
+++ b/tests/unit/agents/api/test_agents_api_import_hygiene.py
@@ -21,7 +21,7 @@ import sys
 import textwrap
 
 
-def test_agents_api_package_import_pulls_no_sdk_or_mcp():
+def test_agents_api_package_import_pulls_no_sdk_or_mcp() -> None:
     """A fresh interpreter import of ``devops_bench.agents.api`` is mcp/SDK-free."""
     script = textwrap.dedent(
         """
@@ -37,13 +37,13 @@ def test_agents_api_package_import_pulls_no_sdk_or_mcp():
         """
     )
     result = subprocess.run(
-        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False, timeout=30
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "OK" in result.stdout
 
 
-def test_agents_api_agent_module_import_pulls_no_sdk_or_mcp():
+def test_agents_api_agent_module_import_pulls_no_sdk_or_mcp() -> None:
     """Importing the concrete agent module must not eagerly load mcp / deepeval.
 
     Even the module that holds the registered :class:`ApiAgent` must keep the
@@ -66,7 +66,7 @@ def test_agents_api_agent_module_import_pulls_no_sdk_or_mcp():
         """
     )
     result = subprocess.run(
-        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False, timeout=30
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "OK" in result.stdout

--- a/tests/unit/agents/api/test_agents_api_mcp.py
+++ b/tests/unit/agents/api/test_agents_api_mcp.py
@@ -24,29 +24,29 @@ import pytest
 from devops_bench.agents.api.mcp import MCPClient, extract_tool_text
 
 
-def test_extract_tool_text_joins_text_blocks():
+def test_extract_tool_text_joins_text_blocks() -> None:
     blocks = [SimpleNamespace(text="alpha"), SimpleNamespace(text="beta")]
     assert extract_tool_text(SimpleNamespace(content=blocks)) == "alpha\nbeta"
 
 
-def test_extract_tool_text_skips_blocks_without_text():
+def test_extract_tool_text_skips_blocks_without_text() -> None:
     # A block missing ``.text`` must not crash; mixed lists fall through to the
     # text-only blocks.
     blocks = [SimpleNamespace(text="alpha"), SimpleNamespace()]
     assert extract_tool_text(SimpleNamespace(content=blocks)) == "alpha"
 
 
-def test_extract_tool_text_falls_back_to_str_when_no_blocks():
+def test_extract_tool_text_falls_back_to_str_when_no_blocks() -> None:
     obj = SimpleNamespace(content=[])
     assert extract_tool_text(obj) == str(obj)
 
 
-def test_extract_tool_text_falls_back_to_str_when_no_content_attr():
+def test_extract_tool_text_falls_back_to_str_when_no_content_attr() -> None:
     obj = SimpleNamespace()
     assert extract_tool_text(obj) == str(obj)
 
 
-def test_mcp_client_enter_rejects_empty_server_path():
+def test_mcp_client_enter_rejects_empty_server_path() -> None:
     # We must surface a clear error rather than spawning ``""``; ValueError
     # surfaces through the agent's _execute as an errored result (see
     # test_execute_returns_errored_on_empty_mcp_server_string).
@@ -55,7 +55,9 @@ def test_mcp_client_enter_rejects_empty_server_path():
         asyncio.run(client.__aenter__())
 
 
-def test_aenter_unwinds_exit_stack_when_session_setup_fails(monkeypatch):
+def test_aenter_unwinds_exit_stack_when_session_setup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """If session setup fails after the stdio transport spawned the server,
     ``__aenter__`` must unwind its exit stack — ``__aexit__`` never runs when
     ``__aenter__`` raises, so without the unwind the server subprocess leaks
@@ -91,7 +93,9 @@ def test_aenter_unwinds_exit_stack_when_session_setup_fails(monkeypatch):
     assert state["transport_exited"] is True
 
 
-def test_call_tool_degrades_gracefully_when_deepeval_missing(monkeypatch):
+def test_call_tool_degrades_gracefully_when_deepeval_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """If ``deepeval`` is not installed, ``call_tool`` still works (untraced).
 
     The legacy implementation imported ``deepeval.tracing.observe`` at the top
@@ -129,7 +133,7 @@ def test_call_tool_degrades_gracefully_when_deepeval_missing(monkeypatch):
     assert client.session.calls == [("t", {"k": "v"})]
 
 
-def test_mcp_module_does_not_import_sdk_at_module_load():
+def test_mcp_module_does_not_import_sdk_at_module_load() -> None:
     """Importing the module must not pull the ``mcp`` SDK — it loads on enter."""
     import subprocess
     import sys

--- a/tests/unit/agents/api/test_agents_api_skills.py
+++ b/tests/unit/agents/api/test_agents_api_skills.py
@@ -16,6 +16,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
 from devops_bench.agents.api.skills import (
     SkillToolInfo,
     discover_skill_tools,
@@ -23,7 +27,7 @@ from devops_bench.agents.api.skills import (
 )
 
 
-def test_parse_skill_md_extracts_frontmatter(tmp_path):
+def test_parse_skill_md_extracts_frontmatter(tmp_path: Path) -> None:
     f = tmp_path / "SKILL.md"
     f.write_text('---\nname: "my-skill"\ndescription: does things\n---\nbody text\n')
     name, description, content = parse_skill_md(str(f))
@@ -32,7 +36,7 @@ def test_parse_skill_md_extracts_frontmatter(tmp_path):
     assert "body text" in content
 
 
-def test_parse_skill_md_strips_single_and_double_quotes(tmp_path):
+def test_parse_skill_md_strips_single_and_double_quotes(tmp_path: Path) -> None:
     f = tmp_path / "SKILL.md"
     f.write_text("---\nname: 'quoted'\ndescription: \"plain\"\n---\n")
     name, description, _ = parse_skill_md(str(f))
@@ -40,7 +44,7 @@ def test_parse_skill_md_strips_single_and_double_quotes(tmp_path):
     assert description == "plain"
 
 
-def test_parse_skill_md_reads_multiline_block_scalar(tmp_path):
+def test_parse_skill_md_reads_multiline_block_scalar(tmp_path: Path) -> None:
     f = tmp_path / "SKILL.md"
     f.write_text(
         "---\n"
@@ -55,31 +59,31 @@ def test_parse_skill_md_reads_multiline_block_scalar(tmp_path):
     assert description == "use this skill when rotating a secret across namespaces"
 
 
-def test_parse_skill_md_missing_file_returns_none():
+def test_parse_skill_md_missing_file_returns_none() -> None:
     assert parse_skill_md("/nonexistent/SKILL.md") == (None, None, None)
 
 
-def test_parse_skill_md_no_frontmatter_returns_none(tmp_path):
+def test_parse_skill_md_no_frontmatter_returns_none(tmp_path: Path) -> None:
     f = tmp_path / "SKILL.md"
     f.write_text("just body, no frontmatter")
     assert parse_skill_md(str(f)) == (None, None, None)
 
 
-def test_discover_skill_tools_empty_paths_returns_empty_lists():
+def test_discover_skill_tools_empty_paths_returns_empty_lists() -> None:
     tools, resources, names = discover_skill_tools(())
     assert tools == []
     assert resources == {}
     assert names == []
 
 
-def test_discover_skill_tools_missing_path_is_skipped(tmp_path):
+def test_discover_skill_tools_missing_path_is_skipped(tmp_path: Path) -> None:
     tools, resources, names = discover_skill_tools((str(tmp_path / "missing"),))
     assert tools == []
     assert resources == {}
     assert names == []
 
 
-def test_discover_skill_tools_normalizes_dashes_to_underscores(tmp_path):
+def test_discover_skill_tools_normalizes_dashes_to_underscores(tmp_path: Path) -> None:
     skill = tmp_path / "first" / "SKILL.md"
     skill.parent.mkdir(parents=True)
     body = '---\nname: "my-cool-skill"\ndescription: ok\n---\nbody\n'
@@ -96,7 +100,7 @@ def test_discover_skill_tools_normalizes_dashes_to_underscores(tmp_path):
     assert names == ["my-cool-skill"]
 
 
-def test_discover_skill_tools_falls_back_to_default_description(tmp_path):
+def test_discover_skill_tools_falls_back_to_default_description(tmp_path: Path) -> None:
     """Missing description still loads the skill with a synthetic description."""
     skill = tmp_path / "SKILL.md"
     skill.write_text('---\nname: "noun"\n---\nbody\n')
@@ -104,7 +108,7 @@ def test_discover_skill_tools_falls_back_to_default_description(tmp_path):
     assert tools[0].description == "Exposes skill: noun"
 
 
-def test_discover_skill_tools_walks_multiple_paths(tmp_path):
+def test_discover_skill_tools_walks_multiple_paths(tmp_path: Path) -> None:
     a = tmp_path / "a" / "SKILL.md"
     b = tmp_path / "b" / "SKILL.md"
     for path, name in [(a, "alpha"), (b, "beta")]:
@@ -116,14 +120,14 @@ def test_discover_skill_tools_walks_multiple_paths(tmp_path):
     assert sorted(names) == ["alpha", "beta"]
 
 
-def test_discover_skill_tools_skips_empty_path_strings(tmp_path):
+def test_discover_skill_tools_skips_empty_path_strings(tmp_path: Path) -> None:
     # Empty / whitespace-only entries from CSV parsing must not be treated as
     # the current working directory.
     tools, _resources, _names = discover_skill_tools(("", str(tmp_path)))
     assert tools == []
 
 
-def test_skill_tool_info_defaults_to_empty_object_schema():
+def test_skill_tool_info_defaults_to_empty_object_schema() -> None:
     """``inputSchema`` must never be ``None`` — the Anthropic/OpenAI-style
     adapters forward the attribute verbatim and those APIs reject a null
     schema (regression for the review finding that broke every skills-enabled
@@ -134,7 +138,9 @@ def test_skill_tool_info_defaults_to_empty_object_schema():
     assert SkillToolInfo(name="skill_y", description="d").inputSchema is not tool.inputSchema
 
 
-def test_discover_skill_tools_expands_user_home(tmp_path, monkeypatch):
+def test_discover_skill_tools_expands_user_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A ``~/...`` skills path must work — the shared walk expanduser-expands it
     (previously the API agent warned-and-skipped where CLI agents loaded it)."""
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -146,7 +152,23 @@ def test_discover_skill_tools_expands_user_home(tmp_path, monkeypatch):
     assert names == ["home-skill"]
 
 
-def test_discover_skill_tools_dedupes_duplicate_names_first_wins(tmp_path):
+def test_discover_skill_tools_dedupes_normalized_name_collisions(tmp_path: Path) -> None:
+    """Distinct raw names that normalize to the same tool name (``my-skill``
+    vs ``my_skill``) must not advertise duplicate tools or silently overwrite
+    the resources map — first wins, later collisions are warned and skipped."""
+    for d, name, body in [("a", "my-skill", "first"), ("b", "my_skill", "second")]:
+        f = tmp_path / d / "SKILL.md"
+        f.parent.mkdir(parents=True)
+        f.write_text(f'---\nname: "{name}"\ndescription: d\n---\n{body}\n')
+
+    tools, resources, names = discover_skill_tools((str(tmp_path),))
+
+    assert [t.name for t in tools] == ["skill_my_skill"]
+    assert resources["skill_my_skill"].endswith("first\n")
+    assert names == ["my-skill"]
+
+
+def test_discover_skill_tools_dedupes_duplicate_names_first_wins(tmp_path: Path) -> None:
     """Duplicate skill names are first-wins in sorted order (shared-walk
     semantics) — previously both were advertised and the resources map was
     last-wins, nondeterministically."""
@@ -161,7 +183,7 @@ def test_discover_skill_tools_dedupes_duplicate_names_first_wins(tmp_path):
     assert names == ["dup"]
 
 
-def test_skills_module_pulls_no_heavy_dependencies():
+def test_skills_module_pulls_no_heavy_dependencies() -> None:
     """``skills`` does only stdlib filesystem work — no SDK/deepeval/mcp."""
     import subprocess
     import sys

--- a/tests/unit/agents/shared/__init__.py
+++ b/tests/unit/agents/shared/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tests/unit/agents/shared/test_cli_capabilities.py
+++ b/tests/unit/agents/shared/test_cli_capabilities.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from devops_bench.agents.capabilities import McpBinding
 from devops_bench.agents.shared.cli_capabilities import (
     agent_workdir,
@@ -26,7 +28,7 @@ from devops_bench.agents.shared.cli_capabilities import (
 )
 
 
-def test_build_mcp_servers_maps_command_to_command_and_args():
+def test_build_mcp_servers_maps_command_to_command_and_args() -> None:
     """``command[0]`` → ``command``; the remainder → ``args``."""
     servers = build_mcp_servers(
         (McpBinding(name="gke", command=("gke-mcp", "--flag", "v"), tools=("t",)),)
@@ -34,25 +36,25 @@ def test_build_mcp_servers_maps_command_to_command_and_args():
     assert servers == {"gke": {"command": "gke-mcp", "args": ["--flag", "v"]}}
 
 
-def test_build_mcp_servers_omits_args_for_bare_command():
+def test_build_mcp_servers_omits_args_for_bare_command() -> None:
     """A single-element command yields no ``args`` key."""
     servers = build_mcp_servers((McpBinding(name="gke", command=("gke-mcp",)),))
     assert servers == {"gke": {"command": "gke-mcp"}}
 
 
-def test_build_mcp_servers_skips_command_less_bindings():
+def test_build_mcp_servers_skips_command_less_bindings() -> None:
     """Empty-command bindings (in-process/built-in servers) are not launched."""
     servers = build_mcp_servers((McpBinding(name="builtin", command=(), tools=("t",)),))
     assert servers == {}
 
 
-def test_build_mcp_servers_names_unnamed_bindings_by_index():
+def test_build_mcp_servers_names_unnamed_bindings_by_index() -> None:
     """A binding with no name falls back to a positional ``mcp<index>`` key."""
     servers = build_mcp_servers((McpBinding(name="", command=("srv",)),))
     assert servers == {"mcp0": {"command": "srv"}}
 
 
-def test_materialize_skills_writes_named_skill_files(tmp_path: Path):
+def test_materialize_skills_writes_named_skill_files(tmp_path: Path) -> None:
     """Each discovered ``SKILL.md`` is copied under ``<root>/<name>/SKILL.md``."""
     src = tmp_path / "src"
     (src / "rotate").mkdir(parents=True)
@@ -69,7 +71,9 @@ def test_materialize_skills_writes_named_skill_files(tmp_path: Path):
     assert "body" in copied.read_text(encoding="utf-8")
 
 
-def test_materialize_skills_rejects_malicious_names(tmp_path: Path, caplog) -> None:
+def test_materialize_skills_rejects_malicious_names(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """Frontmatter names that would escape ``skills_root`` are warned and skipped."""
     src = tmp_path / "src"
     abs_escape = tmp_path / "abs-escape"
@@ -82,9 +86,8 @@ def test_materialize_skills_rejects_malicious_names(tmp_path: Path, caplog) -> N
         )
     good = src / "zz-good"
     good.mkdir(parents=True)
-    (good / "SKILL.md").write_text(
-        "---\nname: good-skill\ndescription: d\n---\nbody\n", encoding="utf-8"
-    )
+    good_skill = "---\nname: good-skill\ndescription: d\n---\nbody\n"
+    (good / "SKILL.md").write_text(good_skill, encoding="utf-8")
     dest = tmp_path / "skills" / "dest"
 
     written = materialize_skills(dest, (str(src),))
@@ -97,7 +100,7 @@ def test_materialize_skills_rejects_malicious_names(tmp_path: Path, caplog) -> N
 
 
 def test_materialize_skills_warns_and_keeps_first_on_duplicate_names(
-    tmp_path: Path, caplog
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A second SKILL.md with an already-seen name is skipped, not overwritten."""
     first = tmp_path / "src1" / "dup"
@@ -116,12 +119,14 @@ def test_materialize_skills_warns_and_keeps_first_on_duplicate_names(
     assert "Skipping duplicate skill 'dup-skill'" in caplog.text
 
 
-def test_materialize_skills_skips_missing_paths(tmp_path: Path):
+def test_materialize_skills_skips_missing_paths(tmp_path: Path) -> None:
     """A non-existent source path is warned and skipped, not fatal."""
     assert materialize_skills(tmp_path / "dest", (str(tmp_path / "nope"),)) == []
 
 
-def test_build_mcp_servers_resolves_path_like_commands(tmp_path: Path, monkeypatch, caplog):
+def test_build_mcp_servers_resolves_path_like_commands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Path-like commands that exist on disk are absolutized; bare commands are not."""
     monkeypatch.chdir(tmp_path)
 
@@ -146,7 +151,7 @@ def test_build_mcp_servers_resolves_path_like_commands(tmp_path: Path, monkeypat
     )
 
 
-def test_agent_workdir_yields_supplied_path_without_cleanup(tmp_path: Path):
+def test_agent_workdir_yields_supplied_path_without_cleanup(tmp_path: Path) -> None:
     """A supplied ``workspace_path`` is yielded as-is and left in place afterward."""
     supplied = tmp_path / "workspace"
     supplied.mkdir()
@@ -159,7 +164,7 @@ def test_agent_workdir_yields_supplied_path_without_cleanup(tmp_path: Path):
     assert (supplied / "marker.txt").read_text(encoding="utf-8") == "artifact"
 
 
-def test_agent_workdir_creates_and_cleans_up_temp_dir_when_no_path_supplied():
+def test_agent_workdir_creates_and_cleans_up_temp_dir_when_no_path_supplied() -> None:
     """``None`` falls back to a prefixed temp dir that is removed on exit."""
     with agent_workdir(None, prefix="agent-workdir-test-") as workdir:
         created = workdir


### PR DESCRIPTION
Flips the 10 frontier entries whose gke-labs content now matches upstream byte-for-byte: the API agent module (agent, skills, mcp, package init, and its four test files), agents/shared, and the shared tests.

To reach that parity, back-ports the review deltas that landed upstream: the normalized-tool-name dedupe in agents/api/skills.py, the ruamel.yaml (YAML 1.2) frontmatter parsing in agents/shared/skills.py, and the matching test updates.

Also adds the two frontier groups the manifest was missing:
- antigravity CLI agent — commented; the gke-labs content is newer than what merged upstream, so it flips once re-exported and at parity.
- composite outcome score (metrics/scoring.py + test) — active; these were added upstream first with no gke-labs copy, so the back-sync materializes them here.

Carries the migrated-override label: the guarded file edits are byte-identical to the upstream content the flip hands ownership to.