### PR TITLE
feat(site): add Gemini 3.7 Flash to the ingest catalog

### DIFF
--- a/site/ingest/catalog.mjs
+++ b/site/ingest/catalog.mjs
@@ -21,10 +21,11 @@
 
 /** @type {Record<string, {name: string, provider: string, license: string, logo: string}>} */
 export const MODELS = {
-    "alpha-pro":      { name: "Alpha Pro",      provider: "Acme",    license: "Proprietary", logo: "alpha" },
-    "beta-sonic":     { name: "Beta Sonic",     provider: "Globex",  license: "Proprietary", logo: "beta" },
-    "gamma-coder":    { name: "Gamma Coder",    provider: "Initech", license: "Open Source", logo: "gamma" },
-    "gemini-3.1-pro": { name: "Gemini 3.1 Pro", provider: "Google",  license: "Proprietary", logo: "gemini" }
+    "alpha-pro":        { name: "Alpha Pro",        provider: "Acme",    license: "Proprietary", logo: "alpha" },
+    "beta-sonic":       { name: "Beta Sonic",       provider: "Globex",  license: "Proprietary", logo: "beta" },
+    "gamma-coder":      { name: "Gamma Coder",      provider: "Initech", license: "Open Source", logo: "gamma" },
+    "gemini-3.1-pro":   { name: "Gemini 3.1 Pro",   provider: "Google",  license: "Proprietary", logo: "gemini" },
+    "gemini-3.7-flash": { name: "Gemini 3.7 Flash", provider: "Google",  license: "Proprietary", logo: "gemini" }
 };
 
 /** @type {Record<string, {name: string, type: "cli"|"api", accent: string, logo: string}>} */
@@ -47,7 +48,8 @@ export const MODEL_ALIASES = {
     // Preview shares the stable Gemini 3.1 Pro metadata. The bare key also lets
     // versioned ids (e.g. gemini-3.1-pro-001) resolve via substring matching.
     "gemini-3.1-pro": "gemini-3.1-pro",
-    "gemini-3.1-pro-preview": "gemini-3.1-pro"
+    "gemini-3.1-pro-preview": "gemini-3.1-pro",
+    "gemini-3.7-flash": "gemini-3.7-flash"
 };
 
 // Map a raw `agentType` (BENCH_AGENT_TYPE, incl. the harness's own aliases

--- a/site/ingest/catalog.test.mjs
+++ b/site/ingest/catalog.test.mjs
@@ -14,6 +14,15 @@ describe("resolveModel", () => {
         expect(r.known).toBe(true);
     });
 
+    // Two Gemini aliases now share a prefix, and the substring pass walks
+    // MODEL_ALIASES in insertion order — so a Flash id must not be captured by
+    // an earlier Pro alias, and vice versa.
+    it("keeps the Gemini families distinct", () => {
+        expect(resolveModel("gemini-3.7-flash", "Google").key).toBe("gemini-3.7-flash");
+        expect(resolveModel("gemini-3.7-flash-preview", "Google").key).toBe("gemini-3.7-flash");
+        expect(resolveModel("gemini-3.1-pro-preview", "Google").key).toBe("gemini-3.1-pro");
+    });
+
     it("synthesizes (never drops) an unknown model, flagged not-known", () => {
         const r = resolveModel("Totally New Model", "NewCo");
         expect(r.known).toBe(false);


### PR DESCRIPTION
## Summary

The first real runs on Gemini 3.7 Flash are landing in #244, and `catalog.mjs` has no entry for the model. Nothing breaks without this: `resolveModel()` deliberately never drops an unknown model, it synthesizes one. But the synthesized entry is what the dashboard then renders:

| | before | after |
|---|---|---|
| name | `gemini-3.7-flash` | Gemini 3.7 Flash |
| provider | Unknown | Google |
| license | Unknown | Proprietary |
| logo | `alpha` | `gemini` |

So the rows ingest fine and show up as an unbranded row carrying the wrong glyph and two Unknown fields. This adds the curated `MODELS` entry and the `MODEL_ALIASES` key, matching the Gemini 3.1 Pro rows directly above.

## Notes

- The alias key doubles as the substring match, so versioned and preview ids (`gemini-3.7-flash-001`, `-preview`) resolve to the same curated entry without their own keys. That's the same mechanism the 3.1 Pro entry documents.
- `SETUP_CATALOG` is left empty. It only pins order and color, discovery order plus `PALETTE` already handles that, and pinning one setup while the rest float is worse than pinning none.
- The `MODELS` block is realigned for the longer key, which is why the diff shows four otherwise untouched lines.

## Test plan

- `vitest run ingest` — **28 passed** (3 files), including a new case asserting the two Gemini families stay distinct. The substring pass walks `MODEL_ALIASES` in insertion order, so it's worth pinning that a Flash id isn't captured by an earlier Pro alias.
- Ran `collectMetadata()` over the five real rows from #244. Before: `unknown models: [ 'gemini-3.7-flash' ]` with the fallback metadata above. After: `unknown models: []` resolving to the curated entry.
