### PR TITLE
docs: add out-of-tree task guide and runnable example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ provision infra → run the agent → optional chaos + verify → judge → tear
 | `tasks/` | Task definitions on disk (`task.yaml` files). |
 | `tf/` | OpenTofu / Terraform infrastructure modules. |
 | `site/` | React + Vite leaderboard plus the Firestore `ingest/` pipeline. |
+| `examples/` | Copyable starting points, not part of the benchmark — e.g. an out-of-tree task. |
 | `docs/` | Human documentation. |
 | `.agents/skills/` | Skills for coding agents. |
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ New tasks live under `tasks/<provider>/<name>/task.yaml`, each pairing a `chaos_
 
 Before submitting, run the `task-review` skill over your task — see [the skills overview](docs/getting-started.md#skills-in-this-repo).
 
+### Keeping tasks in your own repo
+
+You don't have to contribute a task here to evaluate against it. A task definition and its OpenTofu stack can live entirely in your repo — point the harness at the path and it runs. See [docs/how-to/out-of-tree-tasks.md](docs/how-to/out-of-tree-tasks.md) and the runnable [`examples/out-of-tree-task/`](examples/out-of-tree-task/).
+
 ## Documentation
 
 We welcome contributions around adding new tasks, models or agent harness. You can review documentation in [`docs/`](docs/README.md) for detailed instructions and skills. Start with [Getting started](docs/getting-started.md), then browse the component docs and

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ and [glossary](./components/glossary.md).
 
 - [Run evals](./how-to/run-evals.md) — single runs and parallel matrices.
 - [Add a task](./how-to/add-a-task.md) — author a new benchmark task.
+- [Out-of-tree tasks](./how-to/out-of-tree-tasks.md) — keep your tasks and Terraform in your own repo.
 - [Add a model provider](./how-to/add-a-model-provider.md) — wire up a new LLM backend.
 - [Add an agent harness](./how-to/add-an-agent-harness.md) — plug in a new agent under test.
 - [Leaderboard](./how-to/leaderboard.md) — how the leaderboard works and how to ingest results.

--- a/docs/components/infra.md
+++ b/docs/components/infra.md
@@ -48,7 +48,7 @@ Both are listed in the `PROVIDERS` registry.
 The env var outranks the config key so a task can pin a default `provider:` while runs stay overridable from the environment (the same way `TARGET_DEPLOYMENT_NAME` and `NAMESPACE` resolve).
 
 > [!IMPORTANT]
-> Deduction only applies to in-repo (relative) stacks. An absolute or external stack path **must** name its provider explicitly (via `provider:` or `INFRA_PROVIDER`) — the harness will not guess. An unknown provider name is a configuration error.
+> Deduction only applies to in-repo (relative) stacks. An absolute or external stack path **must** name its provider explicitly (via `provider:` or `INFRA_PROVIDER`) — the harness will not guess. An unknown provider name is a configuration error. See [out-of-tree tasks](../how-to/out-of-tree-tasks.md) for running a stack from outside the repo.
 
 ## What the Terraform provisions
 
@@ -122,3 +122,5 @@ Subclass `Provider` in `devops_bench/providers/<cloud>.py`, decorate it with `@P
 
 > [!NOTE]
 > Under parallel runs, each run gets an isolated OpenTofu data directory (a private copy of the `tf/` tree, with per-run state) and a run-unique cluster name, so concurrent stacks don't collide on lock files or state. If you author a task stack, make any **global** resource names (Artifact Registry repos, GCS buckets, IAM bindings, and the like) run-scoped, and clean them up on `destroy`. See [run-evals.md](../how-to/run-evals.md) for how the parallel matrix is driven.
