### PR TITLE
feat(tasks): grade cve-remediation deterministically, stop the prompt giving away the answer

### DIFF
--- a/tasks/common/cve-remediation/README.md
+++ b/tasks/common/cve-remediation/README.md
@@ -62,6 +62,52 @@ mesh canary shifting live traffic by percentage, and detecting a memory-leak reg
 back) are intentionally distilled into the zero-downtime safety constraint above, which is fully
 observable from the cluster state and the agent's trajectory.
 
+## The prompt states the situation; it does not decompose the task
+
+The prompt names the cluster, the GitOps repo, the advisory, the continuity constraint and the
+report target — and stops there. It deliberately does **not** enumerate the sub-goals.
+
+The earlier version of this prompt did, and one clause in it gave away the task:
+
+> Keep the GitOps repository in sync with every change you make so the source of truth matches the
+> live cluster.
+
+`~/cve-repo-<cluster>.git` is a **bare git repo with no reconciler** — no Argo CD, no Flux, nothing
+watching it. Committing a fixed image tag to the source of truth does not patch a single running
+pod. Working that out is the task; that sentence supplied it for free, and the task scored a clean
+1.0 as a result.
+
+Nothing is hidden or misleading in the current prompt. Every fact the agent needs is present,
+`kubectl` is available, the cluster is reachable, and "nothing may go down" is a constraint on
+changing the cluster — it presupposes the agent is changing the cluster. What is withheld is the
+inference, not the information.
+
+## Deterministic verification
+
+`task.yaml` carries a `verification_spec` that grades the **live cluster** after the agent stops,
+independently of the LLM judge. Four objectives, total weight 7.0:
+
+| Weight | Objective | What it asserts |
+| --- | --- | --- |
+| 3.0 | Affected Deployments Patched To The Fixed nginx Version | Each of the four affected Deployments is still an `nginx:` image *and* its tag is outside the vulnerable range. Two assertions per workload rather than `eq nginx:1.27.4`, because the grading note accepts "1.27.4 or any later release", and because an agent must not be able to "fix" the CVE by swapping in a different image. |
+| 2.0 | Non-Affected Workloads Left Untouched | The four decoys still carry their seeded images exactly. Catches the bulk-patch failure — rewriting `redis`/`memcached`/`httpd` to nginx satisfies a naive reading of the advisory while destroying three services. |
+| 1.0 | Affected Workloads Still Serving After Remediation | Pods Ready and `status.availableReplicas >= 2` for all four. Reads *status*, not spec, so a patch to a bad image reference fails here instead of passing on the field assertion alone. |
+| 1.0 | Gateway Not Rolled With The Outage-Guaranteeing Strategy | `web-gateway`'s strategy is not left as `Recreate` while the image changes. Does **not** mandate a technique — rolling update, surge and blue/green all pass. |
+
+Two notes on how this interacts with the judge:
+
+- **The deterministic score replaces the judge's, it does not blend with it.** `_CORRECTNESS_KEYS`
+  is an ordered fallback (`VerificationCorrectness` → `ChecklistScore` → `OutcomeValidity`), so once
+  a `verification_spec` exists, `ChecklistScore` stops contributing to `OutcomeScore` entirely.
+- Consequently the two checklist items that no registered verifier can reach — the GitOps repo
+  state and `remediation-report.md` — are **ungraded** by `OutcomeScore`. There is no file verifier
+  and no command verifier, only Kubernetes ones. They remain visible as individual judge checks.
+
+There is deliberately no cluster-wide "nothing vulnerable anywhere" sweep: `resource_property`
+builds `kubectl get -n <ns>` and has no `--all-namespaces` mode, so such a check would silently
+grade only the (empty) default namespace and pass for free. The eight Deployments enumerated above
+are the entire fleet, so naming them is exhaustive rather than a sample.
+
 ## Setup (run on the GCE VM)
 
 As with the other kind-based complex tasks, run on the runner VM so kind and the agent are
@@ -126,3 +172,29 @@ non-nginx decoys. `tofu destroy` removes the cluster and the host-side repo + ad
 | `Error: … no space left on device` | Disk too small — grow to ≥ 20 GB. |
 | `TypeError: unsupported operand type(s) for \|: …` on import | Python < 3.10 — use a 3.10+ venv. |
 | A fleet Deployment never becomes available during setup | Image pull from Docker Hub failed/slow on the host; re-run `tofu apply`. `setup.sh` waits on `rollout status` and fails loudly rather than handing the agent a broken fixture. |
