### PR TITLE
fix(tasks): make multi-region-failover exercise failover, and cut the prompt to the incident (0.80 → 0.50)

### DIFF
--- a/tasks/gcp/multi-region-failover/task.yaml
+++ b/tasks/gcp/multi-region-failover/task.yaml
@@ -12,18 +12,14 @@ infrastructure:
   stack: "prebuilt/multi-region-failover"
   teardown: true
 prompt: |
-  You are the platform engineer on call for the "storefront" web service in project
-  "{{GCP_PROJECT_ID}}" — a user-facing application that runs on the project's GKE
-  infrastructure (Kubernetes namespace "{{NAMESPACE}}"). The application's desired state
-  is tracked in the git repository at "~/app-repo-{{GKE_CLUSTER_NAME}}.git" (the source of truth).
+  You are the platform engineer on call for the "storefront" web service in
+  project "{{GCP_PROJECT_ID}}".
 
-  Users report the storefront is down. The provider has declared a capacity incident in
-  the affected region: no new compute capacity can be obtained there while the incident
-  lasts, so your recovery must not depend on getting nodes back in that region.
+  Users report the storefront is down. The provider has declared a capacity
+  incident in the affected region; no new compute capacity is available there.
 
-  Investigate, restore the service to a healthy state for users, and write a post-mortem
-  to "incident-report.md" describing what happened, the actions you took, and any
-  follow-ups. Summarise that post-mortem in your final response.
+  Investigate, restore the service, and write a post-mortem covering what
+  happened, what you did, and any follow-ups.
 expected_output: |
   critical requirements:
 
@@ -46,6 +42,15 @@ expected_output: |
     datastore only: probing an HTTP endpoint, or confirming that the standby's pods are
     Running, is not a replication check and does not satisfy it. If the agent never
     inspects the Cloud SQL instances at all, this item fails.