+>
+> The private-copy step covers in-repo stacks only — an external (absolute-path) stack cannot be relocated safely, so concurrent runs share its working directory. See [out-of-tree tasks](../how-to/out-of-tree-tasks.md#2-external-stacks-do-not-get-per-run-isolation).

--- a/docs/how-to/add-a-task.md
+++ b/docs/how-to/add-a-task.md
@@ -6,6 +6,9 @@ This guide walks you through the schema, the placeholders the harness fills in, 
 
 For background terms, see the [glossary](../components/glossary.md). For how deployers and stacks fit together, see [infrastructure](../components/infra.md).
 
+> [!TIP]
+> This guide assumes your task lives in this repo under `tasks/`. It doesn't have to — a task and its OpenTofu stack can live in your own repo, and the harness will run it from there. Everything below still applies; see [out-of-tree tasks](./out-of-tree-tasks.md) for the extra steps.
+
 ## The task schema
 
 Every field below maps to an attribute on `Task`. Fields marked "required" must produce a usable value — the harness validates types strictly (no string-to-bool coercion) and ignores unknown keys, so a typo'd field name is silently dropped rather than flagged. Author carefully.

--- a/docs/how-to/out-of-tree-tasks.md
+++ b/docs/how-to/out-of-tree-tasks.md
@@ -1,0 +1,196 @@
+# How to run out-of-tree tasks
+
+You do not have to contribute a task to devops-bench to evaluate against it. A task definition
+and its OpenTofu stack can live entirely in **your** repo; you point the harness at a path and
+it runs. This is the recommended setup for teams whose evals are their own — private scenarios,
+integrity evals, anything that shouldn't land on the shared leaderboard.
+
+This guide covers what can live outside the repo, the three ways to handle infrastructure, the
+contract an external stack must satisfy, and the four failure modes that will otherwise cost
+you a run. A complete, runnable example lives in
+[`examples/out-of-tree-task/`](../../examples/out-of-tree-task/).
+
+For authoring the task spec itself — the schema, placeholders, rubric style — see
+[add a task](./add-a-task.md); everything there applies unchanged. For deployers and providers,
+see [infrastructure](../components/infra.md).
+
+## What can live outside the repo
+
+| Piece | Out-of-tree? | Mechanism |
+| --- | --- | --- |
+| **Task definition** | Yes | Any path passed as the CLI `source` — a directory or a single `.yaml` / `.yml` / `.json` file (`devops_bench/cli.py`, `FileSystemTaskLoader` in `devops_bench/tasks/loader.py`) |
+| **OpenTofu stack** | Yes | An absolute (or `~`) `stack:` path is used as-is; only a *relative* value resolves under `<repo>/tf` (`TFDeployer.__init__`, `devops_bench/deployers/tofu.py`) |
+| **Cloud provider** | Yes | Register under the `devops_bench.providers` entry-point group (`devops_bench/providers/base.py`) |
+| **Verifier** | Yes | Register under the `devops_bench.verifiers` entry-point group (`devops_bench/verification/base.py`) |
+| **Metric** | Yes | Register under the `devops_bench.metrics` entry-point group (`devops_bench/metrics/base.py`) |
+| **Deployer** | **No** | Selected by a fixed branch in `get_deployer` (`devops_bench/deployers/factory.py`); only `tofu` and `noop` exist. Contribute one upstream if you need a third |
+| **Agent harness** | **No** | The `AGENTS` registry declares no entry-point group (`devops_bench/agents/base.py`). See [add an agent harness](./add-an-agent-harness.md) |
+
+You rarely need a new deployer. `TFDeployer` is the universal OpenTofu engine — a new target is
+almost always a new *provider* plus a stack, and both of those can be yours.
+
+## Three ways to handle infrastructure
+
+### 1. Bring your own Terraform
+
+Give `stack:` an absolute path. The only real constraint is that the stack must satisfy the
+[output contract](#what-an-external-stack-must-provide).
+
+```yaml
+infrastructure:
+  deployer: "tofu"
+  provider: "gcp"        # required — see gotcha 1
+  stack: "/home/me/my-evals/tf/my-stack"
+  teardown: true
+  variables:
+    node_count: 3
+```
+
+### 2. Set infra up out of band
+
+`deployer: noop` skips provisioning entirely. The harness creates and destroys nothing and runs
+the agent against whatever your kubeconfig currently points at — an existing cluster you manage
+yourself, or no cluster at all for manifest-generation tasks.
+
+```yaml
+infrastructure:
+  deployer: "noop"
+```
+
+### 3. Ship a custom cloud provider
+
+Subclass `Provider` (`devops_bench/providers/base.py`), decorate it with
+`@PROVIDERS.register("<name>")`, and expose it from your own package:
+
+```toml
+# your package's pyproject.toml
+[project.entry-points."devops_bench.providers"]
+my-cloud = "my_package.provider:MyCloudProvider"
+```
+
+Install that package alongside devops-bench and `provider: "my-cloud"` resolves. The registry
+scans the entry-point group lazily on first miss (`devops_bench/core/registry.py`), so no
+change to this repo is needed. The same pattern works for verifiers and metrics.
+
+## What an external stack must provide
+
+> [!IMPORTANT]
+> Every stack `TFDeployer` drives **must** output `cluster_name` and `cluster_location`. That's
+> the contract `get_cluster_info()` reads back, and a missing or empty value is a hard
+> `ConfigError`. Note the second name: `cluster_location`, not `location`.
+
+```hcl
+output "cluster_name" {
+  value = kind_cluster.default.name
+}
+
+output "cluster_location" {
+  value = "local"
+}
+```
+
+The stack must also **declare** the variables the provider injects — `cluster_name`,
+`location`, `project_id`, `infra_provider`, and `kubeconfig_path`, depending on the provider
+(`resolve_variables()` in `devops_bench/providers/gcp.py` and `kind.py`). See gotcha 4.
+
+## Gotchas
+
+These are the four things that bite. Each is current behavior, verified against the code.
+
+### 1. An external stack must name its provider explicitly
+
+For in-repo stacks the provider is deduced from the stack name (`kind` in the name means kind,
+otherwise gcp). That deduction is **deliberately not applied** to external stacks —
+`_select_provider` (`devops_bench/deployers/factory.py`) raises rather than guess:
+
+```
+ConfigError: external stack '/home/me/my-evals/tf/my-stack' requires an explicit provider;
+set 'provider' in task config or the INFRA_PROVIDER env var (e.g. 'gcp' or 'kind')
+```
+
+Set `provider:` in the `infrastructure:` block, or export `INFRA_PROVIDER`. The env var wins.
+
+### 2. External stacks do not get per-run isolation
+
+Under `--parallel`, in-repo stacks are copied into a private per-run working directory so
+concurrent runs don't contend on `.terraform.lock.hcl` (no lock file is committed, so every
+`init` rewrites it). `_isolated_work_dir` (`devops_bench/deployers/tofu.py`) **cannot relocate
+an external stack safely, so it returns the original directory unchanged.**
+
+Two concurrent runs pointing at the *same* external stack directory will therefore fight over
+its lock file. If you run a matrix, give each concurrent run its own copy of the stack:
+
+```bash
+cp -r ~/my-evals/tf/my-stack /tmp/stack-$RUN_ID
+# ...and point that run's task at /tmp/stack-$RUN_ID
+```
+
+Per-run OpenTofu **state** is still isolated (`TF_DATA_DIR` and the state file are keyed per
+run) — it's only the working directory that's shared.
+
+### 3. Relative module sources break outside the repo
+
+In-repo stacks pull in shared modules with relative paths — `source = "../../modules/cluster"`
+in `tf/prebuilt/minimum/main.tf`. Copy that stack elsewhere and the path no longer resolves.
+Either declare your resources inline, or reference the modules over git:
+
+```hcl
+module "cluster" {
+  source = "git::https://github.com/gke-labs/devops-bench.git//tf/modules/cluster?ref=main"
+  # ...
+}
+```
+
+### 4. Undeclared variables are silently dropped
+
+`TFDeployer._var_flags` filters the variables it passes against the ones your stack actually
+declares. A **provider-injected** variable your stack doesn't declare is dropped with a log
+warning, not an error — so a stack that forgets `variable "cluster_name"` quietly provisions a
+cluster named by its own default instead of the run-unique name the harness chose. Under a
+parallel matrix, that means every concurrent run tries to create the *same* cluster.
+
+Keys you set yourself in the task's `variables:` block behave differently: those are tracked as
+custom keys and an undeclared one raises a `ConfigError` outright, on the theory that you
+clearly meant the stack to receive it.
+
+Declare everything the provider injects, even what your stack ignores. See
+[`examples/out-of-tree-task/tf/variables.tf`](../../examples/out-of-tree-task/tf/variables.tf).
+
+## Running it
+
+Same CLI as any other task — the `source` is just a different path:
+
+```bash
+# no infra at all
+BENCH_NO_INFRA=true python -m devops_bench --no-infra /abs/path/to/my-task.yaml
+
+# your own stack, real provisioning
+python -m devops_bench --project my-proj --cluster eval /abs/path/to/my-task.yaml
+
+# a whole directory of your tasks
+python -m devops_bench --project my-proj --cluster eval /abs/path/to/my-evals/tasks/
+```
+
+A directory source is scanned recursively for `task.yaml` files. All the usual flags apply —
+see [run evals](./run-evals.md).
+
+> [!NOTE]
+> **In the matrix wrapper** (`scripts/bastion/run_matrix.sh`), `MATRIX_TASKS` takes your paths
+> verbatim, so absolute out-of-tree paths work for **local** runs (each combo runs from the
+> repo root). Two caveats: `MATRIX_TASKS=ALL` is repo-scoped — it enumerates
+> `find tasks -name task.yaml` and will not see your tasks — and under `BENCH_REMOTE=1` the
+> wrapper syncs only the devops-bench working tree to the bastion and runs from there, so an
+> out-of-tree path must already exist at that same absolute path **on the bastion**. Copy your
+> task repo and stack over yourself before launching a remote matrix.
+
+## Leaderboard
+
+Out-of-tree tasks are for **your** results, not the shared board:
+
+- `validated: true` gates leaderboard eligibility, and validation means a human vetted the task
+  in this repo. Leave it `false` for private evals.
+- Task ids are not coordinated across repos. Yours may collide with an in-repo id; that's fine
+  in isolation but makes shared aggregation ambiguous.
+
+If a task turns out to be broadly useful, contribute it — run the `task-review` skill and open
+a PR to `tasks/`.

--- a/examples/out-of-tree-task/README.md
+++ b/examples/out-of-tree-task/README.md
@@ -1,0 +1,63 @@
+# Out-of-tree task example
+
+A complete, runnable benchmark task that lives **outside** the devops-bench repo — task
+definition and OpenTofu stack both. Copy this directory into your own repo, edit it, and point
+the harness at it. Nothing needs to be contributed back to devops-bench.
+
+This is the worked example for [How to run out-of-tree tasks](../../docs/how-to/out-of-tree-tasks.md);
+read that guide for the full extension surface and the gotchas.
+
+```
+out-of-tree-task/
+├── noop-task.yaml   # no infra at all — start here
+├── task.yaml        # provisions the stack below
+└── tf/
+    ├── main.tf      # self-contained kind cluster
+    └── variables.tf # declares what the harness injects
+```
+
+## Run it
+
+**1. No dependencies.** Proves an out-of-tree task file loads and grades. No cloud, no
+credentials, no Docker:
+
+```bash
+BENCH_NO_INFRA=true \
+AGENT_PROVIDER=gemini AGENT_MODEL=gemini-3.1-pro-preview AGENT_API_KEY=$GEMINI_KEY \
+JUDGE_PROVIDER=gemini JUDGE_MODEL=gemini-3.1-pro-preview JUDGE_API_KEY=$GEMINI_KEY \
+python -m devops_bench --no-infra /abs/path/to/out-of-tree-task/noop-task.yaml
+```
+
+**2. With your own Terraform.** Needs Docker and the `kind` binary. First set `stack:` in
+`task.yaml` to the absolute path of the `tf/` directory beside it — stack paths are not
+relative to the task file:
+
+```bash
+AGENT_PROVIDER=gemini AGENT_MODEL=gemini-3.1-pro-preview AGENT_API_KEY=$GEMINI_KEY \
+JUDGE_PROVIDER=gemini JUDGE_MODEL=gemini-3.1-pro-preview JUDGE_API_KEY=$GEMINI_KEY \
+python -m devops_bench --project "" --cluster oot-demo \
+  /abs/path/to/out-of-tree-task/task.yaml
+```
+
+Swap the kind stack for a GCP one by changing `provider:` to `gcp` and writing a stack that
+outputs `cluster_name` and `cluster_location`.
+
+## What to change first
+
+| Where | Why |
+| --- | --- |
+| `task.yaml` → `infrastructure.stack` | Must be the **absolute** path to your stack |
+| `task.yaml` → `infrastructure.provider` | **Required** for an external stack — the harness will not guess it |
+| `tf/variables.tf` | Declare every variable the harness injects, or it is silently dropped |
+| `tf/main.tf` outputs | `cluster_name` and `cluster_location` are a hard contract |
+| `prompt` / `expected_output` | Your actual scenario. Grade on outcome, not on one prescribed method |
+
+## Notes
+
+- Both task files use `{{...}}` placeholders for infra values. Never hardcode a cluster name or
+  project — that is what lets the same task run anywhere, and in parallel.
+- The `documentation:` blocks are optional; they enable the grounding metrics
+  (`GroundingAccuracy`, `ParameterRecallAccuracy`, `DocRetrievalRate`). See
+  [metrics](../../docs/components/metrics.md).
+- `validated: false` only matters if you publish to the shared leaderboard. Private evals can
+  ignore it.

--- a/examples/out-of-tree-task/noop-task.yaml
+++ b/examples/out-of-tree-task/noop-task.yaml
@@ -1,0 +1,46 @@
+# The zero-dependency out-of-tree task: no cloud, no credentials, no Docker.
+# Run it from anywhere on disk to prove the wiring works:
+#
+#   BENCH_NO_INFRA=true python -m devops_bench --no-infra /abs/path/to/noop-task.yaml
+#
+# `deployer: noop` also covers Pradeep's option 2 — infrastructure you set up
+# out of band. The harness will not create or destroy anything; it runs the
+# agent against whatever your current kubeconfig points at.
+
+task_id: "oot-example-noop"
+name: "out-of-tree-noop-example"
+
+infrastructure:
+  deployer: "noop"
+
+prompt: |
+  Generate a Kubernetes manifest that deploys the nginx web server to cluster
+  {{GKE_CLUSTER_NAME}} in namespace {{NAMESPACE}}. It should run 3 replicas and
+  be reachable from inside the cluster on port 80.
+
+expected_output: |
+  critical requirements:
+
+  - A Deployment running the nginx image with 3 replicas.
+  - A readiness probe so traffic is only sent to serving pods.
+  - CPU and memory resource requests set on the container.
+  - A ClusterIP Service selecting the Deployment's pods and exposing port 80.
+
+# Optional. Grounds scoring against authoritative docs and enables the
+# GroundingAccuracy / ParameterRecallAccuracy / DocRetrievalRate metrics.
+# See docs/components/metrics.md.
+documentation:
+  - doc_name: "Configure Liveness, Readiness and Startup Probes"
+    url: "https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/"
+    constraints:
+      - text: "readinessProbe on the nginx container"
+        critical: true
+  - doc_name: "Resource Management for Pods and Containers"
+    url: "https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+    constraints:
+      - text: "resources.requests for cpu and memory"
+        critical: false
+
+# Leave false until a human has vetted the task. Only meaningful if you intend
+# to publish to the shared leaderboard; private evals can ignore it.
+validated: false

--- a/examples/out-of-tree-task/task.yaml
+++ b/examples/out-of-tree-task/task.yaml
@@ -1,0 +1,70 @@
+# An out-of-tree task that provisions its OWN Terraform, from its own repo.
+#
+# Everything here — this file and the tf/ directory beside it — lives outside
+# devops-bench. You point the harness at the file and it does the rest:
+#
+#   python -m devops_bench --project "" --cluster oot-demo /abs/path/to/task.yaml
+#
+# Before running, set `stack:` below to the absolute path of the tf/ directory
+# next to this file. It is left as a placeholder because OpenTofu stack paths
+# cannot be relative to the task file (see the note on `stack:`).
+
+task_id: "oot-example"
+name: "out-of-tree-example"
+
+infrastructure:
+  deployer: "tofu"
+
+  # REQUIRED for an external stack. Provider deduction from the stack name only
+  # applies to in-repo (relative) stacks; `_select_provider` in
+  # devops_bench/deployers/factory.py raises a ConfigError rather than guessing
+  # for an absolute path. Omit this and the run fails immediately with:
+  #   external stack '...' requires an explicit provider
+  provider: "kind"
+
+  # An absolute path (or one starting with ~) is used as-is. A relative value
+  # would instead be resolved under <devops-bench>/tf, which is not what you
+  # want for an external stack. Set this to the tf/ dir beside this file.
+  stack: "/ABSOLUTE/PATH/TO/examples/out-of-tree-task/tf"
+
+  teardown: true
+
+  # Passed to tofu as -var flags. Every key here must be declared in the stack;
+  # an undeclared one is a hard ConfigError, not a warning — see tf/variables.tf.
+  variables:
+    kubeconfig_path: "~/.kube/config"
+
+prompt: |
+  Deploy the nginx web server to cluster {{GKE_CLUSTER_NAME}} in namespace
+  {{NAMESPACE}}. Run 3 replicas and make it reachable from inside the cluster
+  on port 80. Apply the manifests to the cluster; do not just print them.
+
+expected_output: |
+  critical requirements:
+
+  - An nginx Deployment is running in the cluster with 3 ready replicas.
+  - The pods carry the label app=nginx.
+  - A readiness probe is configured on the nginx container.
+  - A ClusterIP Service selects those pods and exposes port 80.
+
+# Deterministic cluster assertions, checked after the agent finishes. Leaf
+# verifier types come from the VERIFIERS registry
+# (devops_bench/verification/verifiers/); `sequence` and `parallel` compose
+# them. You can add your own verifier out-of-tree via the
+# `devops_bench.verifiers` entry-point group.
+verification_spec:
+  - name: "Nginx Rollout Verification"
+    spec:
+      type: pod_healthy
+      name: nginx_pods_ready
+      selector: "app=nginx"
+      namespace: "{{NAMESPACE}}"
+
+documentation:
+  - doc_name: "Configure Liveness, Readiness and Startup Probes"
+    url: "https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/"
+    constraints:
+      - text: "readinessProbe on the nginx container"
+        critical: true
+
+validated: false

--- a/examples/out-of-tree-task/tf/main.tf
+++ b/examples/out-of-tree-task/tf/main.tf
@@ -1,0 +1,42 @@
+# A self-contained OpenTofu stack that lives OUTSIDE the devops-bench repo.
+#
+# Self-contained is the important part. The in-repo stacks under `tf/prebuilt/`
+# pull in shared modules with relative paths (`source = "../../modules/cluster"`
+# in tf/prebuilt/minimum/main.tf), and those paths do not resolve once the stack
+# is somewhere else. An external stack must either declare its resources inline
+# — as this one does — or reference the shared modules over git:
+#
+#   module "cluster" {
+#     source = "git::https://github.com/gke-labs/devops-bench.git//tf/modules/cluster?ref=main"
+#     ...
+#   }
+
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    kind = {
+      source  = "tehcyx/kind"
+      version = ">= 0.5.0"
+    }
+  }
+}
+
+provider "kind" {}
+
+resource "kind_cluster" "default" {
+  name            = var.cluster_name
+  wait_for_ready  = true
+  kubeconfig_path = pathexpand(var.kubeconfig_path)
+}
+
+# The two outputs below are a HARD CONTRACT. `TFDeployer.get_cluster_info()`
+# (devops_bench/deployers/tofu.py) reads exactly these names and raises a
+# ConfigError if either is missing or empty. Note the second is
+# `cluster_location`, not `location`.
+output "cluster_name" {
+  value = kind_cluster.default.name
+}
+
+output "cluster_location" {
+  value = "local"
+}

