### PR TITLE
feat(site): catalog the Claude, GPT and KubeAgents identities

### DIFF
--- a/site/ingest/catalog.mjs
+++ b/site/ingest/catalog.mjs
@@ -25,14 +25,19 @@ export const MODELS = {
     "beta-sonic":       { name: "Beta Sonic",       provider: "Globex",  license: "Proprietary", logo: "beta" },
     "gamma-coder":      { name: "Gamma Coder",      provider: "Initech", license: "Open Source", logo: "gamma" },
     "gemini-3.1-pro":   { name: "Gemini 3.1 Pro",   provider: "Google",  license: "Proprietary", logo: "gemini" },
-    "gemini-3.7-flash": { name: "Gemini 3.7 Flash", provider: "Google",  license: "Proprietary", logo: "gemini" }
+    "gemini-3.7-flash": { name: "Gemini 3.7 Flash", provider: "Google",  license: "Proprietary", logo: "gemini" },
+    "claude-opus-5":    { name: "Claude Opus 5",    provider: "Anthropic", license: "Proprietary", logo: "claude" },
+    "claude-fable-5":   { name: "Claude Fable 5",   provider: "Anthropic", license: "Proprietary", logo: "claude" },
+    "gpt-5.6-sol":      { name: "GPT-5.6 Sol",      provider: "OpenAI",  license: "Proprietary", logo: "openai" }
 };
 
 /** @type {Record<string, {name: string, type: "cli"|"api", accent: string, logo: string}>} */
 export const HARNESSES = {
-    "gemini-cli": { name: "Gemini CLI", type: "cli", accent: "#0ea5e9", logo: "terminal" },
-    "openclaw":   { name: "OpenClaw",   type: "cli", accent: "#f43f5e", logo: "claw" },
-    "api-loop":   { name: "API Runner", type: "api", accent: "#8b5cf6", logo: "braces" }
+    "gemini-cli":  { name: "Gemini CLI",  type: "cli", accent: "#0ea5e9", logo: "terminal" },
+    "openclaw":    { name: "OpenClaw",    type: "cli", accent: "#f43f5e", logo: "claw" },
+    "api-loop":    { name: "API Runner",  type: "api", accent: "#8b5cf6", logo: "braces" },
+    "antigravity": { name: "Antigravity", type: "cli", accent: "#f59e0b", logo: "arrow-up" },
+    "kubeagents":  { name: "KubeAgents",  type: "cli", accent: "#14b8a6", logo: "cluster" }
 };
 
 // --- raw identity -> curated id ----------------------------------------------
@@ -49,7 +54,15 @@ export const MODEL_ALIASES = {
     // versioned ids (e.g. gemini-3.1-pro-001) resolve via substring matching.
     "gemini-3.1-pro": "gemini-3.1-pro",
     "gemini-3.1-pro-preview": "gemini-3.1-pro",
-    "gemini-3.7-flash": "gemini-3.7-flash"
+    "gemini-3.7-flash": "gemini-3.7-flash",
+    // Only the FULL vendor ids are keyed. A bare "gpt-5.6" key would win the
+    // substring pass over "gpt-5.6-sol" (whichever is reached first), collapsing
+    // two distinct models onto one leaderboard line; the same reasoning is why
+    // there is no bare "claude" key. Dated/versioned suffixes still resolve
+    // through the substring pass against these ids.
+    "claude-opus-5": "claude-opus-5",
+    "claude-fable-5": "claude-fable-5",
+    "gpt-5.6-sol": "gpt-5.6-sol"
 };
 
 // Map a raw `agentType` (BENCH_AGENT_TYPE, incl. the harness's own aliases
@@ -63,7 +76,13 @@ export const HARNESS_ALIASES = {
     "openclaw": "openclaw",
     "claw": "openclaw",
     "api": "api-loop",
-    "api-loop": "api-loop"
+    "api-loop": "api-loop",
+    "antigravity": "antigravity",
+    // Harness lookup is exact-match only (no substring pass), so every spelling
+    // a producer emits needs its own key. "kube-agents" is how the fleet reports
+    // it in prose; "kubeagents" is the value that lands on the row.
+    "kubeagents": "kubeagents",
+    "kube-agents": "kubeagents"
 };
 
 // --- presentation ------------------------------------------------------------

--- a/site/ingest/catalog.test.mjs
+++ b/site/ingest/catalog.test.mjs
@@ -23,6 +23,22 @@ describe("resolveModel", () => {
         expect(resolveModel("gemini-3.1-pro-preview", "Google").key).toBe("gemini-3.1-pro");
     });
 
