### PR TITLE
openclaw: reasoning-effort flag, openai runtime pin, session-tool deny list

### DIFF
--- a/.agents/references/running-evals.md
+++ b/.agents/references/running-evals.md
@@ -125,6 +125,7 @@ To run **both arms in parallel**: sync once, then start each wrapper with
 | `MATRIX_AGENT_CONFIGS` | Refactored arm only. Each `oc\|gcli` `[+mcp][+skills]` (e.g. `gcli+mcp+skills`). |
 | `MAX_PARALLEL` | Max combos running at once (default `3`). Each combo is its own cluster — mind quota. |
 | `AGENT_TIMEOUT_SEC` | Per-agent timeout (default `1200` in the matrix). |
+| `AGENT_REASONING_EFFORT` | Reasoning-effort level (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `adaptive`, `max`). Only the openclaw harness honors it, mapping it onto `oc agent --thinking <level>`. |
 | `BENCH_VERTEX` | Run agents + judges on Vertex via VM-SA ADC (no API keys). |
 | `BENCH_REMOTE` | Run on the bastion over ssh; unset runs every combo locally. |
 | `SKIP_SYNC` | Skip the working-tree sync to the bastion (after one real sync). |

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -168,6 +168,20 @@ _PROVIDER_TRANSPORT: dict[str, dict[str, str]] = {
     },
 }
 
+# Agent runtime each provider's models must be pinned to in the per-run
+# config. oc's default routing sends every ``openai/*`` model (gpt-5.6-sol
+# included, it is literally the fallback default in oc's codex-route module)
+# to the separately-published ``codex`` app-server harness plugin, which is
+# neither bundled nor enabled in the sandbox image, so the run aborts with
+# 'Agent harness runtime "codex" is unavailable'. Pinning ``openclaw`` (oc's
+# own embedded runtime) drives the model straight over the OpenAI Responses
+# transport that oc's built-in catalog already declares for it; confirmed
+# live on openclaw 2026.9.1-beta.1 with ``--thinking high`` reaching the
+# request as reasoningEffort=high.
+_PROVIDER_RUNTIME: dict[str, str] = {
+    "openai": "openclaw",
+}
+
 # Levels ``oc agent --thinking`` accepts.
 _THINKING_LEVELS = frozenset(
     {"off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"}
@@ -260,23 +274,54 @@ def _build_model_override(config: AgentConfig) -> dict:
     }
 
 