--- a/examples/out-of-tree-task/tf/variables.tf
+++ b/examples/out-of-tree-task/tf/variables.tf
@@ -1,0 +1,40 @@
+# Declare every variable the harness may inject, even the ones this stack
+# ignores. `TFDeployer` filters `-var` flags against the variables a stack
+# actually declares (devops_bench/deployers/tofu.py `_var_flags`), so an
+# undeclared variable is silently DROPPED rather than passed through — the stack
+# then falls back to its own default and you get a cluster with the wrong name.
+#
+# The provider decides what gets injected: see `resolve_variables()` in
+# devops_bench/providers/kind.py (kind) or gcp.py (GCP).
+
+variable "cluster_name" {
+  type        = string
+  description = "Run-unique cluster name, injected by the harness."
+  default     = "devops-bench-oot"
+}
+
+variable "location" {
+  type        = string
+  description = "Region/zone (GCP) or 'local' (kind)."
+  default     = "local"
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  description = "Where to write the kubeconfig."
+  default     = "~/.kube/config"
+}
+
+# Injected by both providers. Unused by this kind stack, but declared so they
+# are not dropped with a warning in the run log.
+variable "infra_provider" {
+  type        = string
+  description = "Target infra provider (gcp, kind)."
+  default     = "kind"
+}
+
+variable "project_id" {
+  type        = string
+  description = "GCP project ID; 'local' under the kind provider."
+  default     = ""
+}

