### PR TITLE
fix(results): read OpenClaw's camelCase cache token buckets

### DIFF
--- a/devops_bench/results/normalize.py
+++ b/devops_bench/results/normalize.py
@@ -65,10 +65,17 @@ _RECOVERABLE_KEYS = (
 )
 CATASTROPHIC_SCORE_KEY = score_keys.VERIFICATION_CATASTROPHIC_KEY
 
-# Token usage aliases per provider, in lookup priority. The canonical keys
-# (``input`` / ``cached`` / ``reasoning`` / ``output``; see
-# ``devops_bench.agents.result.TOKEN_BUCKETS``) come first; the rest keep
-# historical ``results.json`` records readable.
+# Token usage aliases per provider, in lookup priority. ``AgentResult.tokens`` is
+# explicitly provider-defined and passed through unchanged, so there is no
+# canonical upstream shape to defer to — this table is the only place the
+# provider dialects are reconciled, and a bucket whose key is missing here is
+# silently dropped rather than reported. The snake_case names come first; the
+# rest keep historical and pass-through ``results.json`` records readable.
+#
+# ``cacheRead`` / ``cacheWrite`` are OpenClaw's: its session parser sums the
+# provider's ``usage`` mapping verbatim, so Anthropic's cache buckets arrive
+# camelCased. Omitting them discarded ~87% of a cached run's prompt footprint —
+# an Opus run reporting 58 ``input`` tokens had 1.6M more sitting in ``cacheRead``.
 _INPUT_TOKEN_KEYS = ("input", "prompt_tokens", "prompt_token_count", "input_tokens")
 _OUTPUT_TOKEN_KEYS = (
     "output",
@@ -77,8 +84,13 @@ _OUTPUT_TOKEN_KEYS = (
     "completion_tokens",
     "output_tokens",
 )
-_CACHED_TOKEN_KEYS = ("cached", "cache_read_input_tokens", "cached_content_token_count")
-_CACHE_WRITE_TOKEN_KEYS = ("cache_write", "cache_creation_input_tokens")
+_CACHED_TOKEN_KEYS = (
+    "cached",
+    "cacheRead",
+    "cache_read_input_tokens",
+    "cached_content_token_count",
+)
+_CACHE_WRITE_TOKEN_KEYS = ("cache_write", "cacheWrite", "cache_creation_input_tokens")
 _REASONING_TOKEN_KEYS = ("reasoning", "thoughts_token_count", "reasoning_tokens")
 _TOTAL_TOKEN_KEYS = ("total", "total_tokens", "total_token_count")
 

--- a/tests/unit/results/test_results_normalize.py
+++ b/tests/unit/results/test_results_normalize.py
@@ -130,6 +130,35 @@ def test_normalize_tokens_float_coerced_to_int():
     assert normalize_tokens({"input": 12.0, "output": 3.9}) == (12, 3, None, None, None, None)
 
 
+def test_normalize_tokens_openclaw_camel_case_cache_shape() -> None:
+    # OpenClaw sums the provider's `usage` mapping verbatim, so Anthropic's cache
+    # buckets arrive camelCased. Real payload from a claude-opus-5 b-0011 run.
+    tokens = {
+        "input": 58,
+        "output": 11613,
+        "cacheRead": 1613330,
+        "cacheWrite": 225457,
+        "total": 1850458,
+    }
+    assert normalize_tokens(tokens) == (58, 11613, 1613330, None, 225457, 1850458)
+
+
+def test_normalize_tokens_camel_case_cache_buckets_reconcile_to_total() -> None:
+    # The regression that motivated the aliases: dropping cacheRead/cacheWrite
+    # left the buckets summing to 11,671 against a reported total of 1,850,458,
+    # so a fully-cached run looked ~99% cheaper than it was.
+    inp, out, cached, _reasoning, cache_write, total = normalize_tokens(
+        {"input": 58, "output": 11613, "cacheRead": 1613330, "cacheWrite": 225457, "total": 1850458}
+    )
+    assert inp + out + cached + cache_write == total
+
+
+def test_normalize_tokens_snake_case_cached_still_wins_over_camel() -> None:
+    # gemini-cli and antigravity emit `cached`; it stays ahead of the OpenClaw
+    # spelling so a record carrying both is read the canonical way.
+    assert normalize_tokens({"cached": 5, "cacheRead": 900}).cached == 5
+
+
 # -- extract_score -----------------------------------------------------------
 
 


### PR DESCRIPTION
## The bug

`normalize.py`'s token alias tables never learned OpenClaw's spellings. Its session parser sums the provider's `usage` mapping verbatim, so Anthropic's cache buckets arrive camelCased:

```python
_CACHED_TOKEN_KEYS      = ("cached", "cache_read_input_tokens", "cached_content_token_count")
_CACHE_WRITE_TOKEN_KEYS = ("cache_write", "cache_creation_input_tokens")
```

`cacheRead` and `cacheWrite` are in neither, so `_first_token` falls through to `None` and both buckets are dropped on every OpenClaw row. `gemini-cli` and `antigravity` emit the snake_case `cached`, which is why this went unnoticed.

## What it cost

The buckets are disjoint and sum to the reported total, so dropping two loses real volume. A `claude-opus-5` b-0011 run:

```json
{ "input": 58, "output": 11613, "cacheRead": 1613330, "cacheWrite": 225457, "total": 1850458 }
```

Across the 16 evidence runs on #244 that is **87% of the prompt footprint**, and it lands on a rendered column. The dashboard defines Input Tokens as `inputTokens + cacheWriteTokens` (`site/seed/mock-data.mjs`, "cache creation is prompt content sent for this run"), so with `cacheWrite` dropped the arm reads **44 input tokens per run against Gemini's 356,438**:

```
             input    cacheWrite     cacheRead | fresh prompt  hit rate  turns
  opus          44       176,836     1,279,297 |      176,880     87.9%     27
gemini     356,438             0     1,903,635 |      356,438     84.2%     38
```

Anthropic's caching is explicit, so newly-added prompt content is reported as `cacheWrite`; Gemini's is implicit and has no such bucket, so its new content lands in `input`. Like for like the arms differ by **2x**, reported as 8000x. The site's formula was right all along; this table was starving it.

## The fix

Add the two spellings, snake_case first so a record carrying both is read the canonical way.

Also drops the comment's reference to `devops_bench.agents.result.TOKEN_BUCKETS` — no such symbol exists in the repo. `AgentResult.tokens` is documented as provider-defined and passed through unchanged, so this table is the only place the dialects are reconciled, and a key missing from it is silently dropped rather than reported. Saying that plainly is the point: the phantom authority is what let the table drift from its producers.

`reasoning` has the same shape of exposure (no OpenClaw spelling listed), but neither arm emitted the bucket and the remaining buckets reconcile exactly to the provider total, so there is nothing to confirm a spelling against. No alias is guessed.

## Testing

Three tests on the real payload: the full camelCase shape, a reconciliation assert that the buckets sum to the reported total, and a precedence guard that `cached` still wins over `cacheRead`. I verified they are non-vacuous by reverting the alias change — the first two fail, the third is an ordering guard and passes either way by design.

`uv run pytest` 1233 passed. `ruff check` / `ruff format --check` clean.

## Note for reviewers

This does **not** retroactively repair the `rows.json` evidence files already committed on #244 — those were emitted by the buggy normalizer. Every one has its `results.json` beside it with the `tokens` object intact, so re-running the normalizer over them recovers the data. Happy to do that as a follow-up; keeping it out of here so the fix and the data regeneration are reviewable separately.

/cc @eugene-l this is adjacent to your `normalize.py` thread about a canonical per-row total.