### PR TITLE
fix(site): make the local emulator project match what the app reads

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -293,14 +293,25 @@ Needs **Java** for the Firestore emulator
 
 ```bash
 # 1. start the emulator (Firestore :8080, UI :4000)
-npx -y firebase-tools emulators:start --only firestore --project devops-bench-demo
+npx -y firebase-tools emulators:start --only firestore --project devops-bench-shared
 
 # 2. in another shell: seed the emulator (writes to the leaderboard-test DB)
-cd seed && FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=devops-bench-demo npm run seed && cd ..
+cd seed && FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=devops-bench-shared npm run seed && cd ..
 
 # 3. run the app — firebase.js auto-connects to the emulator on localhost
 npm run dev          # http://localhost:5173
 ```
+
+> **The project id must match `VITE_FIREBASE_PROJECT_ID` in `.env`** (that is
+> `devops-bench-shared`, the same project named at the top of this section). The
+> emulator keeps each project id in a **separate namespace**, so seeding one id
+> while the app reads another leaves the dashboard **silently empty** — no error,
+> just no rows. If that happens, check the id in all three places above, or query
+> the emulator directly to see which namespace the data landed in:
+>
+> ```bash
+> curl -s "http://127.0.0.1:8080/v1/projects/devops-bench-shared/databases/leaderboard-test/documents/setups" | head
+> ```
 
 ### B) Staging (real cloud DB, fabricated data)
 

--- a/site/ingest/README.md
+++ b/site/ingest/README.md
@@ -88,11 +88,11 @@ brew install openjdk
 export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"
 
 # 2. Start the emulator (from site/, leave it running in another terminal):
-cd .. && npx -y firebase-tools emulators:start --only firestore --project devops-bench-demo
+cd .. && npx -y firebase-tools emulators:start --only firestore --project devops-bench-shared
 # Firestore on :8080, emulator UI on :4000
 
 # 3. Ingest against it (from site/ingest/):
-FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=devops-bench-demo \
+FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=devops-bench-shared \
   node ingest.mjs fixtures/
 ```
 
@@ -131,7 +131,7 @@ or `catalog.mjs` presentation? Re-score every setup from the **existing** raw
 rows — no re-upload (emulator from Option A still running, or ADC for real Firestore):
 
 ```bash
-FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=devops-bench-demo \
+FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=devops-bench-shared \
   node derive.mjs
 ```
 

--- a/site/ingest/derive.mjs
+++ b/site/ingest/derive.mjs
@@ -175,7 +175,7 @@ export function derive(rows, opts = {}) {
 // re-score every setup from the existing raw rows WITHOUT re-uploading. The
 // normal path (ingest.mjs) runs derive automatically after each upload.
 //
-//   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=devops-bench-demo \
+//   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=devops-bench-shared \
 //     node derive.mjs
 //   GCLOUD_PROJECT=devops-bench-shared FIRESTORE_DATABASE_ID=leaderboard-test \
 //     node derive.mjs

--- a/site/ingest/firestore.mjs
+++ b/site/ingest/firestore.mjs
@@ -35,7 +35,7 @@ export function openDb() {
     const projectId =
         process.env.GCLOUD_PROJECT ||
         process.env.GOOGLE_CLOUD_PROJECT ||
-        (emulator ? "devops-bench-demo" : "devops-bench-shared");
+        "devops-bench-shared";
     const databaseId = process.env.FIRESTORE_DATABASE_ID || "leaderboard-test";
 
     if (databaseId === PROD_DATABASE_ID && process.env.ALLOW_PROD_INGEST !== "true") {

--- a/site/seed/seed.mjs
+++ b/site/seed/seed.mjs
@@ -32,7 +32,7 @@ const EMULATOR = !!process.env.FIRESTORE_EMULATOR_HOST;
 const PROJECT_ID =
     process.env.GCLOUD_PROJECT ||
     process.env.GOOGLE_CLOUD_PROJECT ||
-    (EMULATOR ? "devops-bench-demo" : "devops-bench-shared");
+    "devops-bench-shared";
 // Named Firestore database (must match the client's VITE_FIRESTORE_DATABASE_ID).
 // Defaults to the test DB; never silently defaults to prod.
 const DATABASE_ID = process.env.FIRESTORE_DATABASE_ID || "leaderboard-test";

--- a/site/seed/seed.mjs
+++ b/site/seed/seed.mjs
@@ -11,7 +11,7 @@
 // Two targets, selected by whether FIRESTORE_EMULATOR_HOST is set:
 //
 //   EMULATOR (default, no credentials needed):
-//     FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=devops-bench-demo \
+//     FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GCLOUD_PROJECT=devops-bench-shared \
 //       node seed.mjs                                  # → DB leaderboard-test
 //
 //   REAL Firestore (the shared TEST database — uses Application Default Creds;


### PR DESCRIPTION
## The bug

Running the site locally per the README produced a **silently empty dashboard** — no error, no warning, just no rows.

The seeder and the ingest CLI both defaulted to project `devops-bench-demo` when talking to the emulator:

```js
process.env.GCLOUD_PROJECT || ... || (EMULATOR ? "devops-bench-demo" : "devops-bench-shared")
```

but the browser always reads `VITE_FIREBASE_PROJECT_ID` from `.env`, which is `devops-bench-shared`, and there is no emulator-specific override anywhere in the `.env` layering. The Firestore emulator namespaces data **per project id**, so out of the box the writers and the reader were pointed at two different namespaces.

The README then passed the mismatched id *explicitly* in both the emulator and seed commands, so following it reproduced the bug rather than avoiding it — while §3 of that same README states the project is `devops-bench-shared`.

## The fix

- Default both writers (`seed/seed.mjs`, `ingest/firestore.mjs`) to the project the app actually reads, so the happy path needs no env vars at all.
- Correct `site/README.md` §3A and purge the remaining `devops-bench-demo` references from `ingest/README.md` and two usage comments.
- Add a troubleshooting note, since the failure is silent and the symptom points nowhere useful.

## Verification

Seeding with **no** `GCLOUD_PROJECT` set now lands where the app reads:

```
Seeding emulator (127.0.0.1:8080) — project: devops-bench-shared, database: leaderboard-test...
  wrote 3 models, 3 harnesses
  wrote 8640 raw results rows
  wrote 8 derived setups
```

and the dashboard renders. Before this change the same command wrote to `devops-bench-demo` and the app showed nothing.

Docs and local-only defaults; no runtime or deployed behaviour changes (the non-emulator branch already used `devops-bench-shared`).