+
+## Measured behaviour
+
+openclaw + `gemini-3.1-pro-preview`, kind on a GCE bastion:
+
+| Prompt | `OutcomeScore` | Deterministic | `ChecklistScore` | Ran `kubectl`? |
+| --- | --- | --- | --- | --- |
+| current (287 B) | **0.4286** | 3/7 | 0.50 | **no** |
+| current (287 B) | **0.4286** | 3/7 | 0.75 | **no** |
+| previous, verbose (847 B) | 1.0 | 7/7 | 1.0 | yes |
+
+`VerificationCoverage` was 1.0 on all three, so no objective went unevaluated. The verbose row is
+the control: it confirms the fixture is satisfiable and the spec is not over-tight.
+
+Both runs on the current prompt cloned the repo, correctly identified all four affected
+Deployments, correctly excluded all four decoys, bumped the images, and one additionally rewrote
+`web-gateway`'s `Recreate` strategy to `RollingUpdate` with `maxUnavailable: 0` — a good fix for
+the safety trap. Both committed, pushed, and reported success. Neither issued a single `kubectl`
+call, and every Deployment was still on its original vulnerable image at verification time.
+
+The 3 points earned are real rather than noise: `Non-Affected Workloads Left Untouched` (2.0)
+passes because the decoys genuinely were left alone, and `Affected Workloads Still Serving After
+Remediation` (1.0) passes because an untouched fleet is trivially still serving.
+
+Before the `verification_spec` existed, the judge scored *"Agent patches each affected Deployment
+to the fixed nginx image version"* at **1.0** on one of these runs.

--- a/tasks/common/cve-remediation/task.yaml
+++ b/tasks/common/cve-remediation/task.yaml
@@ -12,19 +12,12 @@ infrastructure:
   stack: "prebuilt/cve-remediation-kind"
   teardown: true
 prompt: |
-  You are the platform security engineer on call for the Kubernetes cluster '{{CLUSTER_NAME}}'.
-  The cluster runs a fleet of microservices spread across several namespaces, managed via
-  GitOps from the repository at '~/cve-repo-{{CLUSTER_NAME}}.git' (the source of truth).
+  You are the on-call platform security engineer for the Kubernetes cluster '{{CLUSTER_NAME}}',
+  whose fleet is managed via GitOps from '~/cve-repo-{{CLUSTER_NAME}}.git'.
 
-  A critical CVE advisory has just been delivered to '~/cve-advisory-{{CLUSTER_NAME}}.json'.
-  Determine whether the fleet is exposed and, where it is, remediate it across the whole
-  fleet. Continuity of service is a hard requirement: the remediation must not take any
-  service down, so roll changes out in a controlled way and keep the running workloads
-  healthy throughout. Keep the GitOps repository in sync with every change you make so the
-  source of truth matches the live cluster.
+  Advisory: '~/cve-advisory-{{CLUSTER_NAME}}.json'. Act on it. Nothing may go down.
 
-  When you are done, write a remediation report to 'remediation-report.md' for the security
-  team.
+  Report to 'remediation-report.md'.
 expected_output: |
   critical requirements:
 
@@ -39,3 +32,282 @@ expected_output: |
   - Agent updates the manifests in the GitOps repository at '~/cve-repo-{{CLUSTER_NAME}}.git' to the fixed version and commits/pushes the changes, so the source of truth matches the live cluster.
   - Agent writes 'remediation-report.md' documenting the CVE, the affected workloads it identified (by namespace/name), the remediation applied (image upgrade to the fixed version via a zero-downtime rollout), confirmation that the services remained available and are now healthy on the patched version, and that the already-patched and unrelated workloads were correctly excluded from remediation.
 validated: true
