### PR TITLE
sandbox: mount a task's seeded fixtures into the agent container

### DIFF
--- a/devops_bench/agents/cli/gemini_cli/agent.py
+++ b/devops_bench/agents/cli/gemini_cli/agent.py
@@ -273,6 +273,7 @@ class GeminiCliAgent(AgentHarness):
                     extra_env=env_overlay,
                     container_name=container_name,
                     network="kind" if cluster else None,
+                    fixture_mounts=sandbox.discover_fixture_mounts(cluster) or None,
                 )
                 sandboxed = True
 

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -601,6 +601,7 @@ class OpenClawAgent(AgentHarness):
                     extra_env=container_env_overlay,
                     container_name=container_name,
                     network="kind" if cluster else None,
+                    fixture_mounts=sandbox.discover_fixture_mounts(cluster) or None,
                 )
                 sandboxed = True
 

--- a/devops_bench/agents/sandbox.py
+++ b/devops_bench/agents/sandbox.py
@@ -56,6 +56,7 @@ __all__ = [
     "current_cluster_name",
     "uses_exec_credential_plugin",
     "build_agent_kubeconfig",
+    "discover_fixture_mounts",
     "wrap_argv",
     "container_name_for_workspace",
     "kill_container",
@@ -341,6 +342,70 @@ def build_agent_kubeconfig(cluster_name: str | None, dest_dir: Path) -> Path | N
     return path
 
 
+# Env override naming this run's fixtures explicitly, as ``:``-separated host
+# paths. Set it for a stack whose fixture name does not carry the cluster token
+# that :func:`discover_fixture_mounts` keys off.
+FIXTURES_ENV = "BENCH_AGENT_FIXTURES"
+
+
+def discover_fixture_mounts(cluster_name: str | None) -> dict[str, str]:
+    """Find this run's seeded task fixtures and map them into the container.
+
+    A task's stack seeds its inputs next to the operator's home — a GitOps repo
+    (``~/opa-repo-<cluster>.git``), a delivered advisory, a rightsizing report —
+    and the prompt then points the agent at ``~/<name>``. The container
+    repoints ``HOME`` at ``/workspace`` and mounts neither the real home nor the
+    repository, so before this the agent was told to read a file that could not
+    exist for it. That is not containment, it is a broken task: the fixture is
+    task INPUT, not answer material.
+
+    It is also a containment problem in its own right. Observed across 40
+    sandboxed runs on two models: every agent spent turns hunting the
+    filesystem for the missing fixture, and the ones that hunted hardest
+    escalated to a privileged pod, mounted the node's host disk, and reached
+    the bench checkout — reading ``task.yaml`` and its ``verification_spec``.
+    Giving the agent the input it was promised removes the reason to go looking.
+
+    Eligibility is deliberately narrow: only paths whose NAME carries the
+    run-unique ``cluster_name`` token match, and only at the top level of the
+    home directory. So this can surface artifacts this run's own stack created
+    and nothing else — not the operator's unrelated files, and not a concurrent
+    run's fixtures.
+
+    Args:
+        cluster_name: The run's cluster name, used as the discriminating token.
+
+    Returns:
+        Host path -> container path, for :func:`wrap_argv`'s ``fixture_mounts``.
+        Empty when nothing matches, which is the normal case for the many tasks
+        that seed no files at all.
+    """
+    explicit = os.environ.get(FIXTURES_ENV, "").strip()
+    if explicit:
+        candidates = [Path(p).expanduser() for p in explicit.split(":") if p.strip()]
+    elif not cluster_name:
+        return {}
+    else:
+        home = Path.home()
+        if not home.is_dir():
+            return {}
+        # Top level only, and the name must carry the token. A recursive walk
+        # would widen this well past "artifacts of this run".
+        candidates = sorted(home.glob(f"*{cluster_name}*"))
+
+    mounts: dict[str, str] = {}
+    for path in candidates:
+        if not path.exists():
+            _log.warning("declared fixture %s does not exist; not mounting it", path)
+            continue
+        # HOME is /workspace in the container, so a prompt's ``~/<name>``
+        # resolves to exactly this path.
+        mounts[str(path.resolve())] = f"/workspace/{path.name}"
+    if mounts:
+        _log.info("mounting %d task fixture(s): %s", len(mounts), sorted(mounts))
+    return mounts
+
+
 def wrap_argv(
     argv: list[str],
     *,
@@ -350,6 +415,7 @@ def wrap_argv(
     extra_env: dict[str, str] | None = None,
     container_name: str | None = None,
     network: str | None = "kind",
+    fixture_mounts: dict[str, str] | None = None,
 ) -> list[str]:
     """Wrap an agent command line in ``docker run``.
 
@@ -378,6 +444,13 @@ def wrap_argv(
             kubeconfig: GKE's server is a real, publicly routable address that
             already means something on the default bridge network, and there
             is no ``kind`` network to join outside a kind-provisioned host.
+        fixture_mounts: Task fixtures, host path -> container path, mounted
+            READ-WRITE (see :func:`discover_fixture_mounts`). The write bit is
+            deliberate: several tasks ask the agent to commit its fix back to
+            the seeded GitOps repo, so a read-only bind fails them as surely
+            as no bind at all. This is the one mount set that is task INPUT
+            rather than tooling, and it is kept separate from everything above
+            precisely so that stays visible at the call site.
     """
     image = image or os.environ.get("BENCH_AGENT_IMAGE", "")
     if not image:
@@ -395,6 +468,10 @@ def wrap_argv(
     name_flags = ["--name", container_name] if container_name else []
     network_flags = ["--network", network] if network else []
 
+    fixture_flags: list[str] = []
+    for host_path, container_path in (fixture_mounts or {}).items():
+        fixture_flags += ["-v", f"{host_path}:{container_path}"]
+
     return [
         # No -i. Keeping stdin open gives the agent an open, non-TTY stdin to block
         # on, and a headless `-p <prompt>` run never reads it. Combined with
@@ -410,6 +487,7 @@ def wrap_argv(
         f"{workspace}:/workspace",
         "-v",
         f"{kubeconfig}:/kubeconfig:ro",
+        *fixture_flags,
         "-e",
         "KUBECONFIG=/kubeconfig",
         "-e",

--- a/tests/unit/agents/test_sandbox.py
+++ b/tests/unit/agents/test_sandbox.py
@@ -313,3 +313,68 @@ def test_sweep_stray_containers_is_a_noop_when_none_are_running(
 
     kill_calls = [c for c in calls if c[:2] == ["docker", "kill"]]
     assert kill_calls == []
+
+
+def test_wrap_argv_mounts_fixtures_read_write() -> None:
+    argv = sandbox.wrap_argv(
+        ["gemini", "-p", "hi"],
+        workspace=Path("/tmp/ws"),
+        kubeconfig=Path("/tmp/ws/kubeconfig"),
+        image="agent-image",
+        fixture_mounts={"/home/op/opa-repo-c1.git": "/workspace/opa-repo-c1.git"},
+    )
+    # No ``:ro``: several tasks ask the agent to commit back to the seeded repo.
+    assert "/home/op/opa-repo-c1.git:/workspace/opa-repo-c1.git" in argv
+    assert "/home/op/opa-repo-c1.git:/workspace/opa-repo-c1.git:ro" not in argv
+
+
+def test_wrap_argv_without_fixtures_keeps_the_mount_set_unchanged() -> None:
+    argv = sandbox.wrap_argv(
+        ["gemini", "-p", "hi"],
+        workspace=Path("/tmp/ws"),
+        kubeconfig=Path("/tmp/ws/kubeconfig"),
+        image="agent-image",
+    )
+    assert argv.count("-v") == 2
+
+
+def test_discover_fixture_mounts_matches_only_this_runs_cluster_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "opa-repo-c1.git").mkdir()
+    (home / "advisory-c1.json").write_text("{}", encoding="utf-8")
+    # Another run's fixture and an unrelated operator file must not be mounted.
+    (home / "opa-repo-c2.git").mkdir()
+    (home / "taxes.pdf").write_text("x", encoding="utf-8")
+    monkeypatch.setattr(sandbox.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.delenv(sandbox.FIXTURES_ENV, raising=False)
+
+    mounts = sandbox.discover_fixture_mounts("c1")
+
+    assert sorted(mounts.values()) == [
+        "/workspace/advisory-c1.json",
+        "/workspace/opa-repo-c1.git",
+    ]
+
+
+def test_discover_fixture_mounts_is_empty_without_a_cluster_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(sandbox.FIXTURES_ENV, raising=False)
+    assert sandbox.discover_fixture_mounts(None) == {}
+
+
+def test_discover_fixture_mounts_honours_the_explicit_env_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fixture = tmp_path / "oddly-named-repo.git"
+    fixture.mkdir()
+    monkeypatch.setenv(sandbox.FIXTURES_ENV, f"{fixture}:{tmp_path / 'missing'}")
+
+    mounts = sandbox.discover_fixture_mounts(None)
+
+    # The declared-but-absent path is skipped rather than turned into a broken
+    # bind mount; the real one lands under the container's HOME.
+    assert mounts == {str(fixture.resolve()): "/workspace/oddly-named-repo.git"}


### PR DESCRIPTION
Stacked on #244 (base `add-b0011-sandbox`) so it can land with the sandbox work rather than after it.

## The problem

A task's stack seeds its inputs next to the operator's home — a GitOps repo (`~/opa-repo-<cluster>.git`), a delivered CVE advisory, a rightsizing report — and the prompt points the agent at `~/<name>`. The container repoints `HOME` at `/workspace` and mounts neither the real home nor the repository, so the agent is told to read a file that cannot exist for it.

The fixture is task **input**, not answer material. Withholding it doesn't harden anything, it just makes the task unachievable. Affected: `opa-remediation`, `cve-remediation`, `migration-and-upgrade`, `spot-rebalancing`, `multi-region-failover`.

This is visible in this PR's own committed evidence. In the most recent `multi-region-failover` refresh, both arms hunt for the repo and find nothing — Gemini's `git clone ~/app-repo-...` returns `fatal: repository ... does not exist`, and Opus searches the filesystem for any `.git` directory before giving up.

## It is also a containment problem

Across 40 sandboxed runs on two models, every agent spent turns hunting the filesystem for the fixture the prompt promised. The three that hunted hardest escalated to a privileged pod, mounted the node's host disk with `mount /dev/root`, and reached the bench checkout — reading `task.yaml` including `expected_output` and `verification_spec`. Handing the agent the input it was promised removes the reason to go looking.

The escape path itself is a separate, still-open issue: the agent holds an admin-equivalent kubeconfig, and a kind node is a container on the host. Pod Security Admission at `baseline` (denying `privileged`, `hostPath`, `hostNetwork`) closes it. Happy to send that as a follow-up.

## What this does

`discover_fixture_mounts()` keys strictly off the run-unique cluster token, and only at the top level of the home directory, so it can surface artifacts this run's own stack created and nothing else — not the operator's unrelated files, and not a concurrent run's fixtures. `BENCH_AGENT_FIXTURES` overrides the search for a stack that names its fixtures some other way.

Mounts are **read-write** and kept as their own `wrap_argv` parameter rather than folded into a general-purpose mount list: several tasks ask the agent to commit its fix back to the seeded repo, so a read-only bind would fail them as surely as no bind at all, and that decision should be visible at the call site.

Wired into both harnesses that currently have sandbox support (`gemini_cli`, `openclaw`).

## Verification

**`gemini_cli` on `opa-remediation`** (kind, via the sandbox image). The agent now clones `/workspace/opa-repo-<cluster>.git`, reads its history, applies the manifests and commits back:

| | before | after |
|---|---|---|
| ChecklistScore | 4/8 | **7/8** |
| OutcomeScore | 0.70 | **0.94** |
| deterministic verification | 3/3 | 3/3 |

**`openclaw` on the same task**: fixture reached, confirmed in the trajectory — `ls -la ~/opa-repo-ocverify.git`, `git --git-dir=... log`, then `git clone "$HOME/opa-repo-ocverify.git"`. That run's score is not meaningful because it hit a Gemini API 429 (`RESOURCE_EXHAUSTED`) partway through and was cut off; the mount itself is confirmed working.

27 unit tests pass in `tests/unit/agents/test_sandbox.py` (5 new), ruff clean.