--- a/tasks/AGENTS.md
+++ b/tasks/AGENTS.md
@@ -10,4 +10,5 @@ A task is `tasks/<provider>/<name>/task.yaml` — the typed eval contract.
   its verification/chaos specs.
 - Run the **task-review** skill before submitting.
 
-Deeper guide: `../docs/how-to/add-a-task.md`.
+Deeper guide: `../docs/how-to/add-a-task.md`. Tasks do not have to live here — to keep yours
+in your own repo, see `../docs/how-to/out-of-tree-tasks.md`.


### PR DESCRIPTION
Follow-up to the agentic-integrity-evals thread, where the ask was "an example or instructions in the README" for defining tasks whose `task.yaml` and Terraform live in a consumer's own repo.

**Docs only — zero source changes.** The capability already exists in full; what was missing is a written-down description of it and of the ways it bites.

## What's here

- `docs/how-to/out-of-tree-tasks.md` — the guide: what can live outside the repo, three ways to handle infra, the external-stack contract, four gotchas, matrix caveats, leaderboard note.
- `examples/out-of-tree-task/` — a directory to copy wholesale into your own repo:
  - `noop-task.yaml` — `deployer: noop`, runs with no cloud, no credentials, no Docker.
  - `task.yaml` + `tf/` — `deployer: tofu` with an absolute `stack:` path and a self-contained kind stack. kind rather than GCP so anyone with Docker can run it.