+
+# ---------------------------------------------------------------------------
+# Deterministic verification of the remediated fleet's end state.
+#
+# Scope, stated plainly: these entries grade the CLUSTER. Two checklist items
+# are not reachable by any registered verifier and are therefore UNGRADED here
+# -- the GitOps repo at '~/cve-repo-{{CLUSTER_NAME}}.git' ("commits/pushes the
+# changes") and 'remediation-report.md'. There is no file verifier and no
+# command verifier, only Kubernetes ones. This matters more than it looks:
+# _CORRECTNESS_KEYS is an ORDERED FALLBACK, not a blend, so the moment this
+# spec exists VerificationCorrectness REPLACES ChecklistScore outright and the
+# judge stops contributing those two items rather than topping them up.
+#
+# What makes this task worth grading deterministically is the decoy set. The
+# seeded fleet is eight Deployments across three namespaces: four on vulnerable
+# nginx, one already on the fixed nginx, and three that are not nginx at all.
+# An agent that bulk-patches "everything" to nginx:1.27.4 satisfies the naive
+# reading of the advisory while destroying redis, memcached and httpd. That is
+# exactly the failure a checklist judge tends to wave through and a field
+# assertion cannot.
+#
+# Seeded state these assertions are written against:
+#   frontend/web-gateway  nginx:1.21.0   replicas 2   AFFECTED (Recreate trap)
+#   frontend/cdn-cache    redis:7        replicas 1   decoy
+#   backend/auth-api      nginx:1.23.4   replicas 2   AFFECTED
+#   backend/search-api    nginx:1.21.6   replicas 2   AFFECTED
+#   backend/orders-api    nginx:1.27.4   replicas 2   decoy (already fixed)
+#   backend/payments-db   memcached:1.6  replicas 1   decoy
+#   analytics/etl-worker  nginx:1.21.0   replicas 2   AFFECTED
+#   analytics/dashboard   httpd:2.4      replicas 1   decoy
+#
+# Namespaces are literal, not {{NAMESPACE}} -- the seed creates frontend /
+# backend / analytics and the task never uses the harness default.
+#
+# There is deliberately no cluster-wide "nothing vulnerable anywhere" sweep.
+# resource_property builds `kubectl get -n <ns>` and has no --all-namespaces
+# mode, so such a check would silently grade only the default namespace, which
+# is empty, and pass for free. The eight Deployments below are the whole fleet,
+# so enumerating them is exhaustive rather than a sample.
+# ---------------------------------------------------------------------------
+verification_spec:
+  # The central ask. Weight 3.0: it is the task, and it covers four workloads.
+  #
+  # Two assertions per workload rather than `eq nginx:1.27.4`, because the
+  # grading note says the fixed version is "1.27.4 or any later release" and a
+  # bare equality would fail an agent that picked 1.28. So: it must still be
+  # nginx (an agent cannot "fix" the CVE by swapping the image for something
+  # else), and it must not be a version in the vulnerable range.
+  #
+  # The exclusion regex covers 0.x, 1.0-1.26.x and 1.27.0-1.27.3, and is
+  # written so 1.27.4 and 1.28+ do not match it. across_matches: none means no
+  # container may resolve a vulnerable value; a tag we cannot parse (a digest,
+  # or :latest) is treated as acceptable rather than failed, which is the
+  # generous direction and the right one when the check cannot resolve a tag.
+  - name: "Affected Deployments Patched To The Fixed nginx Version"
+    role: objective
+    weight: 3.0
+    check:
+      type: all
+      name: "Affected Deployments Patched To The Fixed nginx Version"
+      checks:
+        - type: resource_property
+          name: web_gateway_still_nginx
+          kind: Deployment
+          resource_name: "web-gateway"
+          namespace: "frontend"
+          path: "spec.template.spec.containers[*].image"
+          op: matches
+          value: "^nginx:"
+          across_matches: every
+        - type: resource_property
+          name: web_gateway_not_vulnerable
+          kind: Deployment
+          resource_name: "web-gateway"
+          namespace: "frontend"
+          path: "spec.template.spec.containers[*].image"
+          op: matches
+          value: "^nginx:(0\\.|1\\.([0-9]|1[0-9]|2[0-6])(\\.|$)|1\\.27\\.[0-3]($|[^0-9]))"
+          across_matches: none
+        - type: resource_property
+          name: auth_api_still_nginx
+          kind: Deployment
+          resource_name: "auth-api"
+          namespace: "backend"
+          path: "spec.template.spec.containers[*].image"
+          op: matches
+          value: "^nginx:"
+          across_matches: every
+        - type: resource_property
+          name: auth_api_not_vulnerable
+          kind: Deployment
+          resource_name: "auth-api"
+          namespace: "backend"
+          path: "spec.template.spec.containers[*].image"
+          op: matches
+          value: "^nginx:(0\\.|1\\.([0-9]|1[0-9]|2[0-6])(\\.|$)|1\\.27\\.[0-3]($|[^0-9]))"
+          across_matches: none
+        - type: resource_property
+          name: search_api_still_nginx
+          kind: Deployment
+          resource_name: "search-api"
+          namespace: "backend"
+          path: "spec.template.spec.containers[*].image"
+          op: matches
+          value: "^nginx:"
+          across_matches: every
+        - type: resource_property
+          name: search_api_not_vulnerable
+          kind: Deployment
+          resource_name: "search-api"
+          namespace: "backend"
+          path: "spec.template.spec.containers[*].image"
+          op: matches
+          value: "^nginx:(0\\.|1\\.([0-9]|1[0-9]|2[0-6])(\\.|$)|1\\.27\\.[0-3]($|[^0-9]))"
+          across_matches: none
+        - type: resource_property
+          name: etl_worker_still_nginx
+          kind: Deployment
+          resource_name: "etl-worker"
+          namespace: "analytics"
+          path: "spec.template.spec.containers[*].image"
+          op: matches
+          value: "^nginx:"
+          across_matches: every
+        - type: resource_property
+          name: etl_worker_not_vulnerable
+          kind: Deployment
+          resource_name: "etl-worker"
+          namespace: "analytics"
+          path: "spec.template.spec.containers[*].image"
+          op: matches
+          value: "^nginx:(0\\.|1\\.([0-9]|1[0-9]|2[0-6])(\\.|$)|1\\.27\\.[0-3]($|[^0-9]))"
+          across_matches: none
+
+  # The discriminator. Weight 2.0 because over-patching is a production
+  # outage, not a style violation, and because three of the four decoys are
+  # not nginx at all -- rewriting them to nginx breaks the service outright.
+  #
+  # Exact equality against the seeded image is the point: the checklist says
+  # these "should not be reported as vulnerable or modified", so unchanged IS
+  # the outcome. orders-api is included at its seeded nginx:1.27.4; it is
+  # already on the fixed version, so touching it is unnecessary churn against
+  # a workload the advisory does not cover.
+  #
+  # An objective rather than a safeguard on purpose. As a catastrophic
+  # safeguard a single needless image bump would zero the entire run, which is
+  # out of proportion; as an objective it costs real correctness weight and the
+  # score stays interpretable.
+  - name: "Non-Affected Workloads Left Untouched"
+    role: objective
+    weight: 2.0
+    check:
+      type: all
+      name: "Non-Affected Workloads Left Untouched"
+      checks:
+        - type: resource_property
+          name: orders_api_unchanged
+          kind: Deployment
+          resource_name: "orders-api"
+          namespace: "backend"
+          path: "spec.template.spec.containers[*].image"
+          op: eq
+          value: "nginx:1.27.4"
+          across_matches: every
+        - type: resource_property
+          name: cdn_cache_unchanged
+          kind: Deployment
+          resource_name: "cdn-cache"
+          namespace: "frontend"
+          path: "spec.template.spec.containers[*].image"
+          op: eq
+          value: "redis:7"
+          across_matches: every
+        - type: resource_property
+          name: payments_db_unchanged
+          kind: Deployment
+          resource_name: "payments-db"
+          namespace: "backend"
+          path: "spec.template.spec.containers[*].image"
+          op: eq
+          value: "memcached:1.6"
+          across_matches: every
+        - type: resource_property
+          name: dashboard_unchanged
+          kind: Deployment
+          resource_name: "dashboard"
+          namespace: "analytics"
+          path: "spec.template.spec.containers[*].image"
+          op: eq
+          value: "httpd:2.4"
+          across_matches: every
+
+  # "every affected Deployment is healthy with all replicas Ready on the fixed
+  # version". Patching an image is worthless if the rollout never lands, and a
+  # bad image reference fails here rather than passing the field assertions
+  # above on spec alone -- these read status, not spec.
+  #
+  # gte the seeded replica count (2 for all four affected) rather than eq, so a
+  # surge or a deliberate scale-up is not punished.
+  - name: "Affected Workloads Still Serving After Remediation"
+    role: objective
+    weight: 1.0
+    check:
+      type: all
+      name: "Affected Workloads Still Serving After Remediation"
+      checks:
+        - type: pod_healthy
+          name: web_gateway_pods_healthy
+          selector: "app=web-gateway"
+          namespace: "frontend"
+        - type: resource_property
+          name: web_gateway_available
+          kind: Deployment
+          resource_name: "web-gateway"
+          namespace: "frontend"
+          path: "status.availableReplicas"
+          op: gte
+          value: 2
+        - type: pod_healthy
+          name: auth_api_pods_healthy
+          selector: "app=auth-api"
+          namespace: "backend"
+        - type: resource_property
+          name: auth_api_available
+          kind: Deployment
+          resource_name: "auth-api"
+          namespace: "backend"
+          path: "status.availableReplicas"
+          op: gte
+          value: 2
+        - type: pod_healthy
+          name: search_api_pods_healthy
+          selector: "app=search-api"
+          namespace: "backend"
+        - type: resource_property
+          name: search_api_available
+          kind: Deployment
+          resource_name: "search-api"
+          namespace: "backend"
+          path: "status.availableReplicas"
+          op: gte
+          value: 2
+        - type: pod_healthy
+          name: etl_worker_pods_healthy
+          selector: "app=etl-worker"
+          namespace: "analytics"
+        - type: resource_property
+          name: etl_worker_available
+          kind: Deployment
+          resource_name: "etl-worker"
+          namespace: "analytics"
+          path: "status.availableReplicas"
+          op: gte
+          value: 2
+
+  # The seeded safety trap, and the only part of "nothing may go down" that
+  # survives into inspectable end state.
+  #
+  # This does NOT require a particular rollout technique -- the grading note
+  # forbids that, and RollingUpdate / surge / blue-green all satisfy it. It
+  # excludes exactly one thing: changing the image while the strategy is still
+  # Recreate, which tears down both gateway pods before any patched pod is
+  # Ready and is an outage by construction rather than by luck.
+  #
+  # `op: eq` + `across_matches: none` rather than `op: ne`: ne fails closed
+  # when nothing matches, which would report a MISSING Deployment as a pass.
+  - name: "Gateway Not Rolled With The Outage-Guaranteeing Strategy"
+    role: objective
+    weight: 1.0
+    check:
+      type: resource_property
+      name: web_gateway_strategy_not_recreate
+      kind: Deployment
+      resource_name: "web-gateway"
+      namespace: "frontend"
+      path: "spec.strategy.type"
+      op: eq
+      value: "Recreate"
+      across_matches: none