+  - Agent establishes where the application's WRITE path points once traffic is running in
+    the standby region. "app-config" names a Cloud SQL primary ("SQL_PRIMARY") that lives in
+    the impaired region and a read-only replica ("SQL_REPLICA") in the standby, so after the
+    failover writes either still cross back into the impaired region or have nowhere to go.
+    The agent must resolve this one way or the other: either make writes serveable from the
+    standby (for example by promoting the replica), or state explicitly that the primary
+    remains reachable because the incident affects compute only, and record the resulting
+    cross-region write dependency as a risk or follow-up. Either resolution passes this item.
+    Saying nothing at all about the write path after the failover fails it.
   - Agent shifts user traffic to the standby region by changing the global load balancer's
     routing (its URL map's default service).
   - Agent gives the standby enough capacity to absorb the redirected production traffic —
@@ -53,12 +58,14 @@ expected_output: |
     pre-incident standby size.
   - Agent reconciles the standby's configuration drift against the source of truth: it
     detects that "app-config" and "app-secret" are absent from the standby's namespace and
-    applies them from "~/app-repo-{{GKE_CLUSTER_NAME}}.git".
+    applies them from the GitOps repository it finds on disk ("~/app-repo-*.git").
   - Agent honours the stated capacity constraint: it does NOT restore service by
     provisioning new nodes or a new node pool in the impaired region. Recreating capacity
     there fails this item even if the service ends up healthy.
   - Agent validates the fix from the user's vantage point: it requests the global endpoint
     after the change and observes a successful (2xx) response, rather than inferring
     recovery from per-cluster or per-region checks alone.
-  - Agent writes "incident-report.md" and reports its substance in its final response,
-    covering the incident timeline, the root cause, the actions it took, and follow-ups.
+  - Agent writes a post-mortem to a file on disk AND reports its substance in its final
+    response, covering the incident timeline, the root cause, the actions it took, and
+    follow-ups. The prompt does not specify a filename, so ANY filename satisfies this
+    item — do not fail it because a particular name was not used.

--- a/tasks/gcp/multi-region-failover/task.yaml
+++ b/tasks/gcp/multi-region-failover/task.yaml
@@ -17,15 +17,48 @@ prompt: |
   infrastructure (Kubernetes namespace "{{NAMESPACE}}"). The application's desired state
   is tracked in the git repository at "~/app-repo-{{GKE_CLUSTER_NAME}}.git" (the source of truth).
 
-  Investigate the ongoing outage in the storefront service, restore the service to a
-  healthy state for users, and write a post-mortem to "incident-report.md" describing
-  what happened, the actions you took, and any follow-ups.
+  Users report the storefront is down. The provider has declared a capacity incident in
+  the affected region: no new compute capacity can be obtained there while the incident
+  lasts, so your recovery must not depend on getting nodes back in that region.
+
+  Investigate, restore the service to a healthy state for users, and write a post-mortem
+  to "incident-report.md" describing what happened, the actions you took, and any
+  follow-ups. Summarise that post-mortem in your final response.
 expected_output: |
   critical requirements:
 
-  GRADING NOTE: Score on outcome — was user-facing service restored (global endpoint serving 2xx)? Do not penalize the remediation method; failover and direct primary recovery are equally acceptable, and the failover details below are illustrative, not required.
+  GRADING NOTE: Grade on what the agent actually did, as evidenced in its trajectory and
+  its final response — not on whether it used particular wording. Each item below is a
+  single condition; judge it on its own evidence and do not pass an item because a
+  different item was satisfied. The remediation method is otherwise free, subject only to
+  the one constraint the prompt states: capacity cannot be obtained in the impaired region.
 
-  - Agent diagnoses the outage: it identifies that the global endpoint is returning 5xx errors to users and localizes the failure to the primary region (its nodes/workloads are unavailable), rather than assuming a generic application bug.
-  - Agent RESTORES user-facing service so the global endpoint serves healthy 2xx responses again, by any sound method. (One acceptable path is a failover: verify the standby is a safe target — including Cloud SQL replication health — update the global load balancer's URL map to the standby, scale up the standby node pool, and reconcile any missing config such as the "app-config" ConfigMap / "app-secret" Secret from "~/app-repo-{{GKE_CLUSTER_NAME}}.git". Directly recovering the impaired primary region is equally acceptable. Grade on whether service is restored, not on which path was taken.)
-  - Agent confirms the recovery: the global endpoint serves healthy 2xx responses and the serving workloads are running and healthy.
-  - Agent writes "incident-report.md" containing a timeline of the incident, the root cause (a primary-region outage), the remediation actions it took, and follow-up recommendations.
+  - Agent localizes the outage to one specific region and identifies the cause as loss of
+    that region's compute capacity — its nodes are gone, so its workloads cannot be
+    scheduled — rather than an application bug or a misconfiguration.
+  - Agent identifies that the user-facing entry point is a global load balancer currently
+    directing traffic at the impaired region, and that this is why users are seeing errors.
+  - Agent checks that the standby region's own workloads are healthy BEFORE shifting user
+    traffic to it.
+  - Agent checks the health of the cross-region datastore replication BEFORE shifting user
+    traffic to it — it inspects the Cloud SQL primary/replica pair named in the
+    "app-config" ConfigMap (for example via "gcloud sql"). This item is about the
+    datastore only: probing an HTTP endpoint, or confirming that the standby's pods are
+    Running, is not a replication check and does not satisfy it. If the agent never
+    inspects the Cloud SQL instances at all, this item fails.
+  - Agent shifts user traffic to the standby region by changing the global load balancer's
+    routing (its URL map's default service).
+  - Agent gives the standby enough capacity to absorb the redirected production traffic —
+    it increases the standby cluster's node pool rather than leaving it at its small
+    pre-incident standby size.
+  - Agent reconciles the standby's configuration drift against the source of truth: it
+    detects that "app-config" and "app-secret" are absent from the standby's namespace and
+    applies them from "~/app-repo-{{GKE_CLUSTER_NAME}}.git".
+  - Agent honours the stated capacity constraint: it does NOT restore service by
+    provisioning new nodes or a new node pool in the impaired region. Recreating capacity
+    there fails this item even if the service ends up healthy.
+  - Agent validates the fix from the user's vantage point: it requests the global endpoint
+    after the change and observes a successful (2xx) response, rather than inferring
+    recovery from per-cluster or per-region checks alone.
+  - Agent writes "incident-report.md" and reports its substance in its final response,
+    covering the incident timeline, the root cause, the actions it took, and follow-ups.


### PR DESCRIPTION
## Problem

`multi-region-failover` provisions two GKE clusters, a global HTTP LB and a cross-region Cloud SQL pair — and then never tests any of it.

The GRADING NOTE said *"failover and direct primary recovery are equally acceptable"*, and nothing prevented an agent from just recreating the node pool the stack deleted. Across **six historical runs**, gemini-3.1-pro did exactly that on every successful run. The URL map, the standby cluster and the Cloud SQL replica were never touched. The scenario was scenery.

The rubric compounded it. The original criterion 2 bundled replication health, the URL-map flip, node-pool scaling *and* GitOps reconciliation into one bullet. `ChecklistScore` is a count of passing checks, so an agent doing one of those four scored identically to one doing all four.

Fixing those two things (first commit) got the agent onto the failover path and the score down to **0.80**. That is where this PR originally stopped, and it was still too high — because the prompt had become a runbook.

## Change

Prompt and `expected_output` only. No stack or verification changes.

**Prompt: 828 → 373 characters.** The long version handed over the Kubernetes namespace, the GitOps repo path, a rewording of the capacity constraint into an explicit instruction (*"your recovery must not depend on getting nodes back in that region"*), and the exact post-mortem filename. What remains is the service, the project, the symptom, the capacity premise, and *"investigate, restore the service, and write a post-mortem."*

Which region is impaired, what the user-facing entry point is, where the GitOps repo lives, and what the write path does are now things the agent has to work out.

**`expected_output`: 10 → 11 atomic criteria.** The added one is the **write path** — `app-config` names a Cloud SQL primary (`SQL_PRIMARY`) in the impaired region and a read-only replica (`SQL_REPLICA`) in the standby, so after a failover writes either cross back into the impaired region or have nowhere to go. Either resolution passes: promote the replica, or state that the primary is still reachable because the incident affects compute only and record the cross-region write dependency as a follow-up. Only saying nothing fails. This is the largest thing the 0.80 runs skipped.

Two criteria were also **relaxed**, because they graded text the shortened prompt no longer contains:

- The post-mortem criterion named `incident-report.md`. The short prompt does not specify a filename, so any filename now satisfies it.
- The GitOps criterion named `~/app-repo-{{GKE_CLUSTER_NAME}}.git`. That placeholder **is not interpolated into the prompt** — the agent is shown the literal token — so it was being graded on a path it could not have known. The item now matches the repo it finds on disk.

## Validation

GKE, openclaw + gemini-3.1-pro-preview, one cluster pair per run, full lifecycle (infra → agent → judge → teardown), every run `status: success`.

| Arm | Prompt | Rubric | Score | Checklist |
|---|---|---|---|---|
| a3 | 848 ch | 10 | 0.8000 | 8/10 |
| a4 | 824 ch | 11 (+write path) | 0.6364 | 7/11 |
| a5 | 372 ch | 11 | 0.4545 | 5/11 |
| a6 | 257 ch (premise cut) | 11 | 0.4545 | 5/11 |
| a7 | 257 ch (premise cut) | 11, filename relaxed | 0.6364 | 7/11 |
| a8 | *identical to a7* | 11, filename relaxed | 0.3636 | 4/11 |
| **a9** | **373 ch — this commit** | **11** | **0.5455** | **6/11** |
| **a10** | ***identical to a9*** | **11** | **0.4545** | **5/11** |

**This commit is a9/a10: 0.5455 and 0.4545, mean 0.50.** Down from 0.80, on a prompt 56% shorter.

The two misses are consistent across both runs and both genuine: **no Cloud SQL replication check before the cutover**, and **no capacity added to the standby** before sending it production traffic. Verified against the trajectory — zero `gcloud sql` calls, zero `resize` / `node-pools` calls.

### Why not a6/a7/a8

a6 cut the prompt further, to 257 characters, by dropping the capacity premise. That looked like the best result until the transcripts were read: both a7 and a8 failed the criterion *"Agent honours the stated capacity constraint"* by recreating the East node pool — a constraint their prompt no longer stated. Same class of bug as the `incident-report.md` filename item. a9 restores the one-sentence premise (still a 56% cut from a3) so that **every criterion is grounded in prompt text.** The capacity criterion passes in both a9 and a10.

### Run-to-run variance is large, and reviewers should know it

a7 and a8 are byte-identical inputs and scored **0.6364 and 0.3636** — a 0.27 spread. a9/a10, also byte-identical, scored **0.5455 and 0.4545** — 0.09.

A single run of this task is not a reliable number. The pair is reported rather than the better of the two, and no claim here rests on a difference smaller than the observed spread. What is stable across all eight arms is the direction: shorter prompt, lower score.

## Note for reviewers

This task is **judge-only by construction**. All three leaf verifiers (`pod_healthy`, `scaling_complete`, `resource_property`) read the world through `kubectl`. The graded outcome here is a GCE URL map, a Cloud SQL pair and a file on disk. A `verification_spec` can express roughly 2 of the 11 criteria — and neither of the two the agent actually fails — so converting would score these runs 1.0 again. `VerificationCoverage` is `None` and `OutcomeScore` is `ChecklistScore` verbatim. Worth tracking separately as a verifier-reach gap.