- Index wiring: `README.md`, `docs/README.md`, `docs/how-to/add-a-task.md`, `docs/components/infra.md`, `AGENTS.md`, `tasks/AGENTS.md`.

## Corrects one claim

Out-of-tree **providers** are supported, contrary to what's been said in passing. `PROVIDERS` carries the entry-point group `devops_bench.providers` (`devops_bench/providers/base.py:27-30`), as do `METRICS` and `VERIFIERS`. Genuinely in-repo-only: **deployers** (fixed branch in `deployers/factory.py`) and **agent harnesses** (`AGENTS` registry declares no group). The guide's extension-surface table says so plainly rather than implying everything is pluggable.

## The four gotchas

1. **An external stack must name its provider explicitly.** `_select_provider` refuses to deduce it from an absolute path. *Empirically reproduced* — the `ConfigError` text in the doc is verbatim from the run.
2. **External stacks don't get per-run isolation.** `_isolated_work_dir` returns the original dir when the stack is outside `tf/`, so concurrent runs of the same external stack contend on `.terraform.lock.hcl`. Documented, **not fixed** — see below.
3. **Relative module sources break outside the repo.** `source = "../../modules/cluster"` doesn't resolve elsewhere; the example shows both the inline and the git-module-source fix.
4. **Undeclared variables are dropped.** Provider-injected ones with a log warning; keys from the task's own `variables:` block raise a `ConfigError` (they're tracked as custom keys). *Empirically reproduced* — deleting `variable "cluster_name"` confirmed the injected name never reaches tofu.

Gotcha 2 is left as-is deliberately. Fixing it is a behavior change with parallel-safety implications and deserves its own PR, not a drive-by in a docs change; it's already tracked as a known hack at `docs/appendix/known_issues.md:65`. The guide documents current behavior and gives the workaround (per-run copy of the stack dir).

## Verification

- Both task files load from `/tmp/oot-demo`, outside the repo.
- `get_deployer` resolves the absolute stack and passes all five injected vars as `-var` flags.
- Gotchas 1 and 4 reproduced (above).
- `tofu validate` → valid; `tofu fmt -check -recursive examples/` clean.
- `pytest tests/` → 932 passed. Ruff error count identical with and without this change (pre-existing, and this PR adds no Python).
- `MATRIX_TASKS=ALL` globs `find tasks -name task.yaml`, so nothing under `examples/` can reach the leaderboard matrix.