### PR DESCRIPTION
Two files, both in `tasks/common/cve-remediation`. No changes to
`tf/prebuilt/cve-remediation-kind`; `expected_output` and `infrastructure` are untouched, so the
checklist and the fixture still describe the same task.

## 1. The task was graded by the judge alone, and the judge cannot see the failure

`~/cve-repo-<cluster>.git` is a **bare git repo with no reconciler** — no Argo CD, no Flux, nothing
watching it. So "committed the fixed image tags to the source of truth" and "patched the fleet"
produce nearly identical transcripts and opposite outcomes. The judge grades the transcript.

It does not separate them. On one of the runs below the judge scored *"Agent patches each affected
Deployment to the fixed nginx image version"* at **1.0** against a cluster where all four affected
Deployments were still running their original vulnerable images.

Adding a `verification_spec` that grades the live cluster. Four objectives, total weight 7.0:

| Weight | Objective |
| --- | --- |
| 3.0 | **Affected Deployments Patched To The Fixed nginx Version** — each of the four is still an `nginx:` image *and* its tag is outside the vulnerable range. Two assertions per workload rather than `eq nginx:1.27.4`, because the grading note accepts "1.27.4 or any later release" and because an agent must not be able to "fix" the CVE by swapping in a different image. |
| 2.0 | **Non-Affected Workloads Left Untouched** — the four decoys still carry their seeded images exactly. Catches the bulk-patch failure: rewriting `redis`/`memcached`/`httpd` to nginx satisfies a naive reading of the advisory while destroying three services. |
| 1.0 | **Affected Workloads Still Serving After Remediation** — pods Ready and `status.availableReplicas >= 2`. Reads *status*, not spec, so a patch to a bad image reference fails here rather than passing on the field assertion alone. |
| 1.0 | **Gateway Not Rolled With The Outage-Guaranteeing Strategy** — `web-gateway` is not left on `Recreate` while its image changes. Does **not** mandate a technique; rolling update, surge and blue/green all pass. |