+def _build_runtime_pin(config: AgentConfig) -> dict:
+    """Pin the agent runtime for providers oc would otherwise misroute.
+
+    Returns ``{"agents": {"defaults": {"models": {model_id: {"agentRuntime":
+    {"id": runtime}}}}}}`` when the resolved provider is in
+    :data:`_PROVIDER_RUNTIME`, else an empty dict.
+    """
+    model_id = _oc_model_id(config)
+    if not model_id:
+        return {}
+    provider, _, _ = model_id.partition("/")
+    runtime = _PROVIDER_RUNTIME.get(provider)
+    if runtime is None:
+        return {}
+    return {"agents": {"defaults": {"models": {model_id: {"agentRuntime": {"id": runtime}}}}}}
+
+
+def _deep_merge(dst: dict, src: dict) -> None:
+    """Recursively merge ``src`` into ``dst`` in place; ``src`` wins on leaves."""
+    for key, value in src.items():
+        if isinstance(value, dict) and isinstance(dst.get(key), dict):
+            _deep_merge(dst[key], value)
+        else:
+            dst[key] = value
+
+
 def _build_openclaw_config(config: AgentConfig, mcp_servers: tuple[McpBinding, ...]) -> dict:
     """Assemble the isolated ``openclaw.json`` payload for a run.
 
-    Merges the two per-run config concerns the harness owns: command-bearing MCP
-    bindings (``mcp.servers``) and a catalog entry for a model openclaw doesn't
-    ship by default (``models``/``agents``; see :func:`_build_model_override`).
-    Their key spaces are disjoint, so either, both, or neither may be present.
+    Merges the per-run config concerns the harness owns: command-bearing MCP
+    bindings (``mcp.servers``), a catalog entry for a model openclaw doesn't ship
+    by default (``models``/``agents``; see :func:`_build_model_override`), and an
+    agent-runtime pin for a provider oc would otherwise misroute (``agents``; see
+    :func:`_build_runtime_pin`). The model-override and runtime-pin payloads are
+    deep-merged (via :func:`_deep_merge`) rather than shallow-updated, since both
+    can write into the same ``agents.defaults.models[model_id]`` entry.
 
     Args:
-        config: Resolved :class:`AgentConfig` (drives the model-catalog entry).
+        config: Resolved :class:`AgentConfig` (drives the model-catalog entry and
+            the runtime pin).
         mcp_servers: Bindings to render into ``mcp.servers`` (empty-command
             bindings are skipped by :func:`build_mcp_servers`).
 
     Returns:
-        A config mapping, or an empty dict when there is neither a launchable MCP
-        binding nor a model needing a catalog entry (caller then skips the config
-        write and leaves ``OPENCLAW_CONFIG_PATH`` unset).
+        A config mapping, or an empty dict when there is no launchable MCP
+        binding, no model needing a catalog entry, and no model needing a
+        runtime pin (caller then skips the config write and leaves
+        ``OPENCLAW_CONFIG_PATH`` unset).
 
     Each MCP server entry inherits the run's ``KUBECONFIG`` (set by ``RunEnv``) as
     an explicit ``env`` so the MCP server (e.g. gke-mcp) reads the run-scoped
@@ -290,7 +335,8 @@ def _build_openclaw_config(config: AgentConfig, mcp_servers: tuple[McpBinding, .
             for entry in servers.values():
                 entry.setdefault("env", {})["KUBECONFIG"] = kubeconfig
         payload["mcp"] = {"servers": servers}
-    payload.update(_build_model_override(config))
+    _deep_merge(payload, _build_model_override(config))
+    _deep_merge(payload, _build_runtime_pin(config))
     return payload
 
 

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -182,6 +182,26 @@ _PROVIDER_RUNTIME: dict[str, str] = {
     "openai": "openclaw",
 }
 
+# Session and subagent tools need an authenticated gateway websocket, which a
+# one-shot `oc agent --local` run never has. Without this deny list the model
+# can call sessions_spawn (which reports accepted even though the child dies
+# on a credentials error) and then sessions_yield, ending its turn with no
+# work done. Deny them so the agent does the task in its own turn.
+_SUBAGENT_TOOL_DENY: tuple[str, ...] = (
+    "sessions_spawn",
+    "sessions_yield",
+    "sessions_send",
+    "sessions_list",
+    "sessions_history",
+    "sessions_search",
+    "subagents",
+)
+
+
+def _build_tool_policy() -> dict:
+    return {"tools": {"deny": list(_SUBAGENT_TOOL_DENY)}}
+
+
 # Levels ``oc agent --thinking`` accepts.
 _THINKING_LEVELS = frozenset(
     {"off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"}
@@ -305,11 +325,13 @@ def _build_openclaw_config(config: AgentConfig, mcp_servers: tuple[McpBinding, .
 
     Merges the per-run config concerns the harness owns: command-bearing MCP
     bindings (``mcp.servers``), a catalog entry for a model openclaw doesn't ship
-    by default (``models``/``agents``; see :func:`_build_model_override`), and an
+    by default (``models``/``agents``; see :func:`_build_model_override`), an
     agent-runtime pin for a provider oc would otherwise misroute (``agents``; see
-    :func:`_build_runtime_pin`). The model-override and runtime-pin payloads are
-    deep-merged (via :func:`_deep_merge`) rather than shallow-updated, since both
-    can write into the same ``agents.defaults.models[model_id]`` entry.
+    :func:`_build_runtime_pin`), and the session/subagent tool deny list every run
+    needs (``tools``; see :func:`_build_tool_policy`). The model-override and
+    runtime-pin payloads are deep-merged (via :func:`_deep_merge`) rather than
+    shallow-updated, since both can write into the same
+    ``agents.defaults.models[model_id]`` entry.
 
     Args:
         config: Resolved :class:`AgentConfig` (drives the model-catalog entry and
@@ -318,10 +340,9 @@ def _build_openclaw_config(config: AgentConfig, mcp_servers: tuple[McpBinding, .
             bindings are skipped by :func:`build_mcp_servers`).
 
     Returns:
-        A config mapping, or an empty dict when there is no launchable MCP
-        binding, no model needing a catalog entry, and no model needing a
-        runtime pin (caller then skips the config write and leaves
-        ``OPENCLAW_CONFIG_PATH`` unset).
+        A config mapping. Never empty: the tool-policy deny list (see
+        :func:`_build_tool_policy`) is always merged in, on top of any MCP
+        servers, model-catalog entry, and runtime pin.
 
     Each MCP server entry inherits the run's ``KUBECONFIG`` (set by ``RunEnv``) as
     an explicit ``env`` so the MCP server (e.g. gke-mcp) reads the run-scoped
@@ -337,6 +358,7 @@ def _build_openclaw_config(config: AgentConfig, mcp_servers: tuple[McpBinding, .
         payload["mcp"] = {"servers": servers}
     _deep_merge(payload, _build_model_override(config))
     _deep_merge(payload, _build_runtime_pin(config))
+    _deep_merge(payload, _build_tool_policy())
     return payload
 
 

--- a/devops_bench/agents/cli/openclaw/agent.py
+++ b/devops_bench/agents/cli/openclaw/agent.py
@@ -168,6 +168,11 @@ _PROVIDER_TRANSPORT: dict[str, dict[str, str]] = {
     },
 }
 
+# Levels ``oc agent --thinking`` accepts.
+_THINKING_LEVELS = frozenset(
+    {"off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"}
+)
+
 
 def _oc_model_id(config: AgentConfig) -> str:
     """Resolve the canonical ``provider/model`` id ``oc agent --model`` expects.