+    it("resolves the Anthropic and OpenAI ids to curated metadata", () => {
+        expect(resolveModel("claude-opus-5", null)).toEqual({
+            key: "claude-opus-5", meta: MODELS["claude-opus-5"], known: true
+        });
+        expect(resolveModel("claude-fable-5", null).key).toBe("claude-fable-5");
+        expect(resolveModel("gpt-5.6-sol", null).key).toBe("gpt-5.6-sol");
+    });
+
+    // Same insertion-order hazard as the Gemini families: the two Claude ids
+    // share a "claude-" prefix, and a dated suffix must not drift onto the
+    // sibling. Guards the "no bare vendor key" rule in MODEL_ALIASES.
+    it("keeps the Claude families distinct across versioned ids", () => {
+        expect(resolveModel("claude-opus-5-20260101", null).key).toBe("claude-opus-5");
+        expect(resolveModel("claude-fable-5-20260101", null).key).toBe("claude-fable-5");
+    });
+
     it("synthesizes (never drops) an unknown model, flagged not-known", () => {
         const r = resolveModel("Totally New Model", "NewCo");
         expect(r.known).toBe(false);
@@ -40,6 +56,15 @@ describe("resolveHarness", () => {
     it("maps api to api-loop", () => {
         const r = resolveHarness("api");
         expect(r).toEqual({ key: "api-loop", meta: HARNESSES["api-loop"], known: true });
+    });
+
+    it("maps the antigravity and kubeagents runners to curated entries", () => {
+        expect(resolveHarness("antigravity")).toEqual({
+            key: "antigravity", meta: HARNESSES["antigravity"], known: true
+        });
+        // Both spellings land on one line rather than two near-duplicate rows.
+        expect(resolveHarness("kubeagents").key).toBe("kubeagents");
+        expect(resolveHarness("kube-agents").key).toBe("kubeagents");
     });
 
     it("synthesizes an unknown harness as a cli-typed entry", () => {

--- a/site/src/components/Logo.jsx
+++ b/site/src/components/Logo.jsx
@@ -2,12 +2,19 @@
 // Model logos are filled squares with a letter; harness icons are line glyphs
 // tinted with the harness accent so the runner reads as its own entity class.
 
+// Keyed by the `logo` field of a catalog MODELS entry. A model whose logo key is
+// missing here renders NOTHING (see the null return below), so the two must stay
+// in step — Logo.test.jsx asserts every curated key has a brand.
 const BRANDS = {
     alpha: { fill: "#6366f1", letter: "A" },
     beta: { fill: "#0ea5e9", letter: "B" },
     gamma: { fill: "#f97316", letter: "C" },
-    gemini: { fill: "#4285F4", letter: "G" }
+    gemini: { fill: "#4285F4", letter: "G" },
+    claude: { fill: "#d97757", letter: "C" },
+    openai: { fill: "#10a37f", letter: "O" }
 };
+
+export const BRAND_KEYS = Object.keys(BRANDS);
 
 export function BrandLogo({ logo }) {
     const brand = BRANDS[logo];
@@ -30,8 +37,17 @@ const HARNESS_GLYPHS = {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 12l8 4 8-4M4 17l8 4 8-4" />
         </>
     ),
-    braces: <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 5c-2 0-2 2-2 3.5S6 12 4 12c2 0 2 2.5 2 4s0 3 2 3m8-14c2 0 2 2 2 3.5S18 12 20 12c-2 0-2 2.5-2 4s0 3-2 3" />
+    braces: <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 5c-2 0-2 2-2 3.5S6 12 4 12c2 0 2 2.5 2 4s0 3 2 3m8-14c2 0 2 2 2 3.5S18 12 20 12c-2 0-2 2.5-2 4s0 3-2 3" />,
+    "arrow-up": <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 20V5m0 0l-5 5m5-5l5 5" />,
+    cluster: (
+        <>
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 3l7 4v10l-7 4-7-4V7l7-4z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5z" />
+        </>
+    )
 };
+
+export const HARNESS_GLYPH_KEYS = Object.keys(HARNESS_GLYPHS);
 
 export function HarnessIcon({ harness }) {
     return (

--- a/site/src/components/Logo.test.jsx
+++ b/site/src/components/Logo.test.jsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+
+import { BrandLogo, HarnessIcon, BRAND_KEYS, HARNESS_GLYPH_KEYS } from "./Logo.jsx";
+import { MODELS, HARNESSES } from "../../ingest/catalog.mjs";
+
+// The catalog and the renderer are two separate tables joined by a bare string
+// key, and an unmatched key fails SILENTLY: BrandLogo returns null and
+// HarnessIcon renders an empty <svg>. Adding a curated entry without its glyph
+// therefore ships a blank icon rather than an error, so the join is asserted
+// here instead of being left to a visual check.
+describe("catalog logo keys", () => {
+    it("has a brand for every curated model", () => {
+        for (const [id, meta] of Object.entries(MODELS)) {
+            expect(BRAND_KEYS, `model "${id}" uses logo "${meta.logo}"`).toContain(meta.logo);
+        }
+    });
+
+    it("has a glyph for every curated harness", () => {
+        for (const [id, meta] of Object.entries(HARNESSES)) {
+            expect(HARNESS_GLYPH_KEYS, `harness "${id}" uses logo "${meta.logo}"`).toContain(meta.logo);
+        }
+    });
+});
+
+describe("BrandLogo", () => {
+    it("draws a lettered tile for a known brand", () => {
+        const { container } = render(<BrandLogo logo="claude" />);
+        expect(container.querySelector("rect")).toHaveAttribute("fill", "#d97757");
+        expect(container.querySelector("text")).toHaveTextContent("C");
+    });
+
+    it("renders nothing for an unknown brand", () => {
+        const { container } = render(<BrandLogo logo="nope" />);
+        expect(container).toBeEmptyDOMElement();
+    });
+});
+
+describe("HarnessIcon", () => {
+    it("tints the glyph with the harness accent", () => {
+        const { container } = render(<HarnessIcon harness={HARNESSES["kubeagents"]} />);
+        const svg = container.querySelector("svg");
+        expect(svg).toHaveAttribute("stroke", "#14b8a6");
+        expect(svg.querySelectorAll("path").length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## Why

The fleet's week-2 results drop carries model and harness identities the ingest catalog has no entry for. They are not dropped (`resolveModel` / `resolveHarness` synthesize a fallback rather than hiding the setup), but the fallback renders them wrong:

| raw identity | before | after |
| --- | --- | --- |
| `gpt-5.6-sol` | `GPT-5.6 Sol` / Unknown / Unknown, mock "A" tile | `GPT-5.6 Sol` / OpenAI / Proprietary |
| `claude-opus-5` | `claude-opus-5` / Unknown / Unknown, mock "A" tile | `Claude Opus 5` / Anthropic / Proprietary |
| `kubeagents` | `kubeagents`, grey blank glyph | `KubeAgents`, teal cluster glyph |
| `antigravity` | `antigravity`, grey blank glyph | `Antigravity`, amber glyph |

Pure preparation: nothing is ingested here, and every identity already on the board resolves to the same key it did before.

## What

`site/ingest/catalog.mjs`
- **Models**: `claude-opus-5`, `claude-fable-5`, `gpt-5.6-sol`.
- **Harnesses**: `antigravity`, `kubeagents` (plus the `kube-agents` spelling).

`antigravity` is a harness registered in this repo (`devops_bench/agents/cli/antigravity/agent.py:176`) that was never catalogued. The rest come from the fleet's own manifests; `claude-opus-5`, `gpt-5.6-sol` and `kubeagents` are the literal strings its rows carry.

Two resolver hazards drove how the aliases are keyed, and both are covered by tests:

- The model resolver falls back to a **substring** pass over `MODEL_ALIASES` in insertion order. A bare `gpt-5.6` or `claude` key would capture its own siblings and collapse two models onto one leaderboard line, so only the full vendor ids are aliased. Dated suffixes (`claude-opus-5-20260101`) still resolve.
- Harness lookup is **exact-match only**, no substring pass, so every spelling a producer emits needs its own key.

`site/src/components/Logo.jsx`
- The catalog and the renderer are separate tables joined by a bare `logo` string, and an unmatched key fails **silently**: `BrandLogo` returns `null` and `HarnessIcon` renders an empty `<svg>`. Adding an entry without its glyph therefore ships a blank icon with no error.
- Adds the brands (`claude`, `openai`) and glyphs (`arrow-up`, `cluster`) the new entries need, exports the key sets, and adds `Logo.test.jsx` asserting every curated entry has a matching brand/glyph so the next addition can't regress this.

## Assumptions worth a second pair of eyes

- **`gpt-5.6-sol` → provider "OpenAI"** is inferred from the model id. The run rows record `model_auth: api-key` but no provider string, so if that is wrong it is a one-word fix.
- **`claude-fable-5`** has not appeared in a run yet; it is keyed on the documented model id ahead of the runs that are expected to produce it. Harmless if the eventual id differs (it just falls back as it does today), but worth confirming.
- **`kubeagents`** has no scored runs yet and its methodology is still under discussion. This only gives the label a home; it does not put anything on the board.

## Test

`npm run test` — 15 files, 131 tests, all passing (was 126). `npm run build` clean.