### PR TITLE
fix(matrix): batch per-task rows into one run before ingest

### DIFF
--- a/scripts/bastion/_matrix_lib.sh
+++ b/scripts/bastion/_matrix_lib.sh
@@ -150,6 +150,36 @@ _poll_until_done() {
   done
 }
 
+# Combine the per-combo rows.json files into one batch run for dashboard ingest.
+#
+# The matrix runs one task per process, so every combo emits its own rows.json
+# carrying its own runId/t. The dashboard models a run as a BATCH of tasks
+# sharing one runId/t (tasks stay distinct via taskFolder), so left as-is an
+# N-task matrix renders as N separate one-task runs: one task and an N-point
+# trend, instead of N tasks and one point. aggregate.py re-stamps the rows onto
+# the matrix's own STAMP, which is already run_YYYYMMDD_HHMMSS-shaped.
+#
+# Best-effort. The per-combo rows.json are the source of truth and are untouched
+# by this, so a missing interpreter or an import error warns with the command to
+# re-run rather than failing a matrix that otherwise succeeded.
+_aggregate_for_ingest() {
+  local out="$1"
+
+  # The legacy arm emits no rows.json; nothing to batch, and no warning owed.
+  if [ -z "$(find "${out}" -name rows.json -print -quit 2>/dev/null)" ]; then
+    return 0
+  fi
+
+  local run_id="run_${STAMP}"
+  echo "==> aggregating rows.json for ingest (run_id=${run_id})"
+  if ( cd "${REPO_ROOT}" && python3 -m devops_bench.results.aggregate "${out}" -o "${out}" --run-id "${run_id}" ); then
+    return 0
+  fi
+  echo "WARN: aggregation failed; per-combo rows.json under ${out} are intact." >&2
+  echo "      The dashboard needs one batch runId, so re-run before ingest:" >&2
+  echo "      (cd ${REPO_ROOT} && python3 -m devops_bench.results.aggregate ${out} -o ${out} --run-id ${run_id})" >&2
+}
+
 # Pull results (with retry) and summarize from the pulled dirs. Reads the local
 # <rid> subdirs rather than COMBOS, so it also serves RESUME_STAMP attach.
 _pull_and_summarize() {
@@ -164,6 +194,8 @@ _pull_and_summarize() {
     echo "==> local results at ${LOCAL_OUT}"
   fi
 
+  _aggregate_for_ingest "${LOCAL_OUT}"
+
   echo "==> summary"
   printf '%-56s %-8s %s\n' "COMBO" "EXIT" "results.json"
   local d rid st rj
@@ -175,6 +207,11 @@ _pull_and_summarize() {
     printf '%-56s %-8s %s\n' "${rid}" "${st}" "${rj:-<none>}"
   done
   echo "==> done. results under ${LOCAL_OUT} (each combo provisioned + tore down its own cluster)"
+  # Guarded as an `if`, not a trailing `&&`: a false test would make this the
+  # function's nonzero exit status under `set -e`.
+  if [ -f "${LOCAL_OUT}/rows.json" ]; then
+    echo "    ingest this: ${LOCAL_OUT}/rows.json"
+  fi
 }
 
 # Run the COMBOS matrix. Arg: a human label for logging.

--- a/site/ingest/PROTOCOL.md
+++ b/site/ingest/PROTOCOL.md
@@ -117,6 +117,33 @@ pass@k formula.
 - **`history[]`** — one point per distinct `t` (time-ordered); each point is the
   mean of that run's per-task scores.
 
+> **Every task from one sweep must share one `runId` and one `t`.** That pairing
+> is what makes a set of rows *a run*; `taskFolder` is what keeps the tasks
+> inside it distinct. Give each task its own `runId`/`t` and derive reads them as
+> N separate one-task runs — the board shows **1 task and an N-point trend**
+> instead of N tasks and one point, and `catastrophicCount` drops to whatever the
+> single latest run happened to contain. The scores themselves are unaffected,
+> so this fails silently: valid rows, wrong shape.
+>
+> This bites whenever tasks are run **one process per task** (the bastion
+> matrix, or just invoking the harness once per task), because each invocation
+> mints its own run identity. Two ways out:
+>
+> - Run the sweep as **one harness invocation** over a tasks directory. It
+>   executes them sequentially in one process and writes one `manifest.json`, so
+>   the shared identity is automatic. (Sequential vs parallel is not the issue —
+>   the number of *invocations* is.)
+> - Or re-batch after the fact with
+>   [`devops_bench/results/aggregate.py`](../../devops_bench/results/aggregate.py),
+>   which rewrites per-task rows onto a single `run_id`/`t`, de-dupes retried
+>   tasks (latest wins), and writes a combined `rows.json`:
+>
+>   ```bash
+>   python3 -m devops_bench.results.aggregate <results-root> -o <out-dir>
+>   ```
+>
+>   `run_matrix.sh` runs this automatically over each matrix's results.
+
 Scoring (single definition, in `seed/mock-data.mjs`, reused by ingest):
 - An iteration **passes** when `outcomeScore >= 0.7`.
 - `pass1` = pass rate over the run's scored iterations.

--- a/site/ingest/README.md
+++ b/site/ingest/README.md
@@ -25,6 +25,18 @@ produce a file. In short: you provide raw per-iteration rows; everything the
 dashboard shows (setups, tasks, history) is *derived*, and model/harness display
 metadata comes from `catalog.mjs`, not the upload.
 
+**One run = one `runId`/`t` shared by all its tasks.** If a sweep was run one
+process per task (the bastion matrix, or invoking the harness once per task),
+each task carries its own run identity and the dashboard reads it as N one-task
+runs. Re-batch first — `run_matrix.sh` does this for you, otherwise:
+
+```bash
+python3 -m devops_bench.results.aggregate <results-root> -o <out-dir>
+```
+
+See [`PROTOCOL.md` §4](./PROTOCOL.md#4-how-rows-become-the-dashboard) for what
+this looks like when it goes wrong.
+
 ## Pieces
 
 | File | Role |


### PR DESCRIPTION
## Summary

`devops_bench/results/aggregate.py` was added in `f9ddeb6` for exactly one job, and nothing calls it. Its own docstring names the failure it prevents:

> The matrix runs one task per process, emitting a `rows.json` per task with its own `runId`/`t`; the dashboard models a run as a batch of tasks sharing one `runId`/`t`.

Left unaggregated, an N-task matrix reaches the leaderboard as **N separate one-task runs**. Every score is correct and every row validates, so nothing errors and nothing warns; only the shape is wrong. Measured on five real rows from #244:

| | per-task `runId` | one batch `runId` |
|---|---|---|
| tasks | **1** | **5** |
| history points | **5** | **1** |
| `catastrophicCount` | **0** | **2** |

`catastrophicCount` collapses because `tasks[]` is built from the setup's *latest* run only, and the latest run is whichever single task finished last.

## What changed

`_pull_and_summarize` now runs the aggregation over the pulled tree, using the matrix's own `STAMP` as the batch run id. `STAMP` is `%Y%m%d_%H%M%S`, so `run_${STAMP}` already satisfies `RUN_ID_RE`, and passing it is what `_default_run_id`'s docstring says `--run-id` is for. The final summary points at the combined file.

It is **best-effort by design**: the per-combo `rows.json` are the source of truth and this never touches them, so a missing interpreter or an import failure prints the command to re-run rather than failing a matrix that otherwise succeeded. Provisioning clusters is the expensive part and it's already done by then.

The docs half matters as much as the code, because the constraint was previously discoverable only by reading `aggregate.py`. `PROTOCOL.md` §4 documented how `runId`/`t` are *consumed* but never stated that a sweep must share them, so producing a wrong-shaped file was the natural path. §4 now states the rule and gives both routes to it; the ingest README says it up front.

## Notes

- **Sequential vs parallel is not the axis.** The number of harness *invocations* is. `python -m devops_bench <tasks-dir>` already runs a directory of tasks sequentially in one process and writes one `manifest.json`, so the shared identity is automatic. That's now written down, since it's the cheaper fix for anyone hitting this by hand.
- The legacy arm emits no `rows.json`, so it's skipped silently rather than warning on every run.
- `RESUME_STAMP` attach gets this too — it reuses `_pull_and_summarize` with `STAMP` set to the original, so the batch id stays stable across a re-attach.
- The `[ -f ... ] && echo` I first wrote for the summary line would have become the function's exit status under `set -e` whenever the file was absent. It's an explicit `if`, with a comment.
- Aggregation currently prints a `RuntimeWarning` from `runpy`, because `devops_bench/results/__init__.py` imports `aggregate` before it runs as `__main__`. Cosmetic and pre-existing; fixing it means restructuring that `__init__`, which didn't belong in this change.

## Test plan

Built a fake matrix tree from five real per-task `rows.json` (five combo dirs, five distinct `runId`s) and drove the real function by sourcing `_matrix_lib.sh`:

- **Happy path** — `aggregated 5 file(s) -> 5 rows across 1 setup(s)`. Output rows collapse to one `runId` and one `t`, all five `taskFolder`s preserved. Feeding that to the real `derive()`: `tasks: 5 | history: 1 | catastrophic: 2`.
- **Idempotent** — re-ran over the tree that now contains the output; still 5 rows, same id (the tool excludes its own output).
- **Legacy arm** — a tree with `results.json` and no `rows.json` returns 0 silently, no warning.
- **Failure path** — ran without `pydantic` importable: warns, prints the re-run command, returns 0.
- `bash -n` clean. `shellcheck` reports nothing on the new function (the 16 pre-existing info-level findings are in the heredoc generation and line 109, all untouched).