@@ -345,6 +350,25 @@ def _oc_model_flag(config: AgentConfig) -> str:
     return f"--model {shlex.quote(model_id)} "
 
 
+def _thinking_flag() -> str:
+    """Return ``--thinking <level> `` for ``oc agent``, or ``""`` when unset.
+
+    The reasoning-effort level is chosen per run through ``AGENT_REASONING_EFFORT``
+    rather than a config field, mirroring how the model itself is selected per run
+    via ``--model`` (see :func:`_oc_model_flag`) instead of a global setting. The
+    value maps directly onto one of openclaw's own ``oc agent --thinking`` levels.
+    """
+    raw = os.environ.get("AGENT_REASONING_EFFORT", "")
+    level = raw.strip().lower()
+    if not level:
+        return ""
+    if level not in _THINKING_LEVELS:
+        raise ValueError(
+            f"AGENT_REASONING_EFFORT={raw!r} is not one of {sorted(_THINKING_LEVELS)}"
+        )
+    return f"--thinking {shlex.quote(level)} "
+
+
 def _needs_anthropic_vertex_auth_profile(config: AgentConfig) -> bool:
     """Return whether this run must register a headless anthropic-vertex auth profile.
 
@@ -425,7 +449,8 @@ def _build_local_command(config: AgentConfig, prompt: str, agent_name: str, oc_b
         '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"; '
         f"{auth_setup}"
         f"{quoted_oc} --log-level debug agent --local "
-        f"--agent {shlex.quote(agent_name)} {_oc_model_flag(config)}-m {shlex.quote(prompt)}"
+        f"--agent {shlex.quote(agent_name)} {_oc_model_flag(config)}{_thinking_flag()}"
+        f"-m {shlex.quote(prompt)}"
     )
 
 
@@ -503,6 +528,9 @@ class OpenClawAgent(AgentHarness):
                 env_overlay["OPENCLAW_CONFIG_PATH"] = str(config_path)
 
             command = _build_local_command(self.config, final_prompt, self.agent_name, oc_bin)
+            reasoning_effort = os.environ.get("AGENT_REASONING_EFFORT", "").strip()
+            if reasoning_effort:
+                _log.debug("oc agent --thinking %s", reasoning_effort.lower())
 
             # Containerised execution, opt-in via BENCH_AGENT_SANDBOX=docker. Only
             # the agent turn itself moves into the container: state_dir/openclaw.json

--- a/docs/components/agents.md
+++ b/docs/components/agents.md
@@ -73,6 +73,7 @@ each harness maps them onto its target.
 | `AGENT_TARGET` | unset | Path to the CLI binary (`gemini` / `oc`). Ignored by `api`. |
 | `AGENT_TIMEOUT_SEC` | `600` | Wall-clock budget for each external call. |
 | `AGENT_MAX_TURNS` | harness default (50 for `api`) | Caps the `api` tool-use loop. |
+| `AGENT_REASONING_EFFORT` | unset | Reasoning-effort level: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `adaptive`, or `max`. Only the openclaw harness honors it today, mapping it onto `oc agent --thinking <level>`. |
 
 **Capabilities**
 

--- a/docs/how-to/run-evals.md
+++ b/docs/how-to/run-evals.md
@@ -199,6 +199,7 @@ your handle for monitoring and re-attaching. Outputs land on the runner host und
 | `MATRIX_AGENT_CONFIGS` | Agent-config presets, each `oc\|gcli` `[+mcp][+skills]` (e.g. `gcli+mcp+skills`). |
 | `MAX_PARALLEL` | Max combos running at once (default 3). **Each combo is its own cluster — mind your quota.** |
 | `AGENT_TIMEOUT_SEC` | Per-agent timeout (default 1200 in the matrix; the bare harness default is lower). |
+| `AGENT_REASONING_EFFORT` | Reasoning-effort level (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `adaptive`, `max`). Only the openclaw harness honors it, mapping it onto `oc agent --thinking <level>`. |
 | `BENCH_VERTEX` | Run agents + judges against Vertex via VM-SA ADC (no API keys). |
 | `BENCH_REMOTE` | Run on the bastion over SSH; unset runs every combo locally on this host. |
 | `SKIP_SYNC` | Skip the working-tree sync to the bastion (after you've already synced once). |

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -37,11 +37,13 @@ from devops_bench.agents.capabilities import (
 from devops_bench.agents.cli.openclaw import OpenClawAgent, parse_trajectory_export
 from devops_bench.agents.cli.openclaw import agent as oc_mod
 from devops_bench.agents.cli.openclaw.agent import (
+    _SUBAGENT_TOOL_DENY,
     _build_env,
     _build_local_command,
     _build_model_override,
     _build_openclaw_config,
     _build_runtime_pin,
+    _build_tool_policy,
     _deep_merge,
     _oc_model_id,
 )
@@ -800,19 +802,22 @@ def test_execute_does_not_prepend_rules_when_empty(monkeypatch, tmp_path):
 def test_build_openclaw_config_wraps_servers_under_mcp():
     """A launchable binding renders under the ``mcp.servers`` config path."""
     cfg = _build_openclaw_config(AgentConfig(), (McpBinding(name="gke", command=("gke-mcp",)),))
-    assert cfg == {"mcp": {"servers": {"gke": {"command": "gke-mcp"}}}}
+    assert cfg == {
+        "mcp": {"servers": {"gke": {"command": "gke-mcp"}}},
+        "tools": {"deny": list(_SUBAGENT_TOOL_DENY)},
+    }
 
 
 def test_build_openclaw_config_empty_without_launchable_server_or_override():
-    """No MCP binding and a catalog-known model → empty config (caller skips)."""
-    assert _build_openclaw_config(AgentConfig(), ()) == {}
-    assert (
-        _build_openclaw_config(
-            AgentConfig(model="gemini-3.1-pro-preview"),
-            (McpBinding(name="b", command=(), tools=("t",)),),
-        )
-        == {}
-    )
+    """No MCP binding and a catalog-known model → the config carries only the
+    tools deny list (caller still writes it; every run needs the deny list)."""
+    assert _build_openclaw_config(AgentConfig(), ()) == {
+        "tools": {"deny": list(_SUBAGENT_TOOL_DENY)}
+    }
+    assert _build_openclaw_config(
+        AgentConfig(model="gemini-3.1-pro-preview"),
+        (McpBinding(name="b", command=(), tools=("t",)),),
+    ) == {"tools": {"deny": list(_SUBAGENT_TOOL_DENY)}}
 
 
 def test_build_openclaw_config_merges_mcp_and_model_override():
@@ -932,7 +937,10 @@ def test_model_override_raises_for_unpinned_transport():
 def test_build_openclaw_config_pins_runtime_for_openai_model():
     cfg = AgentConfig(model="gpt-5.6-sol", provider="openai")
     assert _build_openclaw_config(cfg, ()) == {
-        "agents": {"defaults": {"models": {"openai/gpt-5.6-sol": {"agentRuntime": {"id": "openclaw"}}}}}
+        "agents": {
+            "defaults": {"models": {"openai/gpt-5.6-sol": {"agentRuntime": {"id": "openclaw"}}}}
+        },
+        "tools": {"deny": list(_SUBAGENT_TOOL_DENY)},
     }
 
 
@@ -954,8 +962,38 @@ def test_build_runtime_pin_empty_when_no_model():
 def test_build_openclaw_config_no_runtime_pin_for_google_model():
     cfg = AgentConfig(model="gemini-2.5-pro", provider="gemini")
     cfg_out = _build_openclaw_config(cfg, ())
-    assert cfg_out == {}
+    assert cfg_out == {"tools": {"deny": list(_SUBAGENT_TOOL_DENY)}}
     assert "agentRuntime" not in json.dumps(cfg_out)
+
+
+# ---------------------------------------------------------------------------
+# Tool policy: session/subagent tools need an authenticated gateway websocket
+# a one-shot ``oc agent --local`` run never has, so they're denied globally.
+# ---------------------------------------------------------------------------
+
+
+def test_build_tool_policy_denies_session_and_subagent_tools():
+    assert _build_tool_policy() == {
+        "tools": {
+            "deny": [
+                "sessions_spawn",
+                "sessions_yield",
+                "sessions_send",
+                "sessions_list",
+                "sessions_history",
+                "sessions_search",
+                "subagents",
+            ]
+        }
+    }
+
+
+def test_build_openclaw_config_denies_subagent_tools_for_anthropic_vertex_model():
+    """A non-openai provider (anthropic-vertex, no runtime pin) still carries the
+    tools deny list — it is unconditional, not tied to the runtime pin."""
+    cfg = AgentConfig(model="claude-fable-4", provider="anthropic-vertex")
+    cfg_out = _build_openclaw_config(cfg, ())
+    assert cfg_out == {"tools": {"deny": list(_SUBAGENT_TOOL_DENY)}}
 
 
 def test_deep_merge_merges_nested_dicts_and_src_wins_on_leaves():
@@ -1006,17 +1044,24 @@ def test_execute_writes_mcp_servers_into_isolated_config(monkeypatch, tmp_path):
     )
     OpenClawAgent(AgentConfig(target=str(tmp_path / "oc"), capabilities=caps)).run("p")
     assert captured["cfg_path"], "OPENCLAW_CONFIG_PATH must be set when MCP is bound"
-    assert captured["config"] == {"mcp": {"servers": {"gke": {"command": "gke-mcp"}}}}
+    assert captured["config"] == {
+        "mcp": {"servers": {"gke": {"command": "gke-mcp"}}},
+        "tools": {"deny": list(_SUBAGENT_TOOL_DENY)},
+    }
 
 
-def test_execute_writes_no_config_when_no_launchable_server(monkeypatch, tmp_path):
-    """No command-bearing MCP binding and a catalog-known model → no isolated
-    config, env var unset."""
+def test_execute_writes_tool_deny_config_when_no_launchable_server(monkeypatch, tmp_path):
+    """No command-bearing MCP binding and a catalog-known model → the isolated
+    config is still written, carrying only the tools deny list."""
     captured: dict = {}
 
     def fake_bash(cmd, **kwargs):
         env = kwargs.get("env") or {}
-        captured["has_cfg"] = "OPENCLAW_CONFIG_PATH" in env
+        cfg_path = env.get("OPENCLAW_CONFIG_PATH")
+        captured["cfg_path"] = cfg_path
+        captured["config"] = (
+            json.loads(Path(cfg_path).read_text()) if cfg_path and Path(cfg_path).exists() else None
+        )
         return _make_subprocess_result(stdout="ok", returncode=0)
 
     monkeypatch.setattr(subprocess, "run", fake_bash)
@@ -1031,7 +1076,8 @@ def test_execute_writes_no_config_when_no_launchable_server(monkeypatch, tmp_pat
             capabilities=caps,
         )
     ).run("p")
-    assert captured["has_cfg"] is False
+    assert captured["cfg_path"], "OPENCLAW_CONFIG_PATH must be set even with no MCP binding"
+    assert captured["config"] == {"tools": {"deny": list(_SUBAGENT_TOOL_DENY)}}
 
 
 def test_execute_writes_model_override_config_without_mcp(monkeypatch, tmp_path):

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -286,6 +286,26 @@ def test_build_local_command_omits_model_flag_when_no_model_configured():
     assert "models set" not in cmd
 
 
+def test_build_local_command_omits_thinking_flag_when_reasoning_effort_unset(monkeypatch):
+    monkeypatch.delenv("AGENT_REASONING_EFFORT", raising=False)
+    cmd = _build_local_command(AgentConfig(), "prompt", "main", "/usr/local/bin/oc")
+    assert "--thinking" not in cmd
+
+
+def test_build_local_command_passes_thinking_flag_between_model_and_prompt(monkeypatch):
+    monkeypatch.setenv("AGENT_REASONING_EFFORT", "high")
+    cfg = AgentConfig(model="gemini-2.5-pro", provider="gemini")
+    cmd = _build_local_command(cfg, "prompt", "main", "/usr/local/bin/oc")
+    assert "--thinking high" in cmd
+    assert cmd.index("--model") < cmd.index("--thinking high") < cmd.index(" -m ")
+
+
+def test_build_local_command_raises_for_invalid_reasoning_effort(monkeypatch):
+    monkeypatch.setenv("AGENT_REASONING_EFFORT", "turbo")
+    with pytest.raises(ValueError, match="turbo"):
+        _build_local_command(AgentConfig(), "prompt", "main", "/usr/local/bin/oc")
+
+
 def test_pick_session_key_handles_top_level_list():
     payload = json.dumps([{"key": "agent:operator:abc", "model": "x"}])
     assert _pick_session_key(payload) == "agent:operator:abc"

--- a/tests/unit/agents/test_agents_cli_openclaw.py
+++ b/tests/unit/agents/test_agents_cli_openclaw.py
@@ -41,6 +41,8 @@ from devops_bench.agents.cli.openclaw.agent import (
     _build_local_command,
     _build_model_override,
     _build_openclaw_config,
+    _build_runtime_pin,
+    _deep_merge,
     _oc_model_id,
 )
 from devops_bench.agents.cli.openclaw.parsing import _pick_session_key, _strip_ansi
@@ -919,6 +921,62 @@ def test_model_override_raises_for_unpinned_transport():
     fallback). A full-id with an unknown wire reaches this path."""
     with pytest.raises(ConfigError):
         _build_model_override(AgentConfig(model="mystery/gemini-3.5-flash"))