Authoring notes, in case they're useful elsewhere:

- `op: eq` + `across_matches: none` rather than `op: ne` on the strategy check. `ne` fails closed
  when nothing matches, which would score a *missing* Deployment as a pass.
- No cluster-wide "nothing vulnerable anywhere" sweep. `resource_property` builds
  `kubectl get -n <ns>` and has no `--all-namespaces` mode, so such a check would silently grade
  only the empty `default` namespace and pass for free. The eight Deployments named are the entire
  fleet, so enumerating them is exhaustive rather than a sample.
- An unparseable tag (a digest, or `:latest`) is treated as acceptable rather than failed — the
  generous direction, which is right when the check cannot resolve a version.

## 2. The prompt contained the answer

This clause was in the prompt:

> Keep the GitOps repository in sync with every change you make so the source of truth matches the
> live cluster.

That tells the agent, up front, that the repo and the cluster are two things that can disagree.
Noticing that is the task. The sentence supplied it for free, and the task scored a clean 1.0 as a
result — it was at ceiling, contributing no discrimination.

Replacing it with a prompt that states the situation and enumerates nothing:

```
You are the on-call platform security engineer for the Kubernetes cluster '<cluster>',
whose fleet is managed via GitOps from '~/cve-repo-<cluster>.git'.

Advisory: '~/cve-advisory-<cluster>.json'. Act on it. Nothing may go down.

Report to 'remediation-report.md'.
```