+
+
+# ---------------------------------------------------------------------------
+# Agent-runtime pin: providers oc would otherwise misroute to an unavailable
+# harness plugin (e.g. openai → codex) get an explicit ``agentRuntime`` pin.
+# ---------------------------------------------------------------------------
+
+
+def test_build_openclaw_config_pins_runtime_for_openai_model():
+    cfg = AgentConfig(model="gpt-5.6-sol", provider="openai")
+    assert _build_openclaw_config(cfg, ()) == {
+        "agents": {"defaults": {"models": {"openai/gpt-5.6-sol": {"agentRuntime": {"id": "openclaw"}}}}}
+    }
+
+
+def test_build_runtime_pin_pins_openai_to_openclaw_runtime():
+    cfg = AgentConfig(model="gpt-5.6-sol", provider="openai")
+    assert _build_runtime_pin(cfg) == {
+        "agents": {"defaults": {"models": {"openai/gpt-5.6-sol": {"agentRuntime": {"id": "openclaw"}}}}}
+    }
+
+
+def test_build_runtime_pin_empty_for_unpinned_provider():
+    assert _build_runtime_pin(AgentConfig(model="gemini-2.5-pro", provider="gemini")) == {}
+
+
+def test_build_runtime_pin_empty_when_no_model():
+    assert _build_runtime_pin(AgentConfig()) == {}
+
+
+def test_build_openclaw_config_no_runtime_pin_for_google_model():
+    cfg = AgentConfig(model="gemini-2.5-pro", provider="gemini")
+    cfg_out = _build_openclaw_config(cfg, ())
+    assert cfg_out == {}
+    assert "agentRuntime" not in json.dumps(cfg_out)
+
+
+def test_deep_merge_merges_nested_dicts_and_src_wins_on_leaves():
+    dst = {"a": {"b": 1, "c": {"d": 2}}, "e": 3}
+    src = {"a": {"c": {"d": 99, "f": 4}}, "e": 5}
+    _deep_merge(dst, src)
+    assert dst == {"a": {"b": 1, "c": {"d": 99, "f": 4}}, "e": 5}
+
+
+def test_build_openclaw_config_merges_catalog_override_and_runtime_pin(monkeypatch):
+    """A model that is both a catalog override and pinned to a runtime gets one
+    merged ``agents.defaults.models[model_id]`` entry carrying both."""
+    monkeypatch.setitem(oc_mod._PROVIDER_RUNTIME, "google", "openclaw")
+    cfg = AgentConfig(model="gemini-3.5-flash", provider="google")
+    cfg_out = _build_openclaw_config(cfg, ())
+    assert cfg_out["agents"]["defaults"]["models"] == {
+        "google/gemini-3.5-flash": {"agentRuntime": {"id": "openclaw"}}
+    }
+    assert cfg_out["models"]["providers"]["google"]["models"] == [
+        {"id": "gemini-3.5-flash", "name": "gemini-3.5-flash"}
+    ]
 
 
 def _empty_sessions_run(argv, **kwargs):


### PR DESCRIPTION
Three openclaw harness changes needed to run the sandboxed openclaw agent on gpt-5.6-sol at a chosen reasoning effort. Split out of the fleet work on add-b0011-sandbox so the harness changes can be reviewed on their own; the tf and sandbox fixes from that work are not included here.

1. **Pass AGENT_REASONING_EFFORT as `oc agent --thinking`** (22440a3). The harness reads AGENT_REASONING_EFFORT (off, minimal, low, medium, high, xhigh, adaptive, max) and appends `--thinking <level>` right after `--model`. Unset means no flag, so existing runs are unchanged. An unknown value fails fast with a ValueError. Documented next to AGENT_TIMEOUT_SEC in the agents doc and both run-evals tables.

2. **Pin openai models to oc's embedded agent runtime** (4e78bcb). oc routes every openai/* model to the separately published codex harness plugin, which the sandbox image does not bundle, so gpt-5.6-sol runs aborted with `Agent harness runtime "codex" is unavailable`. The per-run openclaw.json now sets `agents.defaults.models[<id>].agentRuntime = {id: openclaw}` for openai models. Confirmed on openclaw 2026.9.1-beta.1: the run completes and `--thinking high` reaches the request as reasoningEffort=high.

3. **Deny session and subagent tools in one-shot runs** (3156a20). `oc agent --local` has no gateway auth, so sessions_spawn reported accepted while the child died on a credentials error, the model then called sessions_yield, and the turn ended with no work done (seen on gpu-stress-test-diagnosis with gpt-5.6-sol: 4 tool calls, 71 s, score 0). The harness now always merges a tools.deny list for the sessions_* and subagents tools into the per-run config, which is now always written.

Unit tests cover all three (tests/unit/agents/test_agents_cli_openclaw.py).