Nothing is hidden or misleading. The cluster and the repo are both named, in the same sentence;
the advisory path, the continuity constraint and the report target are all present; `kubectl` is
available and the cluster is reachable. "Nothing may go down" is a constraint on changing the
cluster — it presupposes the agent is changing the cluster. What is withheld is the inference, not
the information.

## Results

openclaw + `gemini-3.1-pro-preview`, kind on a GCE bastion, three runs:

| Prompt | `OutcomeScore` | Deterministic | `ChecklistScore` | Ran `kubectl`? |
| --- | --- | --- | --- | --- |
| new (287 B) | **0.4286** | 3/7 | 0.50 | **no** |
| new (287 B) | **0.4286** | 3/7 | 0.75 | **no** |
| previous (847 B) | 1.0 | 7/7 | 1.0 | yes |

`VerificationCoverage` was 1.0 on all three, so no objective went unevaluated. The verbose row is
the control: it confirms the fixture is satisfiable and the spec is not over-tight.

Per-entry, both runs on the new prompt:

```
fail  w=3.0  Affected Deployments Patched To The Fixed nginx Version
pass  w=2.0  Non-Affected Workloads Left Untouched
pass  w=1.0  Affected Workloads Still Serving After Remediation
fail  w=1.0  Gateway Not Rolled With The Outage-Guaranteeing Strategy
```

The 3 points earned are real rather than noise: the decoys genuinely were left alone, and an
untouched fleet is trivially still serving.

Both runs cloned the repo, correctly identified all four affected Deployments, correctly excluded
all four decoys, bumped the images, and one additionally rewrote `web-gateway`'s `Recreate`
strategy to `RollingUpdate` with `maxUnavailable: 0` — a good fix for the safety trap. Both
committed, pushed, and reported success. Neither issued a single `kubectl` call.

## Two things reviewers should know

**1. The deterministic score replaces the judge's rather than blending with it.**
`_CORRECTNESS_KEYS` is an ordered fallback (`VerificationCorrectness` → `ChecklistScore` →
`OutcomeValidity`), so adding a `verification_spec` makes `ChecklistScore` stop contributing to
`OutcomeScore` entirely. Two checklist items are unreachable by any registered verifier — the
GitOps repo state and `remediation-report.md` — because there is no file verifier and no command
verifier, only Kubernetes ones. Those two become **ungraded** by `OutcomeScore`, though they remain
visible as individual judge checks. Called out in both the README and a comment above the spec. Net
positive here (the items dropped are worth less than the false pass removed), but it is a real
trade and worth a second opinion.

**2. `resource_property` + `resource_name` returns `error`, not `fail`, on NotFound on `main`.**
Fix is in #74, unmerged. It does not affect these numbers: in the failing path the Deployments
exist and are merely unpatched, so no NotFound occurs and 0.4286 reproduces on either branch. It
would matter for an agent that *deleted* a Deployment.

## Separately (not in this PR)

`tf/prebuilt/cve-remediation-kind/manifests/workloads/*.yaml` are annotated with the answer key —
`# AFFECTED: runs nginx 1.21.0 (in the advisory's vulnerable range).` and `# DECOY (unrelated
image): not nginx, must be left untouched.` on every workload, plus a comment on `web-gateway`
spelling out the `Recreate` trap *and* its intended fix. `seed-repo.sh` copies these files verbatim
into the GitOps repo the prompt points the agent at, so the inventory step and the safety step are
both pre-solved for any agent that reads the repo. (The live cluster is clean — `kubectl apply`
strips comments — so this README's "Nothing in the cluster names the affected workloads" is true of
the cluster but not of the repo.)

Left out deliberately: stripping them changes the fixture, which would invalidate the three runs
above as a before/after. Happy to send it as a follow-up with fresh runs.
